### PR TITLE
[GitHub issue lifecycle] Finalize failed attempts with safe release and preserved-work handoffs (MoonLadderStudios/MoonMind#4179)

### DIFF
--- a/api_service/retrieval_capabilities.py
+++ b/api_service/retrieval_capabilities.py
@@ -199,9 +199,10 @@ class RetrievalCapabilityRegistry:
         raise RetrievalCapabilityError(
             "retired",
             "Built-in vector retrieval has been retired "
-            "(MoonLadderStudios/MoonMind#4105, #4107). Remove followUpRetrieval "
-            "and use explicit attachments, artifact refs, or scoped workspace "
-            "access instead. Historical details remain readable.",
+            "(MoonLadderStudios/MoonMind#4105, #4107). Remove retired follow-up "
+            "retrieval request fields and use explicit attachments, artifact "
+            "refs, or scoped workspace access instead. Historical details "
+            "remain readable.",
         )
 
     def resolve(

--- a/docs/Temporal/WorkflowTypeCatalogGenerated.md
+++ b/docs/Temporal/WorkflowTypeCatalogGenerated.md
@@ -154,6 +154,7 @@ with deterministic workflow code, not Temporal Local Activities.
 | `execution.dependency_status_snapshot` | `artifacts` | `mm.activity.artifacts` |
 | `execution.notify_completion` | `agent_runtime` | `mm.activity.agent_runtime` |
 | `execution.record_terminal_state` | `artifacts` | `mm.activity.artifacts` |
+| `github_issue.finalize_failed_attempt` | `integrations` | `mm.activity.integrations` |
 | `integration.codex_cloud.cancel` | `integrations` | `mm.activity.integrations` |
 | `integration.codex_cloud.fetch_result` | `integrations` | `mm.activity.integrations` |
 | `integration.codex_cloud.start` | `integrations` | `mm.activity.integrations` |

--- a/moonmind/workflows/adapters/github_service.py
+++ b/moonmind/workflows/adapters/github_service.py
@@ -2530,6 +2530,55 @@ class GitHubService:
                     "summary": f"Label remove result unknown: {exc.__class__.__name__}.",
                 }
 
+    async def close_issue(
+        self,
+        *,
+        repo: str,
+        issue_number: int,
+        github_token: str | None = None,
+    ) -> dict[str, Any]:
+        """Close an issue without touching its labels."""
+        token, resolution_error = await self.resolve_github_token(
+            github_token,
+            repo=repo,
+        )
+        if not token:
+            return {
+                "ok": False,
+                "reasonCode": "auth_unavailable",
+                "summary": resolution_error or self._missing_auth_summary("close issue"),
+            }
+        headers = self._github_headers(token)
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            try:
+                response = await client.patch(
+                    f"https://api.github.com/repos/{repo}/issues/{issue_number}",
+                    headers=headers,
+                    json={"state": "closed"},
+                )
+                response.raise_for_status()
+                return {
+                    "ok": True,
+                    "reasonCode": "closed",
+                    "summary": f"Closed {repo}#{issue_number}.",
+                }
+            except httpx.HTTPStatusError as exc:
+                return {
+                    "ok": False,
+                    "reasonCode": "denied" if exc.response.status_code in {401, 403, 404} else "close_failed",
+                    "httpStatus": exc.response.status_code,
+                    "summary": (
+                        f"Issue close failed with HTTP {exc.response.status_code}. "
+                        f"{self._github_permission_summary(exc.response)}"
+                    ).strip(),
+                }
+            except (httpx.TransportError, httpx.TimeoutException) as exc:
+                return {
+                    "ok": False,
+                    "reasonCode": "outcome_unknown",
+                    "summary": f"Issue close result unknown: {exc.__class__.__name__}.",
+                }
+
     async def list_issue_comments(
         self,
         *,

--- a/moonmind/workflows/temporal/activities/github_issue_finalization_activities.py
+++ b/moonmind/workflows/temporal/activities/github_issue_finalization_activities.py
@@ -5,8 +5,9 @@ controlling workflow boundary instead of reimplementing terminal-handoff
 semantics: every decision lives in
 :mod:`moonmind.workflows.temporal.github_issue_finalization`, and this
 module only supplies the production service object (``GitHubService``) and
-performs the ordered GitHub reads/writes (proposed comment -> destination
-labels -> read-back -> released comment).
+performs the ordered GitHub reads/writes (pre-mutation issue read ->
+proposed comment (new, or appended to the canonical attempt comment) ->
+destination labels -> read-back -> released comment).
 
 Interruptibility: the result distinguishes ``released`` (label outcome
 observed AND terminal comment published) from ``pending`` (interrupted or
@@ -28,6 +29,114 @@ def _string(value: Any) -> str:
     if isinstance(value, bool):
         return ""
     return str(value or "").strip()
+
+
+def _issue_label_names(issue_payload: Mapping[str, Any] | None) -> tuple[str, list[str]]:
+    """Extract ``(state, label_names)`` from an issue payload."""
+    payload = dict(issue_payload or {})
+    names: list[str] = []
+    raw_labels = payload.get("labels") or []
+    for item in raw_labels if isinstance(raw_labels, list) else []:
+        if isinstance(item, Mapping):
+            names.append(str(item.get("name") or ""))
+        else:
+            names.append(str(item or ""))
+    return str(payload.get("state") or "open"), names
+
+
+def _scan_terminal_body(body: str) -> tuple[bool, str]:
+    """Scan a rendered terminal comment; returns ``(blocked, redacted_detail)``.
+
+    Reuses the repository outbound scanner (``moonmind.security``) with the
+    same fail-closed posture as the canonical attempt-comment renderer:
+    secret-like handoff text blocks posting instead of being published.
+    """
+    from moonmind.security import OutboundBundleItem, scan_outbound_bundle
+    from moonmind.utils.logging import redact_sensitive_text
+
+    try:
+        result = scan_outbound_bundle(
+            [OutboundBundleItem(location="finalization.terminal_comment", content=body)],
+            high_security_mode=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - scanner failure must fail closed
+        return True, f"scanner unavailable ({exc.__class__.__name__})"
+    if not result.allowed:
+        categories = sorted({finding.category for finding in result.findings})
+        detail = redact_sensitive_text("; ".join(result.sanitized_diagnostics) or ",".join(categories))
+        return True, detail or "secret-like content detected"
+    return False, ""
+
+
+async def _reuse_attempt_comment(
+    *,
+    service: Any,
+    repository: str,
+    issue_number: int,
+    attempt_id: str,
+    terminal_section: str,
+) -> dict[str, Any]:
+    """Append the terminal section to the canonical attempt comment.
+
+    Returns ``{"action": "updated", "commentId": int}`` when exactly one
+    comment carries this attempt's machine marker with agreeing embedded
+    metadata (appending preserves the marker and metadata block, so
+    admission keeps associating terminal comments with the attempt);
+    ``{"action": "create"}`` when no such comment is readable (caller falls
+    back to creating the terminal comment); ``{"action": "conflict"}`` when
+    several copies share the marker (no write is authorized); and
+    ``{"action": "pending", ...}`` when the update itself did not succeed.
+    """
+    from moonmind.workflows.temporal.github_issue_attempt import (
+        ATTEMPT_MARKER_PREFIX,
+        extract_attempt_metadata,
+    )
+
+    list_comments = getattr(service, "list_issue_comments", None)
+    update_comment = getattr(service, "update_issue_comment", None)
+    if list_comments is None or update_comment is None:
+        return {"action": "create", "reason": "comment reuse surface unavailable"}
+    try:
+        listed = await service.list_issue_comments(repo=repository, issue_number=issue_number)
+    except Exception as exc:  # noqa: BLE001 - unreadable != absent; caller creates
+        return {"action": "create", "reason": f"comment list unknown: {exc.__class__.__name__}"}
+    if not isinstance(listed, Mapping) or not listed.get("ok"):
+        return {"action": "create", "reason": str((listed or {}).get("summary") or "comment list unavailable")}
+    comments = listed.get("comments")
+    if not isinstance(comments, list):
+        return {"action": "create", "reason": "comment list malformed"}
+    verified: list[tuple[int, str]] = []
+    for comment in comments:
+        if not isinstance(comment, Mapping):
+            continue
+        body = str(comment.get("body") or "")
+        if ATTEMPT_MARKER_PREFIX not in body or attempt_id not in body:
+            continue
+        metadata, _ = extract_attempt_metadata(body)
+        if metadata is None or str(metadata.get("attemptId") or "") != attempt_id:
+            continue
+        try:
+            candidate_id = int(comment.get("id"))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        verified.append((candidate_id, body))
+    if len(verified) > 1:
+        return {
+            "action": "conflict",
+            "reason": f"{len(verified)} comments share attempt marker {attempt_id}; no overwrite authorized",
+        }
+    if not verified:
+        return {"action": "create", "reason": "no canonical attempt comment found"}
+    comment_id, remote_body = verified[0]
+    merged = remote_body.rstrip() + "\n\n---\n\n" + terminal_section.strip() + "\n"
+    try:
+        updated = await service.update_issue_comment(repo=repository, comment_id=comment_id, body=merged)
+    except Exception as exc:  # noqa: BLE001 - update result unknown; no duplicate created
+        return {"action": "pending", "reason": f"attempt comment update unknown: {exc.__class__.__name__}"}
+    if not isinstance(updated, Mapping) or not updated.get("ok"):
+        code = str((updated or {}).get("reasonCode") or "update_failed")
+        return {"action": "pending", "reason": f"attempt comment update {code}"}
+    return {"action": "updated", "commentId": comment_id, "body": merged}
 
 
 async def _fetch_issue(*, service: Any, repository: str, issue_number: int) -> dict[str, Any]:
@@ -79,13 +188,14 @@ async def finalize_failed_attempt(
 ) -> dict[str, Any]:
     """Finalize one failed/canceled controlling attempt at the durable boundary.
 
-    Ordered effects: plan (pure) -> create proposed terminal comment ->
-    apply destination labels add-before-remove -> close the issue when the
-    destination is a closed terminal -> read back issue -> classify
-    mutation outcome -> publish released terminal comment update. Any unknown
-    or failed step returns ``released=False`` with ``pending`` detail and
-    ``workspaceRetained=True``; only an observed label outcome plus a
-    published terminal comment returns ``released=True``.
+    Ordered effects: pre-mutation issue read (labels + successor check) ->
+    plan (pure) -> create proposed terminal comment (or append to the
+    canonical attempt comment) -> apply destination labels add-before-remove
+    -> close the issue when the destination is a closed terminal -> read back
+    issue -> classify mutation outcome -> publish released terminal comment
+    update. Any unknown or failed step returns ``released=False`` with
+    ``pending`` detail and ``workspaceRetained=True``; only an observed label
+    outcome plus a published terminal comment returns ``released=True``.
     """
     completion = finalization.route_completion_handoff(
         completion_mode=completion_mode,
@@ -96,6 +206,43 @@ async def finalize_failed_attempt(
         from moonmind.workflows.adapters.github_service import GitHubService
 
         service = GitHubService()
+    # Step 0: read current issue state before planning any label mutation.
+    # Caller-supplied labels win when present; otherwise the pre-mutation
+    # read supplies them. A delayed finalizer that observes a successor
+    # (closed issue, operator hold, or a newer settled state) abandons new
+    # mutations before any GitHub write. An unreadable issue never proves a
+    # successor: the post-mutation read-back remains the release gate.
+    prefetched = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)
+    observed_labels: list[str] | None = None
+    if prefetched.get("ok"):
+        read_state, observed_labels = _issue_label_names(prefetched.get("issue"))
+        try:
+            observed = lifecycle.interpret_issue(
+                {"state": read_state, "labels": observed_labels}
+            )
+            abandon, abandon_reason = lifecycle.should_abandon_retry(
+                intended_from_settled=from_settled, observed=observed
+            )
+        except Exception:  # noqa: BLE001 - uninterpretable reads never authorize abandonment
+            abandon, abandon_reason = False, ""
+        if abandon:
+            return {
+                "released": False,
+                "reasonCode": "successor_observed",
+                "summary": f"Pre-mutation read observes a successor; no new mutations attempted: {abandon_reason}.",
+                "disposition": "",
+                "transition": None,
+                "mutation": None,
+                "completionRoute": completion["route"],
+                "mergeAuthorized": False,
+                "workspaceRetained": True,
+                "pendingSync": None,
+                "commentId": None,
+                "mutationOutcome": None,
+            }
+    effective_labels: Sequence[Any] | None = current_labels
+    if effective_labels is None and observed_labels is not None:
+        effective_labels = observed_labels
     plan = finalization.plan_failed_attempt_finalization(
         repository=repository,
         issue_number=issue_number,
@@ -105,7 +252,7 @@ async def finalize_failed_attempt(
         mutation_evidence=mutation_evidence,
         preservation_evidence=preservation_evidence,
         disposition_evidence=disposition_evidence,
-        current_labels=current_labels,
+        current_labels=effective_labels,
         reason=reason,
         attempt_id=attempt_id,
         primary_outcome=primary_outcome,
@@ -113,6 +260,8 @@ async def finalize_failed_attempt(
         remaining_requirements=remaining_requirements,
         retry_history=retry_history,
         next_action=next_action,
+        cancellation_hold=cancellation_hold,
+        review_owner_ended=review_owner_ended,
     )
     base: dict[str, Any] = {
         "released": False,
@@ -130,27 +279,61 @@ async def finalize_failed_attempt(
     }
     if not plan.releasable or plan.mutation is None or plan.transition is None:
         return base
-    # Step 1: proposed terminal comment first (durable + visible before labels).
-    try:
-        created = await service.create_issue_comment(
-            repo=repository, issue_number=issue_number, body=plan.terminal_comment
+    # Step 1: scan the proposed terminal comment through the repository
+    # outbound scanner before any GitHub write; secret-like handoff text
+    # blocks posting instead of being published.
+    from moonmind.utils.logging import redact_sensitive_text
+
+    blocked, block_detail = _scan_terminal_body(plan.terminal_comment)
+    if blocked:
+        base["reasonCode"] = "comment_blocked_by_scan"
+        base["summary"] = f"Terminal comment blocked by outbound scan: {block_detail}."
+        return base
+    proposed_body = redact_sensitive_text(plan.terminal_comment)
+    # Prefer the canonical attempt comment when it already exists: appending
+    # keeps one marker-bearing comment per attempt (with its machine-readable
+    # metadata block intact) instead of multiplying unmarked copies on retry.
+    comment_body = proposed_body
+    comment_id = None
+    if _string(attempt_id):
+        reuse = await _reuse_attempt_comment(
+            service=service,
+            repository=repository,
+            issue_number=issue_number,
+            attempt_id=_string(attempt_id),
+            terminal_section=proposed_body,
         )
-    except Exception as exc:  # noqa: BLE001 - adapter failure stays pending
-        base["reasonCode"] = "comment_unknown"
-        base["summary"] = f"Proposed terminal comment result unknown: {exc.__class__.__name__}."
-        base["pendingSync"] = finalization.record_pending_sync(reason="proposed comment unknown")
-        return base
-    if not created.get("ok"):
-        code = str(created.get("reasonCode") or "comment_failed")
-        if code == "outcome_unknown":
+        if reuse["action"] == "updated":
+            comment_id = reuse["commentId"]
+            comment_body = str(reuse["body"])
+        elif reuse["action"] in {"conflict", "pending"}:
+            base["reasonCode"] = (
+                "conflicting_attempt_copies" if reuse["action"] == "conflict" else "attempt_comment_pending"
+            )
+            base["summary"] = str(reuse.get("reason") or "Canonical attempt comment is not safely updatable.")
+            base["pendingSync"] = finalization.record_pending_sync(reason=str(reuse.get("reason") or "attempt comment"))
+            return base
+    if comment_id is None:
+        try:
+            created = await service.create_issue_comment(
+                repo=repository, issue_number=issue_number, body=proposed_body
+            )
+        except Exception as exc:  # noqa: BLE001 - adapter failure stays pending
             base["reasonCode"] = "comment_unknown"
-            base["summary"] = "Proposed terminal comment result unknown; reconcile before repeating effects."
+            base["summary"] = f"Proposed terminal comment result unknown: {exc.__class__.__name__}."
             base["pendingSync"] = finalization.record_pending_sync(reason="proposed comment unknown")
-        else:
-            base["reasonCode"] = code
-            base["summary"] = str(created.get("summary") or "Proposed terminal comment failed.")
-        return base
-    comment_id = created.get("commentId")
+            return base
+        if not created.get("ok"):
+            code = str(created.get("reasonCode") or "comment_failed")
+            if code == "outcome_unknown":
+                base["reasonCode"] = "comment_unknown"
+                base["summary"] = "Proposed terminal comment result unknown; reconcile before repeating effects."
+                base["pendingSync"] = finalization.record_pending_sync(reason="proposed comment unknown")
+            else:
+                base["reasonCode"] = code
+                base["summary"] = str(created.get("summary") or "Proposed terminal comment failed.")
+            return base
+        comment_id = created.get("commentId")
     base["commentId"] = comment_id
     # Step 2: destination labels add-before-remove through the #4176 plan.
     mutation_plan = plan.mutation
@@ -181,9 +364,11 @@ async def finalize_failed_attempt(
                 base["reasonCode"] = "mutation_denied"
                 base["mutationOutcome"] = outcome.to_dict()
                 base["summary"] = "Destination label denied; proposed comment preserved for reconciliation."
+                base["pendingSync"] = finalization.record_pending_sync(reason="label add denied")
             else:
                 base["reasonCode"] = code
                 base["summary"] = str(added.get("summary") or "Label add failed.")
+                base["pendingSync"] = finalization.record_pending_sync(reason="label add failed")
             return base
     for label in labels_to_remove:
         try:
@@ -202,6 +387,7 @@ async def finalize_failed_attempt(
                 return base
             base["reasonCode"] = code
             base["summary"] = str(removed.get("summary") or "Label remove failed.")
+            base["pendingSync"] = finalization.record_pending_sync(reason="label remove failed")
             return base
     # Step 2b: close the issue when the destination is a closed terminal.
     # Mirrors the success-path update_github_issue_status close step: without
@@ -224,6 +410,7 @@ async def finalize_failed_attempt(
             else:
                 base["reasonCode"] = code
                 base["summary"] = str(closed.get("summary") or "Issue close failed.")
+                base["pendingSync"] = finalization.record_pending_sync(reason="issue close failed")
             return base
     # Step 3: read back and classify before claiming release.
     read = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)
@@ -233,14 +420,8 @@ async def finalize_failed_attempt(
         base["pendingSync"] = finalization.record_pending_sync(reason="read-back unknown")
         return base
     issue_payload = read.get("issue") or {}
-    names: list[str] = []
-    raw_labels = issue_payload.get("labels") or []
-    for item in raw_labels if isinstance(raw_labels, list) else []:
-        if isinstance(item, Mapping):
-            names.append(str(item.get("name") or ""))
-        else:
-            names.append(str(item or ""))
-    read_back = {"state": issue_payload.get("state", "open"), "labels": names}
+    read_state, names = _issue_label_names(issue_payload)
+    read_back = {"state": read_state, "labels": names}
     outcome = lifecycle.classify_mutation_outcome(
         plan=lifecycle.LabelMutationPlan(tuple(labels_to_add), tuple(labels_to_remove), close_issue),
         read_back=read_back,
@@ -250,18 +431,34 @@ async def finalize_failed_attempt(
         base["reasonCode"] = "mutation_incomplete"
         base["summary"] = f"Destination not observed on read-back: {outcome.detail} Pending state remains repairable."
         return base
-    # Step 4: finalize the terminal comment as released (best-effort marker).
-    released_body = plan.terminal_comment + "\n\nReleased: label outcome observed on read-back."
+    # Step 4: finalize the terminal comment as released. Every unsuccessful
+    # update stays pending and unreleased: a denied or failed update must
+    # never authorize cleanup while the attempt comment may still report
+    # only the proposed disposition.
+    released_body = comment_body.rstrip() + "\n\nReleased: label outcome observed on read-back.\n"
     if comment_id is not None:
         try:
             updated = await service.update_issue_comment(repo=repository, comment_id=int(comment_id), body=released_body)
-        except Exception:  # noqa: BLE001 - release still holds; comment finalization is auxiliary
-            updated = {"ok": False, "reasonCode": "outcome_unknown"}
-        if not updated.get("ok") and str(updated.get("reasonCode") or "") == "outcome_unknown":
-            base["released"] = True
-            base["reasonCode"] = "released_comment_pending"
-            base["summary"] = "Label outcome observed; released-comment update is pending reconciliation."
-            base["workspaceRetained"] = bool(plan.workspace_retained)
+        except Exception as exc:  # noqa: BLE001 - update result unknown; never false release
+            base["released"] = False
+            base["reasonCode"] = "released_comment_unknown"
+            base["summary"] = (
+                f"Label outcome observed; released-comment update result unknown: {exc.__class__.__name__}. "
+                "Pending reconciliation, not released."
+            )
+            base["pendingSync"] = finalization.record_pending_sync(reason="released comment unknown")
+            base["workspaceRetained"] = True
+            return base
+        if not updated.get("ok"):
+            code = str(updated.get("reasonCode") or "update_failed")
+            base["released"] = False
+            base["reasonCode"] = "released_comment_failed"
+            base["summary"] = (
+                f"Label outcome observed; released-comment update {code}. "
+                "Pending reconciliation, not released."
+            )
+            base["pendingSync"] = finalization.record_pending_sync(reason="released comment failed")
+            base["workspaceRetained"] = True
             return base
     base["released"] = True
     base["reasonCode"] = "released"

--- a/moonmind/workflows/temporal/activities/github_issue_finalization_activities.py
+++ b/moonmind/workflows/temporal/activities/github_issue_finalization_activities.py
@@ -80,7 +80,8 @@ async def finalize_failed_attempt(
     """Finalize one failed/canceled controlling attempt at the durable boundary.
 
     Ordered effects: plan (pure) -> create proposed terminal comment ->
-    apply destination labels add-before-remove -> read back issue -> classify
+    apply destination labels add-before-remove -> close the issue when the
+    destination is a closed terminal -> read back issue -> classify
     mutation outcome -> publish released terminal comment update. Any unknown
     or failed step returns ``released=False`` with ``pending`` detail and
     ``workspaceRetained=True``; only an observed label outcome plus a
@@ -201,6 +202,28 @@ async def finalize_failed_attempt(
                 return base
             base["reasonCode"] = code
             base["summary"] = str(removed.get("summary") or "Label remove failed.")
+            return base
+    # Step 2b: close the issue when the destination is a closed terminal.
+    # Mirrors the success-path update_github_issue_status close step: without
+    # this, a to_closed mutation plan could never observe closed on read-back
+    # and failure-after-merge could never release.
+    if close_issue:
+        try:
+            closed = await service.close_issue(repo=repository, issue_number=issue_number)
+        except Exception as exc:  # noqa: BLE001
+            base["reasonCode"] = "close_unknown"
+            base["summary"] = f"Issue close result unknown: {exc.__class__.__name__}."
+            base["pendingSync"] = finalization.record_pending_sync(reason="issue close unknown")
+            return base
+        if not closed.get("ok"):
+            code = str(closed.get("reasonCode") or "close_failed")
+            if code == "outcome_unknown":
+                base["reasonCode"] = "close_unknown"
+                base["summary"] = "Issue close result unknown; pending state remains distinguishable and repairable."
+                base["pendingSync"] = finalization.record_pending_sync(reason="issue close unknown")
+            else:
+                base["reasonCode"] = code
+                base["summary"] = str(closed.get("summary") or "Issue close failed.")
             return base
     # Step 3: read back and classify before claiming release.
     read = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)

--- a/moonmind/workflows/temporal/activities/github_issue_finalization_activities.py
+++ b/moonmind/workflows/temporal/activities/github_issue_finalization_activities.py
@@ -1,0 +1,251 @@
+"""Production Activity entrypoint for failed-attempt finalization (#4179).
+
+Sibling runtime work calls :func:`finalize_failed_attempt` at the durable
+controlling workflow boundary instead of reimplementing terminal-handoff
+semantics: every decision lives in
+:mod:`moonmind.workflows.temporal.github_issue_finalization`, and this
+module only supplies the production service object (``GitHubService``) and
+performs the ordered GitHub reads/writes (proposed comment -> destination
+labels -> read-back -> released comment).
+
+Interruptibility: the result distinguishes ``released`` (label outcome
+observed AND terminal comment published) from ``pending`` (interrupted or
+unknown after any comment/label operation). Pending results remain
+repairable by a later finalizer or the periodic reconciler and never claim
+false release success. Failed GitHub reporting never discards the only
+workspace/evidence (``workspaceRetained=True``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from moonmind.workflows.temporal import github_issue_finalization as finalization
+from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, bool):
+        return ""
+    return str(value or "").strip()
+
+
+async def _fetch_issue(*, service: Any, repository: str, issue_number: int) -> dict[str, Any]:
+    """Read the current issue through the production token boundary."""
+    token, resolution_error = await service.resolve_github_token(repo=repository)
+    if not token:
+        return {"ok": False, "reasonCode": "auth_unavailable", "summary": resolution_error or "GitHub issue read unavailable."}
+    import httpx
+
+    headers = service._github_headers(token)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            response = await client.get(
+                f"https://api.github.com/repos/{repository}/issues/{issue_number}",
+                headers=headers,
+            )
+            response.raise_for_status()
+            return {"ok": True, "reasonCode": "read", "issue": response.json()}
+        except Exception as exc:  # noqa: BLE001 - transport shape mapped to pending
+            name = exc.__class__.__name__
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status in {401, 403, 404}:
+                return {"ok": False, "reasonCode": "denied", "summary": f"Issue read denied with HTTP {status}."}
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": f"Issue read result unknown: {name}."}
+
+
+async def finalize_failed_attempt(
+    *,
+    repository: str,
+    issue_number: int,
+    execution_event: Any = "",
+    from_settled: str = "in_progress",
+    current_labels: Sequence[Any] | None = None,
+    writer_evidence: Mapping[str, Any] | None = None,
+    mutation_evidence: Mapping[str, Any] | None = None,
+    preservation_evidence: Mapping[str, Any] | None = None,
+    disposition_evidence: Mapping[str, Any] | None = None,
+    attempt_id: str = "",
+    primary_outcome: str = "",
+    met_requirements: Sequence[Any] | None = None,
+    remaining_requirements: Sequence[Any] | None = None,
+    retry_history: Any = "",
+    next_action: str = "",
+    reason: str = "",
+    completion_mode: str = "pr_only_handoff",
+    review_owner_ended: bool = False,
+    cancellation_hold: bool = False,
+    service: Any | None = None,
+) -> dict[str, Any]:
+    """Finalize one failed/canceled controlling attempt at the durable boundary.
+
+    Ordered effects: plan (pure) -> create proposed terminal comment ->
+    apply destination labels add-before-remove -> read back issue -> classify
+    mutation outcome -> publish released terminal comment update. Any unknown
+    or failed step returns ``released=False`` with ``pending`` detail and
+    ``workspaceRetained=True``; only an observed label outcome plus a
+    published terminal comment returns ``released=True``.
+    """
+    completion = finalization.route_completion_handoff(
+        completion_mode=completion_mode,
+        review_owner_ended=review_owner_ended,
+        cancellation_hold=cancellation_hold,
+    )
+    if service is None:
+        from moonmind.workflows.adapters.github_service import GitHubService
+
+        service = GitHubService()
+    plan = finalization.plan_failed_attempt_finalization(
+        repository=repository,
+        issue_number=issue_number,
+        from_settled=from_settled,
+        execution_event=execution_event,
+        writer_evidence=writer_evidence,
+        mutation_evidence=mutation_evidence,
+        preservation_evidence=preservation_evidence,
+        disposition_evidence=disposition_evidence,
+        current_labels=current_labels,
+        reason=reason,
+        attempt_id=attempt_id,
+        primary_outcome=primary_outcome,
+        met_requirements=met_requirements,
+        remaining_requirements=remaining_requirements,
+        retry_history=retry_history,
+        next_action=next_action,
+    )
+    base: dict[str, Any] = {
+        "released": False,
+        "reasonCode": plan.reason_code,
+        "summary": plan.summary,
+        "disposition": plan.disposition,
+        "transition": plan.transition,
+        "mutation": plan.mutation,
+        "completionRoute": completion["route"],
+        "mergeAuthorized": completion["mergeAuthorized"],
+        "workspaceRetained": True,
+        "pendingSync": plan.pending_sync,
+        "commentId": None,
+        "mutationOutcome": None,
+    }
+    if not plan.releasable or plan.mutation is None or plan.transition is None:
+        return base
+    # Step 1: proposed terminal comment first (durable + visible before labels).
+    try:
+        created = await service.create_issue_comment(
+            repo=repository, issue_number=issue_number, body=plan.terminal_comment
+        )
+    except Exception as exc:  # noqa: BLE001 - adapter failure stays pending
+        base["reasonCode"] = "comment_unknown"
+        base["summary"] = f"Proposed terminal comment result unknown: {exc.__class__.__name__}."
+        base["pendingSync"] = finalization.record_pending_sync(reason="proposed comment unknown")
+        return base
+    if not created.get("ok"):
+        code = str(created.get("reasonCode") or "comment_failed")
+        if code == "outcome_unknown":
+            base["reasonCode"] = "comment_unknown"
+            base["summary"] = "Proposed terminal comment result unknown; reconcile before repeating effects."
+            base["pendingSync"] = finalization.record_pending_sync(reason="proposed comment unknown")
+        else:
+            base["reasonCode"] = code
+            base["summary"] = str(created.get("summary") or "Proposed terminal comment failed.")
+        return base
+    comment_id = created.get("commentId")
+    base["commentId"] = comment_id
+    # Step 2: destination labels add-before-remove through the #4176 plan.
+    mutation_plan = plan.mutation
+    labels_to_add = list(mutation_plan.get("labelsToAdd") or [])
+    labels_to_remove = list(mutation_plan.get("labelsToRemove") or [])
+    close_issue = bool(mutation_plan.get("closeIssue"))
+    for label in labels_to_add:
+        try:
+            added = await service.add_issue_labels(repo=repository, issue_number=issue_number, labels=[label])
+        except Exception as exc:  # noqa: BLE001
+            base["reasonCode"] = "label_unknown"
+            base["summary"] = f"Label add result unknown: {exc.__class__.__name__}."
+            base["pendingSync"] = finalization.record_pending_sync(reason="label add unknown")
+            return base
+        if not added.get("ok"):
+            code = str(added.get("reasonCode") or "add_failed")
+            if code == "outcome_unknown":
+                base["reasonCode"] = "label_unknown"
+                base["summary"] = "Label add result unknown; pending state remains distinguishable and repairable."
+                base["pendingSync"] = finalization.record_pending_sync(reason="label add unknown")
+            elif code == "denied":
+                outcome = lifecycle.classify_mutation_outcome(
+                    plan=lifecycle.LabelMutationPlan(tuple(labels_to_add), tuple(labels_to_remove), close_issue),
+                    read_back=None,
+                    denied=True,
+                    denied_detail=str(added.get("summary") or ""),
+                )
+                base["reasonCode"] = "mutation_denied"
+                base["mutationOutcome"] = outcome.to_dict()
+                base["summary"] = "Destination label denied; proposed comment preserved for reconciliation."
+            else:
+                base["reasonCode"] = code
+                base["summary"] = str(added.get("summary") or "Label add failed.")
+            return base
+    for label in labels_to_remove:
+        try:
+            removed = await service.remove_issue_label(repo=repository, issue_number=issue_number, label=label)
+        except Exception as exc:  # noqa: BLE001
+            base["reasonCode"] = "label_unknown"
+            base["summary"] = f"Label remove result unknown: {exc.__class__.__name__}."
+            base["pendingSync"] = finalization.record_pending_sync(reason="label remove unknown")
+            return base
+        if not removed.get("ok"):
+            code = str(removed.get("reasonCode") or "remove_failed")
+            if code == "outcome_unknown":
+                base["reasonCode"] = "label_unknown"
+                base["summary"] = "Label remove result unknown; pending state remains distinguishable and repairable."
+                base["pendingSync"] = finalization.record_pending_sync(reason="label remove unknown")
+                return base
+            base["reasonCode"] = code
+            base["summary"] = str(removed.get("summary") or "Label remove failed.")
+            return base
+    # Step 3: read back and classify before claiming release.
+    read = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)
+    if not read.get("ok"):
+        base["reasonCode"] = "read_back_unknown"
+        base["summary"] = "Label mutations applied but read-back is unknown; release not claimed."
+        base["pendingSync"] = finalization.record_pending_sync(reason="read-back unknown")
+        return base
+    issue_payload = read.get("issue") or {}
+    names: list[str] = []
+    raw_labels = issue_payload.get("labels") or []
+    for item in raw_labels if isinstance(raw_labels, list) else []:
+        if isinstance(item, Mapping):
+            names.append(str(item.get("name") or ""))
+        else:
+            names.append(str(item or ""))
+    read_back = {"state": issue_payload.get("state", "open"), "labels": names}
+    outcome = lifecycle.classify_mutation_outcome(
+        plan=lifecycle.LabelMutationPlan(tuple(labels_to_add), tuple(labels_to_remove), close_issue),
+        read_back=read_back,
+    )
+    base["mutationOutcome"] = outcome.to_dict()
+    if outcome.outcome not in {lifecycle.OUTCOME_APPLIED, lifecycle.OUTCOME_ALREADY_APPLIED}:
+        base["reasonCode"] = "mutation_incomplete"
+        base["summary"] = f"Destination not observed on read-back: {outcome.detail} Pending state remains repairable."
+        return base
+    # Step 4: finalize the terminal comment as released (best-effort marker).
+    released_body = plan.terminal_comment + "\n\nReleased: label outcome observed on read-back."
+    if comment_id is not None:
+        try:
+            updated = await service.update_issue_comment(repo=repository, comment_id=int(comment_id), body=released_body)
+        except Exception:  # noqa: BLE001 - release still holds; comment finalization is auxiliary
+            updated = {"ok": False, "reasonCode": "outcome_unknown"}
+        if not updated.get("ok") and str(updated.get("reasonCode") or "") == "outcome_unknown":
+            base["released"] = True
+            base["reasonCode"] = "released_comment_pending"
+            base["summary"] = "Label outcome observed; released-comment update is pending reconciliation."
+            base["workspaceRetained"] = bool(plan.workspace_retained)
+            return base
+    base["released"] = True
+    base["reasonCode"] = "released"
+    base["summary"] = f"Failed-attempt finalization released to {plan.disposition}; label outcome observed and terminal comment published."
+    base["workspaceRetained"] = bool(plan.workspace_retained)
+    base["pendingSync"] = None
+    return base
+
+
+__all__ = ["finalize_failed_attempt"]

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1176,6 +1176,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(
+            activity_type="github_issue.finalize_failed_attempt",
+            family="github_issue",
+            capability_class="integration:github",
+            task_queue=cfg.activity_integrations_task_queue,
+            fleet=INTEGRATIONS_FLEET,
+            timeouts=TemporalActivityTimeouts(120, 300),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
+        ),
+        TemporalActivityDefinition(
             activity_type="pr_resolver.resolve_selector",
             family="pr_resolver",
             capability_class="integration:github",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1030,6 +1030,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "integrations",
         "merge_automation_complete_post_merge_github",
     ),
+    "github_issue.finalize_failed_attempt": (
+        "integrations",
+        "github_issue_finalize_failed_attempt",
+    ),
     "pr_resolver.resolve_selector": (
         "integrations",
         "pr_resolver_resolve_selector",
@@ -5050,6 +5054,84 @@ class TemporalIntegrationActivities:
         return {
             "status": "succeeded" if succeeded else "failed",
             "required": required,
+            "repository": repository,
+            "issueNumber": issue_number,
+            **outputs,
+        }
+
+    async def github_issue_finalize_failed_attempt(self, payload, /, **kwargs):
+        """Finalize a failed/canceled controlling issue attempt (durable entrypoint).
+
+        Durable counterpart to the ``github.finalize_failed_attempt`` skill
+        tool: the controlling terminal path (failed or canceled exits that
+        never reach the success-path status update) schedules
+        ``github_issue.finalize_failed_attempt`` instead of relying on an
+        agent to invoke the skill. Input keys mirror the tool inputs; only
+        ``repository`` and ``issueNumber`` are required.
+        """
+        from moonmind.workflows.temporal.story_output_tools import (
+            finalize_github_issue_failed_attempt,
+        )
+
+        if not isinstance(payload, Mapping):
+            raise TemporalActivityRuntimeError(
+                "github_issue.finalize_failed_attempt requires an object"
+            )
+        config = payload.get("failedAttemptFinalization")
+        if not isinstance(config, Mapping):
+            config = payload
+
+        def _first(*keys: str) -> Any:
+            for key in keys:
+                if key in config and config[key] is not None:
+                    return config[key]
+            return None
+
+        def _block(*keys: str) -> dict[str, Any]:
+            for key in keys:
+                value = config.get(key)
+                if isinstance(value, Mapping):
+                    return dict(value)
+            return {}
+
+        repository = str(
+            _first("repository", "repo") or ""
+        ).strip()
+        try:
+            issue_number = int(_first("issueNumber", "issue_number") or 0)
+        except (TypeError, ValueError):
+            issue_number = 0
+        if not repository or issue_number <= 0:
+            raise TemporalActivityRuntimeError(
+                "github_issue.finalize_failed_attempt requires repository and issueNumber"
+            )
+        result = await finalize_github_issue_failed_attempt(
+            {
+                "repository": repository,
+                "issueNumber": issue_number,
+                "executionEvent": _first("executionEvent", "execution_event", "controllingOutcome", "controlling_outcome", "outcome", "status"),
+                "fromSettled": _first("fromSettled", "from_settled") or "in_progress",
+                "currentLabels": _first("currentLabels", "current_labels"),
+                "writerEvidence": _block("writerEvidence", "writer_evidence"),
+                "mutationEvidence": _block("mutationEvidence", "mutation_evidence"),
+                "preservationEvidence": _block("preservationEvidence", "preservation_evidence"),
+                "dispositionEvidence": _block("dispositionEvidence", "disposition_evidence"),
+                "attemptId": _first("attemptId", "attempt_id"),
+                "primaryOutcome": _first("primaryOutcome", "primary_outcome"),
+                "metRequirements": _first("metRequirements", "met_requirements"),
+                "remainingRequirements": _first("remainingRequirements", "remaining_requirements"),
+                "retryHistory": _first("retryHistory", "retry_history"),
+                "nextAction": _first("nextAction", "next_action"),
+                "reason": _first("reason"),
+                "completionMode": _first("completionMode", "completion_mode") or "pr_only_handoff",
+                "reviewOwnerEnded": _first("reviewOwnerEnded", "review_owner_ended"),
+                "cancellationHold": _first("cancellationHold", "cancellation_hold"),
+            }
+        )
+        outputs = dict(result.outputs)
+        succeeded = result.status == "COMPLETED" and outputs.get("released") is True
+        return {
+            "status": "succeeded" if succeeded else "failed",
             "repository": repository,
             "issueNumber": issue_number,
             **outputs,

--- a/moonmind/workflows/temporal/github_issue_finalization.py
+++ b/moonmind/workflows/temporal/github_issue_finalization.py
@@ -1,0 +1,916 @@
+"""Failed-attempt finalization with safe release and preserved-work handoffs.
+
+Single policy entrypoint for MoonLadderStudios/MoonMind#4179 (design:
+docs/Workflows/GitHubIssueStatusStateMachineDesign.md, sections 3, 4.2,
+and 6). Deterministic and side-effect-free: no network I/O. Trusted
+Activities/services perform GitHub reads/writes; this module decides what
+the reads mean and what a failed/canceled controlling attempt may publish.
+
+Contract summary:
+
+* Finalization attaches to the durable controlling workflow boundary only:
+  success, terminal failure, exhausted retries, blocked outcomes, and
+  intentional cancellation release the controlling attempt. Internal step
+  failures, remediation iterations, and legitimate external review waits
+  keep the same attempt active (Req 1, via ``github_issue_admission``
+  child-attempt propagation: those events never release).
+* Release requires confirmed writer stop, settled push/PR/merge outcomes,
+  and preserved authoritative output under the admitted save/publication
+  policy before any label release. Agent messages, workflow timestamps,
+  cleanup requests, and unmerged-PR presence alone are insufficient (Req 2).
+* The proposed terminal comment carries preserved PR/branch revision,
+  accepted and remaining requirements, primary outcome, retry history, and
+  next action. Destination labels apply through the #4176 lifecycle
+  boundary, are read back, and only then is the comment finalized as
+  released. Incomplete delivery stays durable and visible; failed GitHub
+  reporting never discards the only workspace/evidence (Req 3).
+* Disposition is evidence-driven (Req 4); objective state stays separate
+  from execution result so verified work is never re-bought on a reporting
+  failure (Req 5).
+* Abrupt termination, disconnected devices, and unknown mutation responses
+  are potentially unfinalized with recoverable local pending-sync, never
+  automatic release. Retries reread shared state and never knowingly
+  overwrite an observed successor (Req 6).
+* Both PR-only handoff and parent-owned PR-and-merge completion integrate
+  here; review-owner failure routes to the missing repair/review/
+  finalization phase, cancellation stays an explicit hold, and failure
+  cleanup never introduces merge authority (Req 7).
+
+This module reuses (never duplicates) the portable semantics owned
+elsewhere: lifecycle transitions in ``github_issue_lifecycle``, attempt
+release gating in ``github_issue_attempt``, and admission/child ownership
+in ``github_issue_admission``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, bool):
+        return ""
+    return str(value or "").strip()
+
+
+def _truthy(value: Any) -> bool:
+    if value is True:
+        return True
+    if isinstance(value, str):
+        return bool(value.strip())
+    return bool(value) and value is not False and value is not None
+
+
+# ---------------------------------------------------------------------------
+# Req 1: controlling-attempt finalization boundary
+# ---------------------------------------------------------------------------
+
+#: Controlling terminal outcomes that release the attempt at the durable
+#: execution boundary (normalized lowercase, underscores).
+CONTROLLING_TERMINAL_OUTCOMES = frozenset(
+    {
+        "success",
+        "succeeded",
+        "completed",
+        "failed",
+        "terminal_failure",
+        "exhausted_retries",
+        "retry_budget_exhausted",
+        "blocked",
+        "blocked_outcome",
+        "cancelled",
+        "canceled",
+        "intentional_cancellation",
+    }
+)
+
+#: Events that never release the controlling attempt: the same attempt stays
+#: active through internal retries, remediation, and legitimate review waits.
+NON_RELEASING_EVENTS = frozenset(
+    {
+        "internal_retry",
+        "internal_step_failure",
+        "step_failure",
+        "remediation_iteration",
+        "remediation_retry",
+        "review_wait",
+        "external_review_wait",
+        "awaiting_review",
+        "child_failure",
+        "activity_retry",
+    }
+)
+
+
+def normalize_execution_event(value: Any) -> str:
+    """Normalize an execution event/outcome onto the controlling vocabulary."""
+    return _string(value).lower().replace("-", "_").replace(" ", "_")
+
+
+def should_finalize_controlling_attempt(event: Any) -> dict[str, Any]:
+    """Decide whether *event* releases the controlling attempt (Req 1).
+
+    Returns ``{"finalize": bool, "reasonCode": str, "summary": str}``.
+    """
+    normalized = normalize_execution_event(event)
+    if normalized in NON_RELEASING_EVENTS:
+        return {
+            "finalize": False,
+            "reasonCode": "internal_event_retains_attempt",
+            "summary": (
+                f"Event {normalized or '<empty>'} is an internal step, remediation "
+                "iteration, or legitimate review wait; the controlling attempt stays active."
+            ),
+        }
+    if normalized in CONTROLLING_TERMINAL_OUTCOMES:
+        return {
+            "finalize": True,
+            "reasonCode": "controlling_terminal",
+            "summary": (
+                f"Event {normalized} ends the controlling attempt at the durable "
+                "execution boundary; terminal finalization applies."
+            ),
+        }
+    return {
+        "finalize": False,
+        "reasonCode": "unknown_event_no_release",
+        "summary": (
+            f"Event {normalized or '<empty>'} is not a recognized controlling terminal "
+            "outcome; no release is authorized without an explicit decision."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 2: writer stop + mutation settlement + preservation
+# ---------------------------------------------------------------------------
+
+#: Supported writer-stop confirmation methods (through the runtime boundary).
+SUPPORTED_STOP_METHODS = frozenset(
+    {
+        "runtime_quiescence",
+        "process_wait",
+        "activity_poll_stopped",
+        "device_disabled",
+        "operator_confirmed_stop",
+    }
+)
+
+#: Insufficient stop proofs that never authorize release on their own.
+INSUFFICIENT_STOP_PROOFS = frozenset(
+    {
+        "agent_message_only",
+        "workflow_timestamp_only",
+        "cleanup_request_only",
+        "unmerged_pr_only",
+    }
+)
+
+#: Settled mutation outcomes (per push/PR/merge channel).
+SETTLED_MUTATION_OUTCOMES = frozenset({"confirmed", "absent_na", "verified_absent"})
+UNKNOWN_MUTATION_OUTCOMES = frozenset({"unknown", "pending", "lost_response", ""})
+
+#: Admitted save/publication methods for preserved output.
+ADMITTED_SAVE_METHODS = frozenset(
+    {
+        "pr_head_verified",
+        "saved_branch_verified",
+        "explicit_no_work",
+        "local_only_owner_recovery",
+    }
+)
+
+
+def confirm_writer_stop(evidence: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Confirm all associated writers stopped via the supported boundary."""
+    data = dict(evidence or {})
+    method = _string(data.get("stopMethod") or data.get("stop_method")).lower().replace("-", "_").replace(" ", "_")
+    proof = _string(data.get("stopProof") or data.get("stop_proof")).lower().replace("-", "_").replace(" ", "_")
+    if proof in INSUFFICIENT_STOP_PROOFS:
+        return {
+            "stopped": False,
+            "reasonCode": "insufficient_stop_proof",
+            "summary": (
+                f"Stop proof {proof} is insufficient: a returned agent message, workflow "
+                "timestamp, cleanup request, or currently unmerged PR is not stop evidence."
+            ),
+        }
+    if not _truthy(data.get("writersStopped", data.get("writers_stopped"))):
+        return {
+            "stopped": False,
+            "reasonCode": "writers_running",
+            "summary": "Writers have not confirmed stop; release is blocked.",
+        }
+    if not _string(data.get("stopEvidence", data.get("stop_evidence"))):
+        return {
+            "stopped": False,
+            "reasonCode": "stop_evidence_missing",
+            "summary": "Writer stop is claimed without stop evidence; release is blocked.",
+        }
+    if method and method not in SUPPORTED_STOP_METHODS:
+        return {
+            "stopped": False,
+            "reasonCode": "unsupported_stop_method",
+            "summary": f"Stop method {method!r} is not a supported runtime-boundary confirmation.",
+        }
+    if not method:
+        return {
+            "stopped": False,
+            "reasonCode": "stop_method_missing",
+            "summary": "Writer stop lacks a supported boundary method; release is blocked.",
+        }
+    return {
+        "stopped": True,
+        "reasonCode": "writers_stopped",
+        "summary": f"Writers stopped via {method} with recorded stop evidence.",
+    }
+
+
+def settle_shared_mutations(evidence: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Settle outstanding push/PR/merge outcomes before release."""
+    data = dict(evidence or {})
+    channels = (
+        ("pushOutcome", "push_outcome", "push"),
+        ("prOutcome", "pr_outcome", "pr"),
+        ("mergeOutcome", "merge_outcome", "merge"),
+    )
+    unknown: list[str] = []
+    for camel, snake, label in channels:
+        raw = _string(data.get(camel, data.get(snake))).lower().replace("-", "_").replace(" ", "_")
+        if not raw:
+            # An absent channel (e.g. no merge attempted in a PR-only handoff)
+            # is settled as absent only when explicitly declared.
+            declared_absent = data.get(f"{snake}_absent", data.get(f"{camel}Absent"))
+            if declared_absent is True:
+                continue
+            unknown.append(f"{label}:missing")
+        elif raw in UNKNOWN_MUTATION_OUTCOMES:
+            unknown.append(f"{label}:{raw or 'unknown'}")
+        elif raw not in SETTLED_MUTATION_OUTCOMES:
+            unknown.append(f"{label}:{raw}")
+    if unknown:
+        return {
+            "settled": False,
+            "reasonCode": "mutations_unsettled",
+            "summary": (
+                "Outstanding push/PR/merge outcomes are unknown: "
+                + ", ".join(unknown)
+                + ". Unknown outcomes block automatic release/takeover until resolved."
+            ),
+            "unknown": unknown,
+        }
+    return {
+        "settled": True,
+        "reasonCode": "mutations_settled",
+        "summary": "Push/PR/merge outcomes are settled (confirmed or explicitly absent).",
+        "unknown": [],
+    }
+
+
+def preserve_authoritative_output(evidence: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Preserve authoritative output under the admitted save policy."""
+    data = dict(evidence or {})
+    method = _string(data.get("saveMethod") or data.get("save_method")).lower().replace("-", "_").replace(" ", "_")
+    if not method:
+        return {
+            "preserved": False,
+            "reasonCode": "preservation_missing",
+            "summary": "No admitted save method recorded; preservation is unverified.",
+            "workspaceRetained": True,
+        }
+    if method not in ADMITTED_SAVE_METHODS:
+        return {
+            "preserved": False,
+            "reasonCode": "preservation_unadmitted",
+            "summary": f"Save method {method!r} is outside the admitted save/publication policy.",
+            "workspaceRetained": True,
+        }
+    if method == "explicit_no_work":
+        if _truthy(data.get("trustworthyNoWork", data.get("trustworthy_no_work"))):
+            return {
+                "preserved": True,
+                "reasonCode": "explicit_no_work",
+                "summary": "Trustworthy no-work recorded; nothing to preserve.",
+                "workspaceRetained": False,
+            }
+        return {
+            "preserved": False,
+            "reasonCode": "no_work_untrusted",
+            "summary": "No-work claim is untrusted; preservation is unverified.",
+            "workspaceRetained": True,
+        }
+    if method == "local_only_owner_recovery":
+        return {
+            "preserved": True,
+            "reasonCode": "local_only_owner_recovery",
+            "summary": (
+                "Work is preserved local-only for owner recovery; portable "
+                "recovery is not promised and the workspace is retained."
+            ),
+            "workspaceRetained": True,
+        }
+    revision = _string(data.get("revision") or data.get("savedSha") or data.get("saved_sha") or data.get("prHeadSha") or data.get("pr_head_sha"))
+    ref = _string(data.get("prUrl") or data.get("pr_url") or data.get("savedBranch") or data.get("saved_branch"))
+    if not ref or not revision:
+        return {
+            "preserved": False,
+            "reasonCode": "preservation_incomplete",
+            "summary": "Admitted save lacks the preserved revision reference (PR/branch plus head SHA).",
+            "workspaceRetained": True,
+        }
+    if not _truthy(data.get("preservationVerified", data.get("preservation_verified"))):
+        return {
+            "preserved": False,
+            "reasonCode": "preservation_unverified",
+            "summary": "Preserved revision is recorded but not verified; release is blocked.",
+            "workspaceRetained": True,
+        }
+    return {
+        "preserved": True,
+        "reasonCode": "preservation_verified",
+        "summary": f"Authoritative output preserved via {method} at {ref}@{revision}.",
+        "workspaceRetained": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 4: evidence-driven disposition
+# ---------------------------------------------------------------------------
+
+#: Disposition targets expressed as lifecycle transition targets (#4176).
+DISPOSITION_RECOVERY_NEEDED = "to_recovery_needed"
+DISPOSITION_AVAILABLE = "to_available"
+DISPOSITION_CODE_REVIEW = "to_code_review"
+DISPOSITION_CLOSED = "to_closed"
+DISPOSITION_NEEDS_ATTENTION = "to_needs_attention"
+
+
+def choose_disposition(evidence: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Choose the terminal disposition from evidence (Req 4).
+
+    Precedence (first match wins):
+    intentional cancellation/hold -> needs_attention (hold, never auto-rerun);
+    unsafe recovery / exhausted budget / unresolved decision -> needs_attention;
+    verified objective satisfaction -> closed;
+    fulfilled implementation awaiting normal review -> code_review;
+    safe unfinished portable work -> recovery_needed;
+    trustworthy no-work plus allowed fresh retry -> available.
+    """
+    data = dict(evidence or {})
+    if _truthy(data.get("intentionalCancellation", data.get("intentional_cancellation"))) or _truthy(
+        data.get("operatorHold", data.get("operator_hold"))
+    ):
+        return {
+            "disposition": DISPOSITION_NEEDS_ATTENTION,
+            "reasonCode": "cancellation_hold",
+            "summary": "Intentional cancellation/hold: explicit hold with no automatic replacement work.",
+            "schedulesReplacement": False,
+        }
+    if (
+        _truthy(data.get("unsafeRecovery", data.get("unsafe_recovery")))
+        or _truthy(data.get("budgetExhausted", data.get("budget_exhausted")))
+        or _truthy(data.get("unresolvedDecision", data.get("unresolved_decision")))
+    ):
+        return {
+            "disposition": DISPOSITION_NEEDS_ATTENTION,
+            "reasonCode": "unsafe_or_exhausted",
+            "summary": "Unsafe recovery, exhausted budget, or unresolved decision requires attention.",
+            "schedulesReplacement": False,
+        }
+    if _truthy(data.get("completionVerified", data.get("completion_verified"))):
+        return {
+            "disposition": DISPOSITION_CLOSED,
+            "reasonCode": "objective_satisfied",
+            "summary": "Objective verified satisfied under the existing completion/closure policy.",
+            "schedulesReplacement": False,
+        }
+    if _truthy(data.get("gatesSatisfied", data.get("gates_satisfied"))) and _truthy(
+        data.get("prUrlVerified", data.get("pr_url_verified"))
+    ):
+        return {
+            "disposition": DISPOSITION_CODE_REVIEW,
+            "reasonCode": "awaiting_review",
+            "summary": "Fulfilled implementation awaiting normal review becomes code-review.",
+            "schedulesReplacement": False,
+        }
+    if _truthy(data.get("portableWorkSafe", data.get("portable_work_safe"))) and _truthy(
+        data.get("preservationVerified", data.get("preservation_verified"))
+    ):
+        return {
+            "disposition": DISPOSITION_RECOVERY_NEEDED,
+            "reasonCode": "safe_unfinished_portable",
+            "summary": "Safe unfinished portable work becomes recovery-needed.",
+            "schedulesReplacement": False,
+        }
+    if _truthy(data.get("trustworthyNoWork", data.get("trustworthy_no_work"))) and _truthy(
+        data.get("freshRetryAllowed", data.get("fresh_retry_allowed"))
+    ):
+        return {
+            "disposition": DISPOSITION_AVAILABLE,
+            "reasonCode": "safe_no_work_retry",
+            "summary": "Trustworthy no-work plus allowed fresh retry becomes Available with retained history.",
+            "schedulesReplacement": False,
+        }
+    return {
+        "disposition": DISPOSITION_NEEDS_ATTENTION,
+        "reasonCode": "default_attention",
+        "summary": "Evidence does not establish a safe next action; attention required.",
+        "schedulesReplacement": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 3: proposed terminal comment
+# ---------------------------------------------------------------------------
+
+MAX_COMMENT_REQUIREMENTS = 10
+
+
+def render_terminal_comment(
+    *,
+    repository: str = "",
+    issue_number: int = 0,
+    attempt_id: str = "",
+    primary_outcome: str = "",
+    pr_url: Any = "",
+    pr_head_sha: Any = "",
+    pr_base: Any = "",
+    saved_branch: Any = "",
+    saved_sha: Any = "",
+    met_requirements: Sequence[Any] | None = None,
+    remaining_requirements: Sequence[Any] | None = None,
+    retry_history: Any = "",
+    next_action: str = "",
+    disposition: str = "",
+) -> str:
+    """Render the proposed terminal comment body (Req 3).
+
+    Pure rendering: GitHub writes stay at the trusted Activity boundary.
+    """
+    repo = _string(repository)
+    issue_ref = f"{repo}#{issue_number}" if repo and issue_number else f"issue #{issue_number or '?'}"
+    lines = [
+        f"## MoonMind terminal handoff for {issue_ref}",
+        "",
+        f"Attempt `{_string(attempt_id) or 'unknown'}` ended with primary outcome **{_string(primary_outcome) or 'unknown'}**.",
+        f"Proposed disposition: **{_string(disposition) or 'undecided'}**.",
+    ]
+    preserved: list[str] = []
+    if _string(pr_url):
+        preserved.append(
+            f"PR {_string(pr_url)} @ {_string(pr_head_sha) or 'unknown head'} (base {_string(pr_base) or 'unknown'})"
+        )
+    if _string(saved_branch) or _string(saved_sha):
+        preserved.append(f"saved {_string(saved_branch) or '?'}@{_string(saved_sha) or 'unknown'}")
+    lines.append("Preserved work: " + ("; ".join(preserved) + "." if preserved else "none recorded."))
+    met = [_string(item) for item in (met_requirements or []) if _string(item)][:MAX_COMMENT_REQUIREMENTS]
+    remaining = [_string(item) for item in (remaining_requirements or []) if _string(item)][:MAX_COMMENT_REQUIREMENTS]
+    lines.append("Accepted requirements: " + ("; ".join(met) + "." if met else "none recorded."))
+    lines.append("Remaining requirements: " + ("; ".join(remaining) + "." if remaining else "none recorded."))
+    lines.append(f"Retry history: {_string(retry_history) or 'none recorded'}.")
+    lines.append(f"Next action: **{_string(next_action) or 'undecided'}**.")
+    lines.append("")
+    lines.append("Incomplete delivery remains durable and visible for reconciliation.")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Req 5: objective state vs execution result
+# ---------------------------------------------------------------------------
+
+AUXILIARY_FAILURE_KINDS = frozenset({"preservation", "status_synchronization", "publication", "cleanup"})
+
+
+def separate_objective_from_execution(
+    *,
+    execution_outcome: str = "",
+    objective_verified: bool = False,
+    auxiliary_failures: Sequence[Any] | None = None,
+) -> dict[str, Any]:
+    """Keep objective state separate from execution result (Req 5).
+
+    A verified implementation/merge is never re-bought because final
+    reporting failed; auxiliary failures are distinguished, not merged into
+    the primary outcome.
+    """
+    aux = [_string(item).lower().replace("-", "_") for item in (auxiliary_failures or []) if _string(item)]
+    unknown_aux = [item for item in aux if item not in AUXILIARY_FAILURE_KINDS]
+    if objective_verified:
+        return {
+            "rebuyImplementation": False,
+            "reasonCode": "objective_preserved",
+            "summary": (
+                f"Objective already verified; execution outcome {execution_outcome or 'unknown'} "
+                "does not re-buy implementation. Remaining work is "
+                + (", ".join(aux) if aux else "final reporting")
+                + "."
+            ),
+            "auxiliaryFailures": aux,
+            "unknownAuxiliaryKinds": unknown_aux,
+        }
+    return {
+        "rebuyImplementation": True,
+        "reasonCode": "objective_unverified",
+        "summary": (
+            f"Objective unverified and execution outcome is {execution_outcome or 'unknown'}; "
+            "remaining requirements stay open."
+        ),
+        "auxiliaryFailures": aux,
+        "unknownAuxiliaryKinds": unknown_aux,
+    }
+
+
+def partial_pr_justifies_code_review(*, gates_satisfied: bool, pr_url_verified: bool) -> dict[str, Any]:
+    """A partial PR alone never justifies code-review (Req 5)."""
+    if gates_satisfied and pr_url_verified:
+        return {
+            "allowed": True,
+            "reasonCode": "gates_satisfied",
+            "summary": "Controlling gates satisfied with a verified PR; code-review is justified.",
+        }
+    return {
+        "allowed": False,
+        "reasonCode": "partial_pr_insufficient",
+        "summary": "A partial PR alone does not justify code-review when controlling gates are unsatisfied.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 6: abrupt termination / disconnect / unknown mutation
+# ---------------------------------------------------------------------------
+
+UNFINALIZED_TRIGGERS = frozenset({"abrupt_termination", "disconnected_device", "unknown_mutation"})
+
+
+def classify_potentially_unfinalized(evidence: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Treat abrupt/disconnect/unknown-mutation as potentially unfinalized."""
+    data = dict(evidence or {})
+    triggers = {normalize_execution_event(item) for item in (
+        data.get("triggers") if isinstance(data.get("triggers"), Sequence) and not isinstance(data.get("triggers"), (str, bytes)) else [data.get("trigger")]
+    ) if _string(item)}
+    hit = sorted(triggers & {t.replace("-", "_") for t in UNFINALIZED_TRIGGERS} | triggers & UNFINALIZED_TRIGGERS)
+    if hit or _truthy(data.get("unknownMutation", data.get("unknown_mutation"))):
+        return {
+            "potentiallyUnfinalized": True,
+            "reasonCode": "potentially_unfinalized",
+            "summary": (
+                "Abrupt termination, disconnected device, or unknown mutation response: "
+                "potentially unfinalized, not automatic release."
+            ),
+            "triggers": hit,
+        }
+    if _truthy(data.get("githubUnavailable", data.get("github_unavailable"))):
+        return {
+            "potentiallyUnfinalized": True,
+            "reasonCode": "github_unavailable",
+            "summary": "GitHub unavailable: recoverable local pending synchronization recorded.",
+            "triggers": ["github_unavailable"],
+        }
+    return {
+        "potentiallyUnfinalized": False,
+        "reasonCode": "no_unfinalized_trigger",
+        "summary": "No abrupt-termination, disconnect, or unknown-mutation trigger observed.",
+        "triggers": [],
+    }
+
+
+def record_pending_sync(*, reason: str = "", workspace_retained: bool = True) -> dict[str, Any]:
+    """Record recoverable local pending synchronization (Req 6)."""
+    return {
+        "pendingSync": True,
+        "reasonCode": "pending_sync",
+        "summary": (
+            f"Recoverable local pending synchronization recorded ({_string(reason) or 'GitHub unavailable'}). "
+            "Retry rereads current shared state before acting."
+        ),
+        "workspaceRetained": bool(workspace_retained),
+    }
+
+
+def should_abandon_for_successor(*, intended_from_settled: str, observed_settled: str) -> dict[str, Any]:
+    """Never knowingly overwrite an observed successor's status (Req 6).
+
+    Thin adapter over the #4176 ``should_abandon_retry`` boundary.
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as _lifecycle
+
+    observed = _lifecycle.interpret_issue(
+        {"state": "open", "labels": [_settled_to_label(observed_settled)] if _settled_to_label(observed_settled) else []}
+    )
+    # When the observed settled string is already a lifecycle settled state,
+    # interpret directly instead of round-tripping through a label.
+    if not _settled_to_label(observed_settled) and _string(observed_settled) in {
+        _lifecycle.SETTLED_AVAILABLE,
+        _lifecycle.SETTLED_IN_PROGRESS,
+        _lifecycle.SETTLED_RECOVERY_NEEDED,
+        _lifecycle.SETTLED_CODE_REVIEW,
+        _lifecycle.SETTLED_NEEDS_ATTENTION,
+        _lifecycle.SETTLED_CLOSED,
+        _lifecycle.SETTLED_BLOCKED_MIXED,
+        _lifecycle.SETTLED_BLOCKED_UNKNOWN,
+        _lifecycle.SETTLED_BLOCKED_OPEN_DONE,
+    }:
+        from dataclasses import replace as _replace
+
+        observed = _replace(observed, settled=_string(observed_settled))
+    abandon, reason = _lifecycle.should_abandon_retry(
+        intended_from_settled=intended_from_settled, observed=observed
+    )
+    return {"abandon": bool(abandon), "reason": reason}
+
+
+def _settled_to_label(settled: str) -> str:
+    mapping = {
+        "in_progress": "status: in-progress",
+        "recovery_needed": "status: recovery-needed",
+        "code_review": "status: code-review",
+        "needs_attention": "status: needs-attention",
+    }
+    return mapping.get(_string(settled), "")
+
+
+# ---------------------------------------------------------------------------
+# Req 7: PR-only vs parent PR-and-merge completion
+# ---------------------------------------------------------------------------
+
+COMPLETION_PR_ONLY = "pr_only_handoff"
+COMPLETION_PARENT_PR_AND_MERGE = "parent_pr_and_merge"
+
+
+def route_completion_handoff(
+    *,
+    completion_mode: str = "",
+    review_owner_ended: bool = False,
+    cancellation_hold: bool = False,
+) -> dict[str, Any]:
+    """Integrate PR-only and parent PR-and-merge completion (Req 7)."""
+    mode = _string(completion_mode).lower().replace("-", "_").replace(" ", "_")
+    if cancellation_hold:
+        return {
+            "route": "explicit_hold",
+            "reasonCode": "cancellation_hold",
+            "summary": "Cancellation remains an explicit hold; no replacement work scheduled.",
+            "mergeAuthorized": False,
+        }
+    if mode in {"pr_only", COMPLETION_PR_ONLY}:
+        if review_owner_ended:
+            return {
+                "route": "missing_finalization_phase",
+                "reasonCode": "review_owner_failure",
+                "summary": "Review-owner failure routes to the missing repair/review/finalization phase.",
+                "mergeAuthorized": False,
+            }
+        return {
+            "route": COMPLETION_PR_ONLY,
+            "reasonCode": "pr_only",
+            "summary": "PR-only handoff: review/merge journey owns remaining work.",
+            "mergeAuthorized": False,
+        }
+    if mode in {"parent_pr_and_merge", COMPLETION_PARENT_PR_AND_MERGE, "parent"}:
+        if review_owner_ended:
+            return {
+                "route": "missing_finalization_phase",
+                "reasonCode": "review_owner_failure",
+                "summary": "Review-owner failure routes to the missing repair/review/finalization phase.",
+                "mergeAuthorized": False,
+            }
+        return {
+            "route": COMPLETION_PARENT_PR_AND_MERGE,
+            "reasonCode": "parent_pr_and_merge",
+            "summary": "Parent-owned PR-and-merge completion under the existing merge contract.",
+            "mergeAuthorized": True,
+        }
+    return {
+        "route": "needs_decision",
+        "reasonCode": "unknown_completion_mode",
+        "summary": f"Unknown completion mode {completion_mode!r}; no merge authority granted in failure cleanup.",
+        "mergeAuthorized": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Composition: plan one failed-attempt finalization (Reqs 1-7)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FinalizationPlan:
+    """Typed plan for one failed-attempt finalization."""
+
+    releasable: bool
+    reason_code: str
+    summary: str
+    disposition: str = ""
+    transition: dict[str, Any] | None = None
+    mutation: dict[str, Any] | None = None
+    terminal_comment: str = ""
+    pending_sync: dict[str, Any] | None = None
+    workspace_retained: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "releasable": self.releasable,
+            "reasonCode": self.reason_code,
+            "summary": self.summary,
+            "disposition": self.disposition,
+            "transition": self.transition,
+            "mutation": self.mutation,
+            "terminalComment": self.terminal_comment,
+            "pendingSync": self.pending_sync,
+            "workspaceRetained": self.workspace_retained,
+        }
+
+
+def plan_failed_attempt_finalization(
+    *,
+    repository: str = "",
+    issue_number: int = 0,
+    from_settled: str = "in_progress",
+    execution_event: Any = "",
+    writer_evidence: Mapping[str, Any] | None = None,
+    mutation_evidence: Mapping[str, Any] | None = None,
+    preservation_evidence: Mapping[str, Any] | None = None,
+    disposition_evidence: Mapping[str, Any] | None = None,
+    current_labels: Sequence[Any] | None = None,
+    reason: str = "",
+    attempt_id: str = "",
+    primary_outcome: str = "",
+    met_requirements: Sequence[Any] | None = None,
+    remaining_requirements: Sequence[Any] | None = None,
+    retry_history: Any = "",
+    next_action: str = "",
+) -> FinalizationPlan:
+    """Compose writer/mutation/preservation/disposition into a release plan.
+
+    Returns a non-releasable plan with ``workspaceRetained=True`` whenever
+    any gate fails: failed reporting never discards the only workspace.
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as _lifecycle
+
+    unfinalized = classify_potentially_unfinalized(
+        {"trigger": execution_event, "githubUnavailable": (disposition_evidence or {}).get("githubUnavailable", (disposition_evidence or {}).get("github_unavailable"))}
+    )
+    if unfinalized["potentiallyUnfinalized"] and (
+        normalize_execution_event(execution_event) in UNFINALIZED_TRIGGERS
+        or _truthy((mutation_evidence or {}).get("unknownMutation", (mutation_evidence or {}).get("unknown_mutation")))
+    ):
+        pending = record_pending_sync(reason=str(unfinalized["summary"]))
+        return FinalizationPlan(
+            releasable=False,
+            reason_code="potentially_unfinalized",
+            summary=str(unfinalized["summary"]),
+            pending_sync=pending,
+            workspace_retained=True,
+        )
+    gate = should_finalize_controlling_attempt(execution_event)
+    if not gate["finalize"]:
+        return FinalizationPlan(
+            releasable=False,
+            reason_code=str(gate["reasonCode"]),
+            summary=str(gate["summary"]),
+            workspace_retained=True,
+        )
+    writer = confirm_writer_stop(writer_evidence)
+    if not writer["stopped"]:
+        return FinalizationPlan(
+            releasable=False, reason_code=str(writer["reasonCode"]), summary=str(writer["summary"]), workspace_retained=True
+        )
+    mutations = settle_shared_mutations(mutation_evidence)
+    if not mutations["settled"]:
+        return FinalizationPlan(
+            releasable=False,
+            reason_code=str(mutations["reasonCode"]),
+            summary=str(mutations["summary"]),
+            workspace_retained=True,
+        )
+    preserved = preserve_authoritative_output(preservation_evidence)
+    if not preserved["preserved"]:
+        return FinalizationPlan(
+            releasable=False,
+            reason_code=str(preserved["reasonCode"]),
+            summary=str(preserved["summary"]),
+            workspace_retained=True,
+        )
+    if _truthy((disposition_evidence or {}).get("githubUnavailable", (disposition_evidence or {}).get("github_unavailable"))):
+        pending = record_pending_sync(reason="GitHub unavailable during finalization")
+        return FinalizationPlan(
+            releasable=False,
+            reason_code="github_unavailable",
+            summary=str(pending["summary"]),
+            pending_sync=pending,
+            workspace_retained=True,
+        )
+    disposition = choose_disposition(disposition_evidence)
+    target = str(disposition["disposition"])
+    evidence = _transition_evidence_for_disposition(
+        target, writer_evidence=writer_evidence, disposition_evidence=disposition_evidence
+    )
+    decision = _lifecycle.plan_transition(
+        from_settled=from_settled, to_target=target, evidence=evidence, reason=reason or str(disposition["summary"])
+    )
+    if not decision.allowed:
+        return FinalizationPlan(
+            releasable=False,
+            reason_code=str(decision.reason_code),
+            summary=str(decision.summary),
+            disposition=target,
+            transition=decision.to_dict(),
+            workspace_retained=True,
+        )
+    mutation = _lifecycle.plan_label_mutation(
+        from_settled=from_settled, to_target=target, current_labels=current_labels
+    )
+    comment = render_terminal_comment(
+        repository=repository,
+        issue_number=issue_number,
+        attempt_id=attempt_id,
+        primary_outcome=primary_outcome or normalize_execution_event(execution_event),
+        pr_url=(preservation_evidence or {}).get("prUrl", (preservation_evidence or {}).get("pr_url")),
+        pr_head_sha=(preservation_evidence or {}).get("prHeadSha", (preservation_evidence or {}).get("pr_head_sha")),
+        pr_base=(preservation_evidence or {}).get("prBase", (preservation_evidence or {}).get("pr_base")),
+        saved_branch=(preservation_evidence or {}).get("savedBranch", (preservation_evidence or {}).get("saved_branch")),
+        saved_sha=(preservation_evidence or {}).get("savedSha", (preservation_evidence or {}).get("saved_sha")),
+        met_requirements=met_requirements,
+        remaining_requirements=remaining_requirements,
+        retry_history=retry_history,
+        next_action=next_action or str(disposition["reasonCode"]),
+        disposition=target,
+    )
+    return FinalizationPlan(
+        releasable=True,
+        reason_code="finalization_planned",
+        summary=f"Failed-attempt finalization planned to {target} with proposed terminal comment.",
+        disposition=target,
+        transition=decision.to_dict(),
+        mutation=mutation.to_dict(),
+        terminal_comment=comment,
+        workspace_retained=bool(preserved.get("workspaceRetained", False)),
+    )
+
+
+def _transition_evidence_for_disposition(
+    target: str,
+    *,
+    writer_evidence: Mapping[str, Any] | None = None,
+    disposition_evidence: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Map disposition evidence onto #4176 transition guard keys."""
+    _ = writer_evidence
+    data = dict(disposition_evidence or {})
+    if target == DISPOSITION_RECOVERY_NEEDED:
+        return {
+            "writers_stopped": True,
+            "handoff_published": _truthy(data.get("handoffPublished", data.get("handoff_published", True))),
+        }
+    if target == DISPOSITION_AVAILABLE:
+        return {
+            "writers_stopped": True,
+            "terminal_proof": _truthy(data.get("terminalProof", data.get("terminal_proof", True))),
+        }
+    if target == DISPOSITION_CODE_REVIEW:
+        return {
+            "gates_satisfied": _truthy(data.get("gatesSatisfied", data.get("gates_satisfied"))),
+            "pr_url_verified": _truthy(data.get("prUrlVerified", data.get("pr_url_verified"))),
+        }
+    if target == DISPOSITION_CLOSED:
+        return {"completion_verified": _truthy(data.get("completionVerified", data.get("completion_verified")))}
+    if target == DISPOSITION_NEEDS_ATTENTION:
+        return {"blocking_reason": _string(data.get("blockingReason", data.get("blocking_reason"))) or "terminal attention required"}
+    return {}
+
+
+__all__ = [
+    "ADMITTED_SAVE_METHODS",
+    "AUXILIARY_FAILURE_KINDS",
+    "COMPLETION_PARENT_PR_AND_MERGE",
+    "COMPLETION_PR_ONLY",
+    "CONTROLLING_TERMINAL_OUTCOMES",
+    "DISPOSITION_AVAILABLE",
+    "DISPOSITION_CLOSED",
+    "DISPOSITION_CODE_REVIEW",
+    "DISPOSITION_NEEDS_ATTENTION",
+    "DISPOSITION_RECOVERY_NEEDED",
+    "INSUFFICIENT_STOP_PROOFS",
+    "MAX_COMMENT_REQUIREMENTS",
+    "NON_RELEASING_EVENTS",
+    "SETTLED_MUTATION_OUTCOMES",
+    "SUPPORTED_STOP_METHODS",
+    "UNFINALIZED_TRIGGERS",
+    "UNKNOWN_MUTATION_OUTCOMES",
+    "FinalizationPlan",
+    "choose_disposition",
+    "classify_potentially_unfinalized",
+    "confirm_writer_stop",
+    "normalize_execution_event",
+    "partial_pr_justifies_code_review",
+    "plan_failed_attempt_finalization",
+    "preserve_authoritative_output",
+    "record_pending_sync",
+    "render_terminal_comment",
+    "route_completion_handoff",
+    "separate_objective_from_execution",
+    "settle_shared_mutations",
+    "should_abandon_for_successor",
+    "should_finalize_controlling_attempt",
+]

--- a/moonmind/workflows/temporal/github_issue_finalization.py
+++ b/moonmind/workflows/temporal/github_issue_finalization.py
@@ -142,6 +142,80 @@ def should_finalize_controlling_attempt(event: Any) -> dict[str, Any]:
     }
 
 
+#: Abrupt/disconnect vocabulary from the durable execution boundary that maps
+#: onto the Req 6 potentially-unfinalized triggers instead of automatic
+#: release. Termination and timeout are never silent release evidence.
+ABRUPT_OUTCOME_ALIASES = frozenset(
+    {
+        "abrupt_termination",
+        "unknown_mutation",
+        "terminated",
+        "termination",
+        "timed_out",
+        "timeout",
+        "disconnected",
+        "disconnected_device",
+        "connection_lost",
+    }
+)
+
+
+def execution_event_for_controlling_outcome(outcome: Any) -> dict[str, Any]:
+    """Map a durable controlling-outcome value onto a finalizer event (Req 1).
+
+    The controlling workflow boundary (preset terminal handler, run-workflow
+    terminal state) reports outcomes in execution vocabulary; this thin
+    adapter routes each value to exactly one finalizer path without changing
+    the release semantics owned by :func:`should_finalize_controlling_attempt`
+    and :func:`classify_potentially_unfinalized`:
+
+    * controlling terminal outcomes (success, terminal failure, exhausted
+      retries, blocked outcomes, intentional cancellation) -> ``finalize``;
+    * internal step failures, remediation iterations, review waits ->
+      ``retain`` (the same attempt stays active);
+    * abrupt termination, timeout, disconnect vocabulary ->
+      ``potentially_unfinalized`` (never automatic release);
+    * anything else (unknown, blank, new values) -> ``no_release``.
+
+    Returns ``{"event": str, "action": str, "summary": str}``.
+    """
+    normalized = normalize_execution_event(outcome)
+    if normalized in ABRUPT_OUTCOME_ALIASES:
+        if normalized in UNFINALIZED_TRIGGERS:
+            canonical = normalized
+        elif "disconnect" in normalized or "connection" in normalized:
+            canonical = "disconnected_device"
+        else:
+            canonical = "abrupt_termination"
+        return {
+            "event": canonical,
+            "action": "potentially_unfinalized",
+            "summary": (
+                f"Outcome {normalized or '<empty>'} is abrupt termination, timeout, or "
+                "disconnect evidence: potentially unfinalized with recoverable "
+                "local pending synchronization, never automatic release."
+            ),
+        }
+    gate = should_finalize_controlling_attempt(normalized)
+    if gate["finalize"]:
+        return {
+            "event": normalized,
+            "action": "finalize",
+            "summary": str(gate["summary"]),
+        }
+    if normalized in NON_RELEASING_EVENTS:
+        return {
+            "event": normalized,
+            "action": "retain",
+            "summary": str(gate["summary"]),
+        }
+    return {
+        "event": normalized,
+        "action": "no_release",
+        "summary": str(gate["summary"]),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Req 2: writer stop + mutation settlement + preservation
 # ---------------------------------------------------------------------------
@@ -881,6 +955,7 @@ def _transition_evidence_for_disposition(
 
 
 __all__ = [
+    "ABRUPT_OUTCOME_ALIASES",
     "ADMITTED_SAVE_METHODS",
     "AUXILIARY_FAILURE_KINDS",
     "COMPLETION_PARENT_PR_AND_MERGE",
@@ -902,6 +977,7 @@ __all__ = [
     "choose_disposition",
     "classify_potentially_unfinalized",
     "confirm_writer_stop",
+    "execution_event_for_controlling_outcome",
     "normalize_execution_event",
     "partial_pr_justifies_code_review",
     "plan_failed_attempt_finalization",

--- a/moonmind/workflows/temporal/github_issue_finalization.py
+++ b/moonmind/workflows/temporal/github_issue_finalization.py
@@ -54,12 +54,23 @@ def _string(value: Any) -> str:
     return str(value or "").strip()
 
 
+#: Approved true tokens for string-valued evidence. Rendered tool inputs
+#: commonly carry ``"false"``/``"0"`` strings; only these tokens assert a
+#: guard fact. Mirrors the admission/lifecycle boolean convention
+#: (``github_issue_admission``, ``attempt_evidence_blocks_admission``).
+APPROVED_TRUE_TOKENS = frozenset({"1", "true", "yes"})
+
+
 def _truthy(value: Any) -> bool:
-    if value is True:
-        return True
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
     if isinstance(value, str):
-        return bool(value.strip())
-    return bool(value) and value is not False and value is not None
+        return value.strip().lower() in APPROVED_TRUE_TOKENS
+    return bool(value)
 
 
 # ---------------------------------------------------------------------------
@@ -814,11 +825,15 @@ def plan_failed_attempt_finalization(
     remaining_requirements: Sequence[Any] | None = None,
     retry_history: Any = "",
     next_action: str = "",
+    cancellation_hold: bool = False,
+    review_owner_ended: bool = False,
 ) -> FinalizationPlan:
     """Compose writer/mutation/preservation/disposition into a release plan.
 
     Returns a non-releasable plan with ``workspaceRetained=True`` whenever
     any gate fails: failed reporting never discards the only workspace.
+    An explicit cancellation hold short-circuits before evidence planning:
+    held attempts never release, whatever the disposition evidence claims.
     """
     from moonmind.workflows.temporal import github_issue_lifecycle as _lifecycle
 
@@ -843,6 +858,17 @@ def plan_failed_attempt_finalization(
             releasable=False,
             reason_code=str(gate["reasonCode"]),
             summary=str(gate["summary"]),
+            workspace_retained=True,
+        )
+    if bool(cancellation_hold) is True:
+        return FinalizationPlan(
+            releasable=False,
+            reason_code="cancellation_hold",
+            summary=(
+                "Explicit cancellation hold: no issue mutation is planned and no "
+                "replacement work is scheduled, whatever the disposition evidence claims."
+            ),
+            disposition=DISPOSITION_NEEDS_ATTENTION,
             workspace_retained=True,
         )
     writer = confirm_writer_stop(writer_evidence)
@@ -877,8 +903,15 @@ def plan_failed_attempt_finalization(
         )
     disposition = choose_disposition(disposition_evidence)
     target = str(disposition["disposition"])
+    mapping_evidence = dict(disposition_evidence or {})
+    mapping_evidence.setdefault("reviewOwnerEnded", review_owner_ended)
+    if _string(next_action):
+        mapping_evidence.setdefault("nextAction", _string(next_action))
     evidence = _transition_evidence_for_disposition(
-        target, writer_evidence=writer_evidence, disposition_evidence=disposition_evidence
+        target,
+        writer_evidence=writer_evidence,
+        disposition_evidence=mapping_evidence,
+        from_settled=from_settled,
     )
     decision = _lifecycle.plan_transition(
         from_settled=from_settled, to_target=target, evidence=evidence, reason=reason or str(disposition["summary"])
@@ -928,10 +961,26 @@ def _transition_evidence_for_disposition(
     *,
     writer_evidence: Mapping[str, Any] | None = None,
     disposition_evidence: Mapping[str, Any] | None = None,
+    from_settled: str = "",
 ) -> dict[str, Any]:
-    """Map disposition evidence onto #4176 transition guard keys."""
+    """Map disposition evidence onto #4176 transition guard keys.
+
+    The mapping is origin-aware: a code-review origin requires
+    ``owner_ended`` plus ``next_action_recorded`` (not the in-progress
+    writer/handoff keys), so review-owner recovery carries its required
+    guard evidence instead of always failing with ``missing_guard``.
+    """
     _ = writer_evidence
     data = dict(disposition_evidence or {})
+    origin = _string(from_settled).lower().replace("-", "_").replace(" ", "_")
+    if origin == "code_review" and target in {DISPOSITION_RECOVERY_NEEDED, DISPOSITION_NEEDS_ATTENTION}:
+        return {
+            "owner_ended": _truthy(
+                data.get("ownerEnded", data.get("owner_ended", data.get("reviewOwnerEnded", data.get("review_owner_ended"))))
+            ),
+            "next_action_recorded": _truthy(data.get("nextActionRecorded", data.get("next_action_recorded")))
+            or bool(_string(data.get("nextAction", data.get("next_action")))),
+        }
     if target == DISPOSITION_RECOVERY_NEEDED:
         return {
             "writers_stopped": True,
@@ -957,6 +1006,7 @@ def _transition_evidence_for_disposition(
 __all__ = [
     "ABRUPT_OUTCOME_ALIASES",
     "ADMITTED_SAVE_METHODS",
+    "APPROVED_TRUE_TOKENS",
     "AUXILIARY_FAILURE_KINDS",
     "COMPLETION_PARENT_PR_AND_MERGE",
     "COMPLETION_PR_ONLY",

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -88,6 +88,7 @@ ISSUE_BRIEF_LOADER_TOOL_NAMES = frozenset(
 )
 GITHUB_CHECK_ISSUE_BLOCKERS_TOOL_NAME = "github.check_issue_blockers"
 GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME = "github.update_issue_status"
+GITHUB_FINALIZE_FAILED_ATTEMPT_TOOL_NAME = "github.finalize_failed_attempt"
 GITHUB_RESOLVE_PULL_REQUEST_TARGET_TOOL_NAME = "github.resolve_pull_request_target"
 # The status tool runs inside a 60-second activity. One fetch plus the targeted
 # label operations and optional comment must leave enough time for the activity
@@ -7865,6 +7866,107 @@ async def update_github_issue_status(
     )
 
 
+def _failed_attempt_evidence(inputs: Mapping[str, Any], *keys: str) -> dict[str, Any]:
+    """Return the first mapping-valued finalizer evidence block in *inputs*."""
+    for key in keys:
+        value = inputs.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return {}
+
+
+async def finalize_github_issue_failed_attempt(
+    inputs: Mapping[str, Any],
+    _context: Mapping[str, Any] | None = None,
+    *,
+    github_service_factory: Callable[[], GitHubService] = GitHubService,
+) -> ToolResult:
+    """Finalize a failed/canceled controlling attempt with a safe release handoff.
+
+    Durable failed-path counterpart to the success-path
+    :func:`update_github_issue_status` ``finalize_after_pr_or_done`` mode
+    (MoonLadderStudios/MoonMind#4179): the controlling workflow's terminal
+    failure, exhausted-retries, blocked-outcome, and intentional-cancellation
+    paths invoke this tool instead of stopping without changing GitHub. The
+    outcome mapper keeps internal step failures, remediation iterations, and
+    legitimate review waits non-releasing, so reaching this tool with one of
+    those outcomes reports ``retained`` without GitHub effects. Abrupt
+    termination, timeout, and disconnect outcomes stay potentially unfinalized
+    with recoverable local pending synchronization, never automatic release.
+    """
+    from moonmind.workflows.temporal import github_issue_finalization as _finalization
+    from moonmind.workflows.temporal.activities.github_issue_finalization_activities import (
+        finalize_failed_attempt as _finalize_failed_attempt,
+    )
+
+    try:
+        repository, issue_number = _github_issue_inputs(inputs)
+    except ValueError as exc:
+        return ToolResult(
+            status="FAILED",
+            outputs={"decision": "blocked", "summary": str(exc)},
+        )
+    issue_ref = f"{repository}#{issue_number}"
+    raw_outcome = _first_string(
+        inputs.get("executionEvent"),
+        inputs.get("execution_event"),
+        inputs.get("controllingOutcome"),
+        inputs.get("controlling_outcome"),
+        inputs.get("outcome"),
+        inputs.get("status"),
+    )
+    mapped = _finalization.execution_event_for_controlling_outcome(raw_outcome)
+    execution_event = mapped["event"]
+    from_settled = (
+        _first_string(inputs.get("fromSettled"), inputs.get("from_settled")) or "in_progress"
+    )
+    current_labels = _list(inputs.get("currentLabels", inputs.get("current_labels"))) or None
+    result = await _finalize_failed_attempt(
+        repository=repository,
+        issue_number=issue_number,
+        execution_event=execution_event,
+        from_settled=from_settled,
+        current_labels=current_labels,
+        writer_evidence=_failed_attempt_evidence(inputs, "writerEvidence", "writer_evidence"),
+        mutation_evidence=_failed_attempt_evidence(inputs, "mutationEvidence", "mutation_evidence"),
+        preservation_evidence=_failed_attempt_evidence(inputs, "preservationEvidence", "preservation_evidence"),
+        disposition_evidence=_failed_attempt_evidence(inputs, "dispositionEvidence", "disposition_evidence"),
+        attempt_id=_first_string(inputs.get("attemptId"), inputs.get("attempt_id")),
+        primary_outcome=_first_string(inputs.get("primaryOutcome"), inputs.get("primary_outcome")) or execution_event,
+        met_requirements=_list(inputs.get("metRequirements", inputs.get("met_requirements"))),
+        remaining_requirements=_list(inputs.get("remainingRequirements", inputs.get("remaining_requirements"))),
+        retry_history=_first_string(inputs.get("retryHistory"), inputs.get("retry_history")),
+        next_action=_first_string(inputs.get("nextAction"), inputs.get("next_action")),
+        reason=_first_string(inputs.get("reason")),
+        completion_mode=_first_string(inputs.get("completionMode"), inputs.get("completion_mode")) or "pr_only_handoff",
+        review_owner_ended=_truthy(inputs.get("reviewOwnerEnded", inputs.get("review_owner_ended"))),
+        cancellation_hold=_truthy(inputs.get("cancellationHold", inputs.get("cancellation_hold"))),
+        service=github_service_factory(),
+    )
+    outputs: dict[str, Any] = {
+        "issueRef": issue_ref,
+        "executionEvent": execution_event,
+        "mappingAction": mapped["action"],
+        "mappingSummary": mapped["summary"],
+        "released": result["released"],
+        "reasonCode": result["reasonCode"],
+        "disposition": result["disposition"],
+        "summary": result["summary"],
+        "transition": result["transition"],
+        "mutation": result["mutation"],
+        "mutationOutcome": result["mutationOutcome"],
+        "completionRoute": result["completionRoute"],
+        "mergeAuthorized": result["mergeAuthorized"],
+        "workspaceRetained": result["workspaceRetained"],
+        "pendingSync": result["pendingSync"],
+        "commentId": result["commentId"],
+    }
+    return ToolResult(
+        status="COMPLETED" if result["released"] else "FAILED",
+        outputs=outputs,
+    )
+
+
 async def discover_documents(
     inputs: Mapping[str, Any],
     _context: Mapping[str, Any] | None = None,
@@ -8380,6 +8482,17 @@ def register_story_output_tool_handlers(
         handler=_update_github_issue_status,
     )
 
+    async def _finalize_github_issue_failed_attempt(
+        inputs: Mapping[str, Any],
+        context: Mapping[str, Any] | None = None,
+    ) -> ToolResult:
+        return await finalize_github_issue_failed_attempt(inputs, context)
+
+    dispatcher.register_skill(
+        skill_name=GITHUB_FINALIZE_FAILED_ATTEMPT_TOOL_NAME,
+        handler=_finalize_github_issue_failed_attempt,
+    )
+
     async def _resolve_pull_request_target(
         inputs: Mapping[str, Any],
         context: Mapping[str, Any] | None = None,
@@ -8429,8 +8542,10 @@ __all__ = [
     "GITHUB_LOAD_ISSUE_PRESET_BRIEF_TOOL_NAME",
     "GITHUB_CHECK_ISSUE_BLOCKERS_TOOL_NAME",
     "GITHUB_UPDATE_ISSUE_STATUS_TOOL_NAME",
+    "GITHUB_FINALIZE_FAILED_ATTEMPT_TOOL_NAME",
     "GITHUB_RESOLVE_PULL_REQUEST_TARGET_TOOL_NAME",
     "resolve_pull_request_target",
+    "finalize_github_issue_failed_attempt",
     "GITHUB_STORY_TOOL_NAMES",
     "JIRA_ORCHESTRATE_TASKS_TOOL_NAME",
     "JIRA_STORY_TOOL_NAMES",

--- a/tests/unit/workflows/adapters/test_github_service.py
+++ b/tests/unit/workflows/adapters/test_github_service.py
@@ -1441,3 +1441,81 @@ async def test_evaluate_pull_request_readiness_blocks_changes_requested_review(m
     assert result.ready is False
     assert result.automated_review_complete is False
     assert result.blockers[0]["summary"] == "Automated review has requested changes."
+
+
+# ---------------------------------------------------------------------------
+# close_issue (#4179 failed-attempt finalization close step)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_close_issue_success_patches_state_closed(monkeypatch):
+    """close_issue PATCHes state=closed and reports closed."""
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.patch = AsyncMock(return_value=_mock_response(200, {"state": "closed"}))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("moonmind.workflows.adapters.github_service.httpx.AsyncClient", return_value=mock_client):
+        svc = GitHubService()
+        result = await svc.close_issue(repo="o/r", issue_number=4179)
+
+    assert result["ok"] is True
+    assert result["reasonCode"] == "closed"
+    _args, kwargs = mock_client.patch.call_args
+    assert kwargs["json"] == {"state": "closed"}
+    assert "o/r/issues/4179" in _args[0]
+
+
+@pytest.mark.asyncio
+async def test_close_issue_denied_never_reports_closed(monkeypatch):
+    """A 403 close reports denied, never closed."""
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    denied = _mock_response(403, {"message": "forbidden"})
+    mock_client.patch = AsyncMock(
+        side_effect=httpx.HTTPStatusError("forbidden", request=denied.request, response=denied)
+    )
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("moonmind.workflows.adapters.github_service.httpx.AsyncClient", return_value=mock_client):
+        svc = GitHubService()
+        result = await svc.close_issue(repo="o/r", issue_number=4179)
+
+    assert result["ok"] is False
+    assert result["reasonCode"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_close_issue_transport_loss_is_outcome_unknown(monkeypatch):
+    """Transport loss during close is outcome_unknown, not failure proof."""
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token-fixture")
+
+    mock_client = AsyncMock()
+    mock_client.patch = AsyncMock(side_effect=httpx.ConnectError("lost"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("moonmind.workflows.adapters.github_service.httpx.AsyncClient", return_value=mock_client):
+        svc = GitHubService()
+        result = await svc.close_issue(repo="o/r", issue_number=4179)
+
+    assert result["ok"] is False
+    assert result["reasonCode"] == "outcome_unknown"
+
+
+@pytest.mark.asyncio
+async def test_close_issue_missing_token_is_auth_unavailable(monkeypatch):
+    """No token resolves to auth_unavailable before any GitHub write."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("MOONMIND_GITHUB_TOKEN", raising=False)
+
+    svc = GitHubService()
+    result = await svc.close_issue(repo="o/r", issue_number=4179)
+
+    assert result["ok"] is False
+    assert result["reasonCode"] == "auth_unavailable"

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -599,6 +599,66 @@ async def test_post_merge_github_completion_applies_done_status(
     }
     assert result["status"] == "succeeded"
     assert result["confirmedLabels"] == ["status: done"]
+
+
+async def test_github_issue_finalize_failed_attempt_binding_routes_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The durable failed-attempt entrypoint schedules the finalizer tool.
+
+    Regression for the unreferenced-registration gap: failed/canceled
+    controlling exits dispatch ``github_issue.finalize_failed_attempt``
+    through the durable activity boundary instead of relying on an agent to
+    invoke the skill.
+    """
+    from moonmind.workflows.temporal import story_output_tools
+
+    captured: dict[str, Any] = {}
+
+    async def fake_finalize_failed_attempt(inputs, _context=None):
+        captured.update(inputs)
+        return SimpleNamespace(
+            status="COMPLETED",
+            outputs={
+                "released": True,
+                "reasonCode": "released",
+                "disposition": "to_recovery_needed",
+            },
+        )
+
+    monkeypatch.setattr(
+        story_output_tools,
+        "finalize_github_issue_failed_attempt",
+        fake_finalize_failed_attempt,
+    )
+
+    result = await TemporalIntegrationActivities.github_issue_finalize_failed_attempt(
+        object(),
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 4179,
+            "executionEvent": "failed",
+            "fromSettled": "in_progress",
+            "attemptId": "att_test",
+            "nextAction": "continue-implementation",
+        },
+    )
+
+    assert captured["repository"] == "MoonLadderStudios/MoonMind"
+    assert captured["issueNumber"] == 4179
+    assert captured["executionEvent"] == "failed"
+    assert captured["fromSettled"] == "in_progress"
+    assert captured["attemptId"] == "att_test"
+    assert result["status"] == "succeeded"
+    assert result["released"] is True
+    assert result["disposition"] == "to_recovery_needed"
+
+
+async def test_github_issue_finalize_failed_attempt_requires_issue_identity() -> None:
+    with pytest.raises(Exception, match="requires repository and issueNumber"):
+        await TemporalIntegrationActivities.github_issue_finalize_failed_attempt(
+            object(), {"executionEvent": "failed"}
+        )
 from moonmind.workflows.temporal.report_artifacts import validate_report_bundle_result
 from moonmind.workflows.temporal.runtime.store import ManagedRunStore
 from moonmind.workloads.registry import RunnerProfileRegistry

--- a/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
+++ b/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
@@ -1,0 +1,603 @@
+"""Failed-attempt finalization with safe release (#4179).
+
+Covers MoonLadderStudios/MoonMind#4179 acceptance through the real
+workflow/Activity call shapes: controlling vs internal events, writer-stop
+and mutation/preservation gates, evidence-driven dispositions, objective vs
+execution separation, unfinalized/pending-sync and successor respect,
+completion routing, interrupt-after-every-mutation pending states, and the
+five failure stages (before edits, after partial work, after PR creation,
+after accepted verification, after merge) through the production Activity
+with a fake GitHub service.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from moonmind.workflows.temporal import github_issue_finalization as fin
+from moonmind.workflows.temporal.activities import github_issue_finalization_activities as acts
+
+
+def _writer(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "writers_stopped": True,
+        "stop_method": "runtime_quiescence",
+        "stop_evidence": "runtime reports 0 writers; poll confirms stopped",
+    }
+    base.update(overrides)
+    return base
+
+
+def _mutations(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {"push_outcome": "confirmed", "pr_outcome": "confirmed", "merge_outcome": "absent_na",
+                            "merge_outcome_absent": True}
+    base.update(overrides)
+    return base
+
+
+def _preserved(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "save_method": "pr_head_verified",
+        "pr_url": "https://github.com/o/r/pull/7",
+        "pr_head_sha": "a" * 40,
+        "pr_base": "main",
+        "revision": "a" * 40,
+        "preservation_verified": True,
+    }
+    base.update(overrides)
+    return base
+
+
+# -- Req 1: controlling boundary ---------------------------------------------
+
+
+@pytest.mark.parametrize("event", ["success", "failed", "exhausted_retries", "blocked", "cancelled", "terminal_failure"])
+def test_controlling_terminal_events_finalize(event: str) -> None:
+    decision = fin.should_finalize_controlling_attempt(event)
+    assert decision["finalize"] is True
+    assert decision["reasonCode"] == "controlling_terminal"
+
+
+@pytest.mark.parametrize(
+    "event", ["internal_retry", "remediation_iteration", "review_wait", "step_failure", "child_failure", "awaiting_review"]
+)
+def test_internal_events_retain_attempt(event: str) -> None:
+    decision = fin.should_finalize_controlling_attempt(event)
+    assert decision["finalize"] is False
+    assert decision["reasonCode"] == "internal_event_retains_attempt"
+
+
+def test_unknown_event_never_releases() -> None:
+    decision = fin.should_finalize_controlling_attempt("mystery-outcome")
+    assert decision["finalize"] is False
+    assert decision["reasonCode"] == "unknown_event_no_release"
+
+
+def test_internal_retries_retain_ownership_and_cancellation_holds() -> None:
+    assert fin.should_finalize_controlling_attempt("internal_retry")["finalize"] is False
+    hold = fin.choose_disposition({"intentional_cancellation": True})
+    assert hold["disposition"] == fin.DISPOSITION_NEEDS_ATTENTION
+    assert hold["schedulesReplacement"] is False
+
+
+# -- Req 2: writer / mutation / preservation gates ----------------------------
+
+
+@pytest.mark.parametrize(
+    "proof", ["agent_message_only", "workflow_timestamp_only", "cleanup_request_only", "unmerged_pr_only"]
+)
+def test_insufficient_stop_proofs_rejected(proof: str) -> None:
+    result = fin.confirm_writer_stop(_writer(stop_proof=proof, stop_method="runtime_quiescence"))
+    assert result["stopped"] is False
+    assert result["reasonCode"] == "insufficient_stop_proof"
+
+
+def test_writer_stop_requires_method_and_evidence() -> None:
+    assert fin.confirm_writer_stop({"writers_stopped": False})["stopped"] is False
+    assert fin.confirm_writer_stop(_writer(stop_evidence=""))["reasonCode"] == "stop_evidence_missing"
+    assert fin.confirm_writer_stop(_writer(stop_method=""))["reasonCode"] == "stop_method_missing"
+    assert fin.confirm_writer_stop(_writer())["stopped"] is True
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        _mutations(push_outcome="unknown"),
+        _mutations(pr_outcome="pending"),
+        _mutations(merge_outcome="lost_response", merge_outcome_absent=False),
+        _mutations(pr_outcome=""),
+    ],
+)
+def test_unknown_mutation_outcomes_block_release(evidence: dict[str, Any]) -> None:
+    result = fin.settle_shared_mutations(evidence)
+    assert result["settled"] is False
+    assert result["reasonCode"] == "mutations_unsettled"
+
+
+def test_preservation_failure_blocks_and_retains_workspace() -> None:
+    result = fin.preserve_authoritative_output({"save_method": "pr_head_verified"})
+    assert result["preserved"] is False
+    assert result["workspaceRetained"] is True
+    failed_plan = fin.plan_failed_attempt_finalization(
+        execution_event="failed",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence={"save_method": "pr_head_verified"},
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True},
+    )
+    assert failed_plan.releasable is False
+    assert failed_plan.workspace_retained is True
+
+
+def test_github_outage_never_false_release() -> None:
+    plan = fin.plan_failed_attempt_finalization(
+        execution_event="failed",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True, "github_unavailable": True},
+    )
+    assert plan.releasable is False
+    assert plan.reason_code == "github_unavailable"
+    assert plan.pending_sync is not None
+    assert plan.workspace_retained is True
+
+
+# -- Req 4: disposition matrix -------------------------------------------------
+
+
+def test_disposition_recovery_needed_for_portable_work() -> None:
+    choice = fin.choose_disposition({"portable_work_safe": True, "preservation_verified": True})
+    assert choice["disposition"] == fin.DISPOSITION_RECOVERY_NEEDED
+
+
+def test_disposition_available_for_safe_no_work_retry() -> None:
+    choice = fin.choose_disposition({"trustworthy_no_work": True, "fresh_retry_allowed": True})
+    assert choice["disposition"] == fin.DISPOSITION_AVAILABLE
+
+
+def test_disposition_code_review_only_with_gates() -> None:
+    choice = fin.choose_disposition({"gates_satisfied": True, "pr_url_verified": True})
+    assert choice["disposition"] == fin.DISPOSITION_CODE_REVIEW
+
+
+def test_partial_pr_alone_never_code_review() -> None:
+    assert fin.partial_pr_justifies_code_review(gates_satisfied=False, pr_url_verified=True)["allowed"] is False
+    assert fin.partial_pr_justifies_code_review(gates_satisfied=True, pr_url_verified=False)["allowed"] is False
+
+
+def test_disposition_closed_and_needs_attention() -> None:
+    assert fin.choose_disposition({"completion_verified": True})["disposition"] == fin.DISPOSITION_CLOSED
+    assert fin.choose_disposition({"budget_exhausted": True})["disposition"] == fin.DISPOSITION_NEEDS_ATTENTION
+    assert fin.choose_disposition({"unsafe_recovery": True})["disposition"] == fin.DISPOSITION_NEEDS_ATTENTION
+    assert fin.choose_disposition({"unresolved_decision": True})["disposition"] == fin.DISPOSITION_NEEDS_ATTENTION
+
+
+# -- Req 3: terminal comment ---------------------------------------------------
+
+
+def test_terminal_comment_carries_required_sections() -> None:
+    body = fin.render_terminal_comment(
+        repository="o/r",
+        issue_number=4179,
+        attempt_id="att_test",
+        primary_outcome="failed",
+        pr_url="https://github.com/o/r/pull/7",
+        pr_head_sha="a" * 40,
+        pr_base="main",
+        met_requirements=["req-a"],
+        remaining_requirements=["req-b"],
+        retry_history="1 failed / 0 no-progress",
+        next_action="continue-implementation",
+        disposition="to_recovery_needed",
+    )
+    for section in ("PR https://github.com/o/r/pull/7", "req-a", "req-b", "failed", "continue-implementation", "1 failed"):
+        assert section in body
+
+
+def test_full_plan_recovery_needed() -> None:
+    plan = fin.plan_failed_attempt_finalization(
+        repository="o/r",
+        issue_number=4179,
+        execution_event="failed",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True, "handoff_published": True},
+        current_labels=["status: in-progress"],
+        attempt_id="att_test",
+        met_requirements=["req-a"],
+        remaining_requirements=["req-b"],
+        retry_history="1 failed",
+        next_action="continue-implementation",
+        reason="terminal failure with portable work",
+    )
+    assert plan.releasable is True
+    assert plan.disposition == "to_recovery_needed"
+    assert plan.transition is not None and plan.transition["allowed"] is True
+    assert plan.mutation is not None
+    assert "req-b" in plan.terminal_comment
+
+
+def test_full_plan_available_no_work() -> None:
+    plan = fin.plan_failed_attempt_finalization(
+        execution_event="failed",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence={"save_method": "explicit_no_work", "trustworthy_no_work": True},
+        disposition_evidence={"trustworthy_no_work": True, "fresh_retry_allowed": True, "terminal_proof": True},
+        reason="safe no-work retry",
+    )
+    assert plan.releasable is True
+    assert plan.disposition == "to_available"
+
+
+# -- Req 5: objective vs execution ---------------------------------------------
+
+
+def test_verified_objective_never_rebought_on_reporting_failure() -> None:
+    result = fin.separate_objective_from_execution(
+        execution_outcome="failed", objective_verified=True, auxiliary_failures=["publication"]
+    )
+    assert result["rebuyImplementation"] is False
+    assert result["auxiliaryFailures"] == ["publication"]
+
+
+def test_unverified_objective_keeps_requirements_open() -> None:
+    result = fin.separate_objective_from_execution(execution_outcome="failed", objective_verified=False)
+    assert result["rebuyImplementation"] is True
+
+
+# -- Req 6: unfinalized / pending-sync / successor ------------------------------
+
+
+@pytest.mark.parametrize("trigger", ["abrupt_termination", "disconnected_device", "unknown_mutation"])
+def test_abrupt_triggers_are_potentially_unfinalized(trigger: str) -> None:
+    assert fin.classify_potentially_unfinalized({"trigger": trigger})["potentiallyUnfinalized"] is True
+    plan = fin.plan_failed_attempt_finalization(
+        execution_event=trigger,
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True},
+    )
+    assert plan.releasable is False
+    assert plan.reason_code == "potentially_unfinalized"
+
+
+def test_pending_sync_recorded_and_successor_respected() -> None:
+    pending = fin.record_pending_sync(reason="GitHub outage")
+    assert pending["pendingSync"] is True and pending["workspaceRetained"] is True
+    abandon = fin.should_abandon_for_successor(intended_from_settled="in_progress", observed_settled="recovery_needed")
+    assert abandon["abandon"] is True
+    hold = fin.should_abandon_for_successor(intended_from_settled="in_progress", observed_settled="needs_attention")
+    assert hold["abandon"] is True
+    same = fin.should_abandon_for_successor(intended_from_settled="in_progress", observed_settled="in_progress")
+    assert same["abandon"] is False
+
+
+def test_replayed_finalizer_respects_hold_and_history() -> None:
+    # A late finalizer observing a hold or successor abandons new mutations.
+    assert fin.should_abandon_for_successor(intended_from_settled="in_progress", observed_settled="needs_attention")["abandon"] is True
+    assert fin.should_abandon_for_successor(intended_from_settled="in_progress", observed_settled="closed")["abandon"] is True
+
+
+# -- Req 7: completion routing ---------------------------------------------------
+
+
+def test_pr_only_and_parent_routing() -> None:
+    pr_only = fin.route_completion_handoff(completion_mode="pr_only_handoff")
+    assert pr_only["route"] == fin.COMPLETION_PR_ONLY
+    assert pr_only["mergeAuthorized"] is False
+    parent = fin.route_completion_handoff(completion_mode="parent_pr_and_merge")
+    assert parent["mergeAuthorized"] is True
+    review_failure = fin.route_completion_handoff(completion_mode="pr_only_handoff", review_owner_ended=True)
+    assert review_failure["route"] == "missing_finalization_phase"
+    assert review_failure["mergeAuthorized"] is False
+    hold = fin.route_completion_handoff(completion_mode="parent_pr_and_merge", cancellation_hold=True)
+    assert hold["route"] == "explicit_hold"
+    assert hold["mergeAuthorized"] is False
+    unknown = fin.route_completion_handoff(completion_mode="bogus")
+    assert unknown["mergeAuthorized"] is False
+
+
+# -- Activity boundary with fake service ---------------------------------------
+
+
+class _FakeService:
+    """Minimal fake of the GitHubService surface used by the finalizer."""
+
+    def __init__(
+        self,
+        *,
+        issue_labels: list[str] | None = None,
+        issue_state: str = "open",
+        fail_add: str = "",
+        fail_remove: str = "",
+        fail_create: str = "",
+        unknown_update: bool = False,
+    ) -> None:
+        self.labels = list(issue_labels or ["status: in-progress"])
+        self.state = issue_state
+        self.fail_add = fail_add
+        self.fail_remove = fail_remove
+        self.fail_create = fail_create
+        self.unknown_update = unknown_update
+        self.comments: list[dict[str, Any]] = []
+        self.calls: list[str] = []
+
+    async def resolve_github_token(self, repo: str = "") -> tuple[str | None, str]:
+        _ = repo
+        return "token", ""
+
+    def _github_headers(self, token: str) -> dict[str, str]:
+        _ = token
+        return {}
+
+    async def create_issue_comment(self, *, repo: str, issue_number: int, body: str) -> dict[str, Any]:
+        _ = (repo, issue_number)
+        self.calls.append("create_comment")
+        if self.fail_create == "unknown":
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost response"}
+        if self.fail_create:
+            return {"ok": False, "reasonCode": "create_failed", "summary": "create failed"}
+        comment_id = 100 + len(self.comments)
+        self.comments.append({"id": comment_id, "body": body})
+        return {"ok": True, "reasonCode": "created", "commentId": comment_id}
+
+    async def add_issue_labels(self, *, repo: str, issue_number: int, labels: list[str]) -> dict[str, Any]:
+        _ = (repo, issue_number)
+        self.calls.append(f"add:{','.join(labels)}")
+        if self.fail_add == "unknown":
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost response"}
+        if self.fail_add == "denied":
+            return {"ok": False, "reasonCode": "denied", "summary": "denied"}
+        for label in labels:
+            if label not in self.labels:
+                self.labels.append(label)
+        return {"ok": True, "reasonCode": "added"}
+
+    async def remove_issue_label(self, *, repo: str, issue_number: int, label: str) -> dict[str, Any]:
+        _ = (repo, issue_number)
+        self.calls.append(f"remove:{label}")
+        if self.fail_remove == "unknown":
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost response"}
+        if label in self.labels:
+            self.labels.remove(label)
+        return {"ok": True, "reasonCode": "removed"}
+
+    async def update_issue_comment(self, *, repo: str, comment_id: int, body: str) -> dict[str, Any]:
+        _ = repo
+        self.calls.append(f"update:{comment_id}")
+        if self.unknown_update:
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost response"}
+        for comment in self.comments:
+            if comment["id"] == comment_id:
+                comment["body"] = body
+        return {"ok": True, "reasonCode": "updated", "commentId": comment_id}
+
+
+def _issue_reader(service: _FakeService):  # noqa: ANN202 - test helper
+    async def _read(*, service: Any, repository: str, issue_number: int) -> dict[str, Any]:  # noqa: ANN202
+        _ = (repository, issue_number)
+        return {"ok": True, "reasonCode": "read", "issue": {"state": service.state, "labels": service.labels}}
+
+    return _read
+
+
+def _base_kwargs(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "repository": "o/r",
+        "issue_number": 4179,
+        "execution_event": "failed",
+        "from_settled": "in_progress",
+        "current_labels": ["status: in-progress"],
+        "writer_evidence": _writer(),
+        "mutation_evidence": _mutations(),
+        "preservation_evidence": _preserved(),
+        "disposition_evidence": {
+            "portable_work_safe": True,
+            "preservation_verified": True,
+            "handoff_published": True,
+        },
+        "attempt_id": "att_test",
+        "primary_outcome": "failed",
+        "met_requirements": ["req-a"],
+        "remaining_requirements": ["req-b"],
+        "retry_history": "1 failed",
+        "next_action": "continue-implementation",
+        "reason": "terminal failure with portable work",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_activity_releases_recovery_needed(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is True
+    assert result["disposition"] == "to_recovery_needed"
+    assert "status: recovery-needed" in service.labels
+    assert "status: in-progress" not in service.labels
+    assert result["workspaceRetained"] is False
+    assert any("create_comment" in call for call in service.calls)
+
+
+@pytest.mark.asyncio
+async def test_activity_available_no_work_releases_without_status_label(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            preservation_evidence={"save_method": "explicit_no_work", "trustworthy_no_work": True},
+            disposition_evidence={"trustworthy_no_work": True, "fresh_retry_allowed": True, "terminal_proof": True},
+        ),
+        service=service,
+    )
+    assert result["released"] is True
+    assert result["disposition"] == "to_available"
+    assert "status: in-progress" not in service.labels
+
+
+@pytest.mark.asyncio
+async def test_activity_writer_stop_failure_never_false_release() -> None:
+    service = _FakeService()
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(writer_evidence={"writers_stopped": False}), service=service
+    )
+    assert result["released"] is False
+    assert result["reasonCode"] == "writers_running"
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_activity_unknown_mutation_and_preservation_block() -> None:
+    service = _FakeService()
+    unknown_mut = await acts.finalize_failed_attempt(
+        **_base_kwargs(mutation_evidence=_mutations(push_outcome="unknown")), service=service
+    )
+    assert unknown_mut["released"] is False
+    assert unknown_mut["reasonCode"] == "mutations_unsettled"
+    bad_preserve = await acts.finalize_failed_attempt(
+        **_base_kwargs(preservation_evidence={"save_method": "pr_head_verified"}), service=service
+    )
+    assert bad_preserve["released"] is False
+    assert bad_preserve["workspaceRetained"] is True
+
+
+@pytest.mark.asyncio
+async def test_activity_interrupt_after_every_mutation_stays_pending(monkeypatch) -> None:
+    # Interrupt after comment create: unknown label add.
+    service = _FakeService(fail_add="unknown")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    pending_add = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert pending_add["released"] is False
+    assert pending_add["reasonCode"] == "label_unknown"
+    assert pending_add["pendingSync"] is not None
+    assert pending_add["commentId"] is not None  # proposed comment durable for repair
+
+    # Interrupt after label add: failed comment create never discards workspace.
+    failing = _FakeService(fail_create="create_failed")
+    failed_create = await acts.finalize_failed_attempt(**_base_kwargs(), service=failing)
+    assert failed_create["released"] is False
+    assert failed_create["workspaceRetained"] is True
+
+    # Interrupt after labels: unknown read-back stays pending, not released.
+    async def _unknown_read(*, service: Any, repository: str, issue_number: int) -> dict[str, Any]:
+        _ = (service, repository, issue_number)
+        return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost"}
+
+    service_ok = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _unknown_read)
+    pending_read = await acts.finalize_failed_attempt(**_base_kwargs(), service=service_ok)
+    assert pending_read["released"] is False
+    assert pending_read["reasonCode"] == "read_back_unknown"
+
+
+@pytest.mark.asyncio
+async def test_activity_denied_label_preserves_proposed_comment(monkeypatch) -> None:
+    service = _FakeService(fail_add="denied")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is False
+    assert result["reasonCode"] == "mutation_denied"
+    assert result["commentId"] is not None
+
+
+# -- Five failure stages ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_stage_before_edits_safe_no_work(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            execution_event="failed",
+            preservation_evidence={"save_method": "explicit_no_work", "trustworthy_no_work": True},
+            disposition_evidence={"trustworthy_no_work": True, "fresh_retry_allowed": True, "terminal_proof": True},
+            met_requirements=[],
+            remaining_requirements=["req-a", "req-b"],
+            retry_history="0 failed",
+            next_action="fresh-retry",
+        ),
+        service=service,
+    )
+    assert result["released"] is True
+    assert result["disposition"] == "to_available"
+
+
+@pytest.mark.asyncio
+async def test_failure_stage_after_partial_work_recovery_needed(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is True
+    assert result["disposition"] == "to_recovery_needed"
+
+
+@pytest.mark.asyncio
+async def test_failure_stage_after_pr_creation_recovery_needed(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            preservation_evidence=_preserved(),
+            disposition_evidence={"portable_work_safe": True, "preservation_verified": True, "handoff_published": True},
+            met_requirements=["req-a"],
+            remaining_requirements=["req-b"],
+        ),
+        service=service,
+    )
+    assert result["released"] is True
+    assert "pull/7" in service.comments[0]["body"]
+
+
+@pytest.mark.asyncio
+async def test_failure_stage_after_accepted_verification_code_review(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            execution_event="failed",
+            disposition_evidence={"gates_satisfied": True, "pr_url_verified": True},
+        ),
+        service=service,
+    )
+    assert result["released"] is True
+    assert result["disposition"] == "to_code_review"
+
+
+@pytest.mark.asyncio
+async def test_failure_stage_after_merge_closed_without_rebuy(monkeypatch) -> None:
+    service = _FakeService(issue_labels=["status: code-review"], issue_state="open")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+
+    async def _closed_read(*, service: Any, repository: str, issue_number: int) -> dict[str, Any]:
+        _ = (repository, issue_number)
+        return {"ok": True, "reasonCode": "read", "issue": {"state": "closed", "labels": service.labels}}
+
+    if service.state == "open":
+        service.state = "open"  # labels drive the to_closed read-back below
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            execution_event="failed",
+            from_settled="code_review",
+            current_labels=["status: code-review"],
+            disposition_evidence={"completion_verified": True},
+        ),
+        service=service,
+    )
+    # Close completion uses the Done destination before removing blockers; the
+    # fake read-back here still shows code-review, so the plan is releasable
+    # but the Activity reports incomplete rather than false success.
+    assert result["released"] in {True, False}
+    separation = fin.separate_objective_from_execution(
+        execution_outcome="failed", objective_verified=True, auxiliary_failures=["publication"]
+    )
+    assert separation["rebuyImplementation"] is False
+    monkeypatch.setattr(acts, "_fetch_issue", _closed_read)

--- a/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
+++ b/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
@@ -318,7 +318,9 @@ class _FakeService:
         fail_remove: str = "",
         fail_create: str = "",
         fail_close: str = "",
+        fail_update: str = "",
         unknown_update: bool = False,
+        seed_comments: list[dict[str, Any]] | None = None,
     ) -> None:
         self.labels = list(issue_labels or ["status: in-progress"])
         self.state = issue_state
@@ -326,9 +328,11 @@ class _FakeService:
         self.fail_remove = fail_remove
         self.fail_create = fail_create
         self.fail_close = fail_close
+        self.fail_update = fail_update
         self.unknown_update = unknown_update
-        self.comments: list[dict[str, Any]] = []
+        self.comments: list[dict[str, Any]] = [dict(item) for item in (seed_comments or [])]
         self.calls: list[str] = []
+        self.list_calls: list[str] = []
 
     async def resolve_github_token(self, repo: str = "") -> tuple[str | None, str]:
         _ = repo
@@ -366,15 +370,26 @@ class _FakeService:
         self.calls.append(f"remove:{label}")
         if self.fail_remove == "unknown":
             return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost response"}
+        if self.fail_remove == "failed":
+            return {"ok": False, "reasonCode": "remove_failed", "summary": "remove failed"}
         if label in self.labels:
             self.labels.remove(label)
         return {"ok": True, "reasonCode": "removed"}
 
+    async def list_issue_comments(self, *, repo: str, issue_number: int) -> dict[str, Any]:
+        _ = (repo, issue_number)
+        self.list_calls.append("list_comments")
+        return {"ok": True, "reasonCode": "listed", "comments": [dict(item) for item in self.comments]}
+
     async def update_issue_comment(self, *, repo: str, comment_id: int, body: str) -> dict[str, Any]:
         _ = repo
         self.calls.append(f"update:{comment_id}")
-        if self.unknown_update:
+        if self.unknown_update or self.fail_update == "unknown":
             return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost response"}
+        if self.fail_update == "denied":
+            return {"ok": False, "reasonCode": "denied", "summary": "update denied"}
+        if self.fail_update:
+            return {"ok": False, "reasonCode": "update_failed", "summary": "update failed"}
         for comment in self.comments:
             if comment["id"] == comment_id:
                 comment["body"] = body
@@ -877,3 +892,313 @@ def test_replayed_finalizer_respects_closed_successor_and_hold() -> None:
     )
     assert separated["unknownAuxiliaryKinds"] == ["some_future_kind"]
     assert separated["rebuyImplementation"] is True
+
+
+# -- Codex review remediation (PR #4244 follow-up) -------------------------------
+# Covers the P1 findings on the first finalizer revision: strict boolean
+# evidence parsing, cancellation-hold gating, pre-mutation reads with
+# successor abandonment, outbound scanning, canonical attempt-comment reuse,
+# pending (never released) comment-update failures, pending sync after every
+# partial mutation failure, and origin-aware transition evidence.
+
+
+@pytest.mark.parametrize("value", ["false", "False", "FALSE", "  false  ", "0", "no", "off", "", "  ", "maybe"])
+def test_truthy_rejects_false_like_strings(value: Any) -> None:
+    assert fin._truthy(value) is False
+
+
+@pytest.mark.parametrize("value", [True, "true", "True", "TRUE", "  yes  ", "Yes", "YES", "1", 1, 1.0])
+def test_truthy_accepts_only_approved_true_tokens(value: Any) -> None:
+    assert fin._truthy(value) is True
+
+
+@pytest.mark.parametrize("value", [False, None, 0, 0.0])
+def test_truthy_rejects_falsy_non_strings(value: Any) -> None:
+    assert fin._truthy(value) is False
+
+
+def test_cancellation_hold_blocks_release_despite_releasable_evidence() -> None:
+    plan = fin.plan_failed_attempt_finalization(
+        execution_event="failed",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"trustworthy_no_work": True, "fresh_retry_allowed": True, "terminal_proof": True},
+        cancellation_hold=True,
+        reason="operator hold with releasable evidence",
+    )
+    assert plan.releasable is False
+    assert plan.reason_code == "cancellation_hold"
+    assert plan.workspace_retained is True
+
+
+@pytest.mark.asyncio
+async def test_activity_cancellation_hold_makes_no_github_effects(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(cancellation_hold=True), service=service)
+    assert result["released"] is False
+    assert result["reasonCode"] == "cancellation_hold"
+    assert result["workspaceRetained"] is True
+    assert service.calls == []
+    assert service.comments == []
+
+
+@pytest.mark.asyncio
+async def test_tool_cancellation_hold_string_values(monkeypatch) -> None:
+    from moonmind.workflows.temporal import story_output_tools as tools
+
+    def _inputs(hold: Any) -> dict[str, Any]:
+        return {
+            "repository": "o/r",
+            "issueNumber": 4179,
+            "executionEvent": "failed",
+            "fromSettled": "in_progress",
+            "currentLabels": ["status: in-progress"],
+            "writerEvidence": _writer(),
+            "mutationEvidence": _mutations(),
+            "preservationEvidence": _preserved(),
+            "dispositionEvidence": {
+                "portable_work_safe": True,
+                "preservation_verified": True,
+                "handoff_published": True,
+            },
+            "attemptId": "att_test",
+            "primaryOutcome": "failed",
+            "metRequirements": ["req-a"],
+            "remainingRequirements": ["req-b"],
+            "retryHistory": "1 failed",
+            "nextAction": "continue-implementation",
+            "reason": "terminal failure with portable work",
+            "cancellationHold": hold,
+        }
+
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    held = await tools.finalize_github_issue_failed_attempt(_inputs("true"), github_service_factory=lambda: service)
+    assert held.outputs["released"] is False
+    assert held.outputs["reasonCode"] == "cancellation_hold"
+
+    releasing = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(releasing))
+    loose = await tools.finalize_github_issue_failed_attempt(_inputs("false"), github_service_factory=lambda: releasing)
+    assert loose.status == "COMPLETED"
+    assert loose.outputs["released"] is True
+
+
+@pytest.mark.asyncio
+async def test_preread_successor_abandons_before_effects(monkeypatch) -> None:
+    service = _FakeService(issue_labels=["status: recovery-needed"])
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is False
+    assert result["reasonCode"] == "successor_observed"
+    assert result["workspaceRetained"] is True
+    assert service.calls == []
+    assert service.comments == []
+    assert service.list_calls == []
+
+
+@pytest.mark.asyncio
+async def test_preread_closed_issue_abandons(monkeypatch) -> None:
+    service = _FakeService(issue_labels=["status: in-progress"], issue_state="closed")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is False
+    assert result["reasonCode"] == "successor_observed"
+    assert service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_omitted_current_labels_derive_from_preread(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    kwargs = _base_kwargs()
+    del kwargs["current_labels"]
+    result = await acts.finalize_failed_attempt(**kwargs, service=service)
+    assert result["released"] is True
+    assert result["disposition"] == "to_recovery_needed"
+    assert "status: recovery-needed" in service.labels
+
+
+@pytest.mark.asyncio
+async def test_stale_caller_labels_lose_to_observed_hold(monkeypatch) -> None:
+    service = _FakeService(issue_labels=["status: needs-attention"])
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is False
+    assert result["reasonCode"] == "successor_observed"
+    assert service.calls == []
+    assert service.comments == []
+
+
+@pytest.mark.asyncio
+async def test_scan_blocks_secret_like_handoff(monkeypatch) -> None:
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(met_requirements=["rotate deploy token ghp_" + "A" * 36]),
+        service=service,
+    )
+    assert result["released"] is False
+    assert result["reasonCode"] == "comment_blocked_by_scan"
+    assert result["workspaceRetained"] is True
+    assert service.calls == []
+    assert service.comments == []
+
+
+def _seeded_attempt_comment(attempt_id: str) -> dict[str, Any]:
+    marker = f"<!-- moonmind-github-attempt: {attempt_id} v1 -->"
+    body = (
+        f"{marker}\n## MoonMind attempt `{attempt_id}` — progress\n\n"
+        "<!-- moonmind.github_issue_attempt.v1 metadata (machine-readable, do not edit) -->\n"
+        f'```json\n{{"attemptId": "{attempt_id}"}}\n```\n'
+    )
+    return {"id": 7, "body": body}
+
+
+@pytest.mark.asyncio
+async def test_reuses_canonical_attempt_comment(monkeypatch) -> None:
+    from moonmind.workflows.temporal.github_issue_attempt import extract_attempt_metadata
+
+    attempt_id = "att_" + "b" * 24
+    service = _FakeService(seed_comments=[_seeded_attempt_comment(attempt_id)])
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(attempt_id=attempt_id), service=service
+    )
+    assert result["released"] is True
+    assert result["commentId"] == 7
+    assert len(service.comments) == 1
+    assert not any("create_comment" in call for call in service.calls)
+    assert "update:7" in service.calls
+    merged = service.comments[0]["body"]
+    assert "<!-- moonmind-github-attempt:" in merged
+    assert "terminal handoff" in merged
+    metadata, error = extract_attempt_metadata(merged)
+    assert error == ""
+    assert metadata is not None and metadata.get("attemptId") == attempt_id
+
+
+@pytest.mark.asyncio
+async def test_conflicting_attempt_copies_stay_pending(monkeypatch) -> None:
+    attempt_id = "att_" + "c" * 24
+    service = _FakeService(
+        seed_comments=[_seeded_attempt_comment(attempt_id), _seeded_attempt_comment(attempt_id)]
+    )
+    service.comments[1]["id"] = 8
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(attempt_id=attempt_id), service=service
+    )
+    assert result["released"] is False
+    assert result["reasonCode"] == "conflicting_attempt_copies"
+    assert result["pendingSync"] is not None
+    assert result["workspaceRetained"] is True
+    assert not any("create_comment" in call for call in service.calls)
+    assert len(service.comments) == 2
+
+
+@pytest.mark.asyncio
+async def test_released_comment_failure_stays_pending(monkeypatch) -> None:
+    service = _FakeService(fail_update="denied")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is False
+    assert result["reasonCode"] == "released_comment_failed"
+    assert result["pendingSync"] is not None
+    assert result["workspaceRetained"] is True
+
+
+@pytest.mark.asyncio
+async def test_remove_failure_records_pending_sync(monkeypatch) -> None:
+    service = _FakeService(fail_remove="failed")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(**_base_kwargs(), service=service)
+    assert result["released"] is False
+    assert result["reasonCode"] == "remove_failed"
+    assert result["pendingSync"] is not None
+    assert result["workspaceRetained"] is True
+
+
+@pytest.mark.asyncio
+async def test_close_failure_records_pending_sync(monkeypatch) -> None:
+    service = _FakeService(issue_labels=["status: code-review"], issue_state="open", fail_close="boom")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            execution_event="failed",
+            from_settled="code_review",
+            current_labels=["status: code-review"],
+            disposition_evidence={"completion_verified": True},
+        ),
+        service=service,
+    )
+    assert result["released"] is False
+    assert result["reasonCode"] == "close_failed"
+    assert result["pendingSync"] is not None
+    assert result["workspaceRetained"] is True
+
+
+def test_code_review_recovery_maps_owner_guard_evidence() -> None:
+    allowed = fin.plan_failed_attempt_finalization(
+        execution_event="failed",
+        from_settled="code_review",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True},
+        current_labels=["status: code-review"],
+        review_owner_ended=True,
+        next_action="continue-recovery",
+        reason="review owner ended with safe portable work",
+    )
+    assert allowed.releasable is True
+    assert allowed.disposition == fin.DISPOSITION_RECOVERY_NEEDED
+    # Without owner/next-action evidence the same origin still denies.
+    denied = fin.plan_failed_attempt_finalization(
+        execution_event="failed",
+        from_settled="code_review",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True},
+        current_labels=["status: code-review"],
+        reason="review owner ended with safe portable work",
+    )
+    assert denied.releasable is False
+    assert denied.reason_code == "missing_guard"
+    # The needs-attention target from a code-review origin uses the same guards.
+    held = fin.plan_failed_attempt_finalization(
+        execution_event="cancelled",
+        from_settled="code_review",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"intentional_cancellation": True, "blocking_reason": "operator hold"},
+        current_labels=["status: code-review"],
+        review_owner_ended=True,
+        next_action="await-operator",
+        reason="intentional cancellation",
+    )
+    assert held.releasable is True
+    assert held.disposition == fin.DISPOSITION_NEEDS_ATTENTION
+
+
+@pytest.mark.asyncio
+async def test_activity_code_review_recovery_releases(monkeypatch) -> None:
+    service = _FakeService(issue_labels=["status: code-review"], issue_state="open")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            execution_event="failed",
+            from_settled="code_review",
+            current_labels=["status: code-review"],
+            review_owner_ended=True,
+            next_action="continue-recovery",
+        ),
+        service=service,
+    )
+    assert result["released"] is True
+    assert result["disposition"] == "to_recovery_needed"
+    assert "status: recovery-needed" in service.labels

--- a/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
+++ b/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
@@ -317,6 +317,7 @@ class _FakeService:
         fail_add: str = "",
         fail_remove: str = "",
         fail_create: str = "",
+        fail_close: str = "",
         unknown_update: bool = False,
     ) -> None:
         self.labels = list(issue_labels or ["status: in-progress"])
@@ -324,6 +325,7 @@ class _FakeService:
         self.fail_add = fail_add
         self.fail_remove = fail_remove
         self.fail_create = fail_create
+        self.fail_close = fail_close
         self.unknown_update = unknown_update
         self.comments: list[dict[str, Any]] = []
         self.calls: list[str] = []
@@ -377,6 +379,18 @@ class _FakeService:
             if comment["id"] == comment_id:
                 comment["body"] = body
         return {"ok": True, "reasonCode": "updated", "commentId": comment_id}
+
+    async def close_issue(self, *, repo: str, issue_number: int) -> dict[str, Any]:
+        _ = (repo, issue_number)
+        self.calls.append("close_issue")
+        if self.fail_close == "unknown":
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": "lost response"}
+        if self.fail_close == "denied":
+            return {"ok": False, "reasonCode": "denied", "summary": "close denied"}
+        if self.fail_close:
+            return {"ok": False, "reasonCode": "close_failed", "summary": "close failed"}
+        self.state = "closed"
+        return {"ok": True, "reasonCode": "closed", "summary": "Closed."}
 
 
 def _issue_reader(service: _FakeService):  # noqa: ANN202 - test helper
@@ -576,13 +590,6 @@ async def test_failure_stage_after_accepted_verification_code_review(monkeypatch
 async def test_failure_stage_after_merge_closed_without_rebuy(monkeypatch) -> None:
     service = _FakeService(issue_labels=["status: code-review"], issue_state="open")
     monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
-
-    async def _closed_read(*, service: Any, repository: str, issue_number: int) -> dict[str, Any]:
-        _ = (repository, issue_number)
-        return {"ok": True, "reasonCode": "read", "issue": {"state": "closed", "labels": service.labels}}
-
-    if service.state == "open":
-        service.state = "open"  # labels drive the to_closed read-back below
     result = await acts.finalize_failed_attempt(
         **_base_kwargs(
             execution_event="failed",
@@ -592,12 +599,281 @@ async def test_failure_stage_after_merge_closed_without_rebuy(monkeypatch) -> No
         ),
         service=service,
     )
-    # Close completion uses the Done destination before removing blockers; the
-    # fake read-back here still shows code-review, so the plan is releasable
-    # but the Activity reports incomplete rather than false success.
-    assert result["released"] in {True, False}
+    # Failure after merge with verified objective completion releases to
+    # closed: the Activity executes the close step, observes closed on
+    # read-back, and publishes the released terminal comment.
+    assert result["released"] is True
+    assert result["reasonCode"] == "released"
+    assert result["disposition"] == "to_closed"
+    assert result["mutationOutcome"] is not None
+    assert result["mutationOutcome"]["outcome"] == "applied"
+    assert "close_issue" in service.calls
+    assert service.state == "closed"
+    assert "status: done" in service.labels
+    assert "status: code-review" not in service.labels
+    assert service.comments and "pull/7" in service.comments[0]["body"]
+    assert "Released:" in service.comments[0]["body"]
+    assert result["workspaceRetained"] is False
+    # Objective satisfaction is never re-bought because reporting ran late:
+    # the execution outcome stays failed while the objective stays verified.
     separation = fin.separate_objective_from_execution(
         execution_outcome="failed", objective_verified=True, auxiliary_failures=["publication"]
     )
     assert separation["rebuyImplementation"] is False
-    monkeypatch.setattr(acts, "_fetch_issue", _closed_read)
+
+
+@pytest.mark.asyncio
+async def test_activity_close_unknown_stays_pending(monkeypatch) -> None:
+    service = _FakeService(fail_close="unknown")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            execution_event="failed",
+            from_settled="code_review",
+            current_labels=["status: code-review"],
+            disposition_evidence={"completion_verified": True},
+        ),
+        service=service,
+    )
+    assert result["released"] is False
+    assert result["reasonCode"] == "close_unknown"
+    assert result["workspaceRetained"] is True
+    assert result["pendingSync"] is not None
+    assert result["commentId"] is not None  # proposed comment durable for repair
+
+
+@pytest.mark.asyncio
+async def test_activity_close_denied_never_false_release(monkeypatch) -> None:
+    service = _FakeService(fail_close="denied")
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await acts.finalize_failed_attempt(
+        **_base_kwargs(
+            execution_event="failed",
+            from_settled="code_review",
+            current_labels=["status: code-review"],
+            disposition_evidence={"completion_verified": True},
+        ),
+        service=service,
+    )
+    assert result["released"] is False
+    assert result["reasonCode"] == "denied"
+    assert result["workspaceRetained"] is True
+
+
+# -- Req 1: controlling-outcome mapping ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "outcome", ["success", "failed", "exhausted_retries", "blocked", "cancelled", "terminal_failure"]
+)
+def test_controlling_outcomes_map_to_finalize(outcome: str) -> None:
+    mapped = fin.execution_event_for_controlling_outcome(outcome)
+    assert mapped["action"] == "finalize"
+    assert fin.should_finalize_controlling_attempt(mapped["event"])["finalize"] is True
+
+
+@pytest.mark.parametrize(
+    "outcome", ["internal_retry", "remediation_iteration", "review_wait", "step_failure", "awaiting_review"]
+)
+def test_controlling_outcomes_retain_internal_attempts(outcome: str) -> None:
+    mapped = fin.execution_event_for_controlling_outcome(outcome)
+    assert mapped["action"] == "retain"
+    assert fin.should_finalize_controlling_attempt(mapped["event"])["finalize"] is False
+
+
+@pytest.mark.parametrize("outcome", ["terminated", "timed_out", "disconnected", "abrupt_termination"])
+def test_abrupt_outcomes_are_potentially_unfinalized(outcome: str) -> None:
+    mapped = fin.execution_event_for_controlling_outcome(outcome)
+    assert mapped["action"] == "potentially_unfinalized"
+    plan = fin.plan_failed_attempt_finalization(
+        execution_event=mapped["event"],
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True},
+    )
+    assert plan.releasable is False
+    assert plan.reason_code == "potentially_unfinalized"
+    assert plan.workspace_retained is True
+
+
+@pytest.mark.parametrize("outcome", ["mystery-outcome", "", None, 123])
+def test_unknown_outcomes_never_release(outcome: Any) -> None:
+    mapped = fin.execution_event_for_controlling_outcome(outcome)
+    assert mapped["action"] == "no_release"
+    plan = fin.plan_failed_attempt_finalization(
+        execution_event=mapped["event"] or outcome,
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={"portable_work_safe": True, "preservation_verified": True},
+    )
+    assert plan.releasable is False
+    assert plan.workspace_retained is True
+
+
+# -- Req 1: durable failed-path tool boundary ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_path_tool_releases_recovery_needed(monkeypatch) -> None:
+    from moonmind.workflows.temporal import story_output_tools as tools
+
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await tools.finalize_github_issue_failed_attempt(
+        {
+            "repository": "o/r",
+            "issueNumber": 4179,
+            "executionEvent": "failed",
+            "fromSettled": "in_progress",
+            "currentLabels": ["status: in-progress"],
+            "writerEvidence": _writer(),
+            "mutationEvidence": _mutations(),
+            "preservationEvidence": _preserved(),
+            "dispositionEvidence": {
+                "portable_work_safe": True,
+                "preservation_verified": True,
+                "handoff_published": True,
+            },
+            "attemptId": "att_test",
+            "primaryOutcome": "failed",
+            "metRequirements": ["req-a"],
+            "remainingRequirements": ["req-b"],
+            "retryHistory": "1 failed",
+            "nextAction": "continue-implementation",
+            "reason": "terminal failure with portable work",
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["released"] is True
+    assert result.outputs["disposition"] == "to_recovery_needed"
+    assert result.outputs["mappingAction"] == "finalize"
+    assert result.outputs["mergeAuthorized"] is False
+    assert result.outputs["workspaceRetained"] is False
+    assert "status: recovery-needed" in service.labels
+
+
+@pytest.mark.asyncio
+async def test_failed_path_tool_cancellation_holds_without_rerun(monkeypatch) -> None:
+    from moonmind.workflows.temporal import story_output_tools as tools
+
+    service = _FakeService()
+    monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
+    result = await tools.finalize_github_issue_failed_attempt(
+        {
+            "repository": "o/r",
+            "issueNumber": 4179,
+            "executionEvent": "cancelled",
+            "writerEvidence": _writer(),
+            "mutationEvidence": _mutations(),
+            "preservationEvidence": _preserved(),
+            "dispositionEvidence": {
+                "intentional_cancellation": True,
+                "blocking_reason": "operator hold",
+            },
+            "reason": "intentional cancellation",
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "COMPLETED"
+    assert result.outputs["released"] is True
+    assert result.outputs["disposition"] == "to_needs_attention"
+    assert result.outputs["mergeAuthorized"] is False
+
+
+@pytest.mark.asyncio
+async def test_failed_path_tool_internal_event_retained_without_effects() -> None:
+    from moonmind.workflows.temporal import story_output_tools as tools
+
+    service = _FakeService()
+    result = await tools.finalize_github_issue_failed_attempt(
+        {
+            "repository": "o/r",
+            "issueNumber": 4179,
+            "executionEvent": "remediation_iteration",
+            "writerEvidence": _writer(),
+            "mutationEvidence": _mutations(),
+            "preservationEvidence": _preserved(),
+            "dispositionEvidence": {"portable_work_safe": True, "preservation_verified": True},
+        },
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert result.outputs["released"] is False
+    assert result.outputs["mappingAction"] == "retain"
+    assert service.calls == []
+    assert service.comments == []
+
+
+@pytest.mark.asyncio
+async def test_failed_path_tool_rejects_bad_issue_inputs() -> None:
+    from moonmind.workflows.temporal import story_output_tools as tools
+
+    service = _FakeService()
+    result = await tools.finalize_github_issue_failed_attempt(
+        {"repository": "", "issueNumber": 0, "executionEvent": "failed"},
+        github_service_factory=lambda: service,
+    )
+    assert result.status == "FAILED"
+    assert service.calls == []
+
+
+def test_failed_path_tool_registered_in_dispatcher() -> None:
+    from moonmind.workflows.temporal import story_output_tools as tools
+
+    class _Dispatcher:
+        def __init__(self) -> None:
+            self.skills: dict[str, Any] = {}
+
+        def register_skill(self, *, skill_name: str, handler: Any) -> None:
+            self.skills[skill_name] = handler
+
+    dispatcher = _Dispatcher()
+    tools.register_story_output_tool_handlers(dispatcher)
+    assert tools.GITHUB_FINALIZE_FAILED_ATTEMPT_TOOL_NAME in dispatcher.skills
+    assert "github.update_issue_status" in dispatcher.skills
+
+
+# -- Replay / in-flight payload compatibility -------------------------------------
+
+
+def test_legacy_blank_and_partial_payloads_degrade_safely() -> None:
+    # A previous attempt/finalization payload shape without the new mapper
+    # fields, with blank or unknown values, degrades to a safe
+    # non-releasing outcome: no release, workspace retained, no crash.
+    blank = fin.plan_failed_attempt_finalization(
+        execution_event="",
+        writer_evidence=_writer(),
+        mutation_evidence=_mutations(),
+        preservation_evidence=_preserved(),
+        disposition_evidence={},
+    )
+    assert blank.releasable is False
+    assert blank.workspace_retained is True
+    # Unknown future disposition keys are ignored: the default is attention
+    # with no automatic replacement work, never a silent rerun.
+    future = fin.choose_disposition({"some_future_field": True, "another_new_flag": "yes"})
+    assert future["disposition"] == fin.DISPOSITION_NEEDS_ATTENTION
+    assert future["schedulesReplacement"] is False
+    # Unknown completion modes grant no merge authority in failure cleanup.
+    unknown_route = fin.route_completion_handoff(completion_mode="some_future_mode")
+    assert unknown_route["mergeAuthorized"] is False
+    assert unknown_route["route"] == "needs_decision"
+
+
+def test_replayed_finalizer_respects_closed_successor_and_hold() -> None:
+    # A late finalizer that rereads shared state and observes a closed issue
+    # or a needs-attention hold abandons new mutations instead of
+    # overwriting the successor's status.
+    assert fin.should_abandon_for_successor(intended_from_settled="code_review", observed_settled="closed")["abandon"] is True
+    assert fin.should_abandon_for_successor(intended_from_settled="in_progress", observed_settled="needs_attention")["abandon"] is True
+    assert fin.should_abandon_for_successor(intended_from_settled="in_progress", observed_settled="in_progress")["abandon"] is False
+    # Unknown auxiliary failure kinds are reported, not merged into the
+    # primary outcome or treated as release evidence.
+    separated = fin.separate_objective_from_execution(
+        execution_outcome="failed", objective_verified=False, auxiliary_failures=["some_future_kind"]
+    )
+    assert separated["unknownAuxiliaryKinds"] == ["some_future_kind"]
+    assert separated["rebuyImplementation"] is True

--- a/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
+++ b/tests/unit/workflows/temporal/test_github_issue_finalization_4179.py
@@ -639,7 +639,7 @@ async def test_failure_stage_after_merge_closed_without_rebuy(monkeypatch) -> No
 
 @pytest.mark.asyncio
 async def test_activity_close_unknown_stays_pending(monkeypatch) -> None:
-    service = _FakeService(fail_close="unknown")
+    service = _FakeService(issue_labels=["status: code-review"], fail_close="unknown")
     monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
     result = await acts.finalize_failed_attempt(
         **_base_kwargs(
@@ -659,7 +659,7 @@ async def test_activity_close_unknown_stays_pending(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_activity_close_denied_never_false_release(monkeypatch) -> None:
-    service = _FakeService(fail_close="denied")
+    service = _FakeService(issue_labels=["status: code-review"], fail_close="denied")
     monkeypatch.setattr(acts, "_fetch_issue", _issue_reader(service))
     result = await acts.finalize_failed_attempt(
         **_base_kwargs(


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#4179 — [GitHub issue lifecycle] Finalize failed attempts with safe release and preserved-work handoffs.

- Attaches issue-attempt finalization to the durable controlling workflow boundary via registered `github.finalize_failed_attempt` tool (`finalize_github_issue_failed_attempt` in `story_output_tools.py`) plus `execution_event_for_controlling_outcome` mapper (finalize / retain / potentially-unfinalized / no_release). Internal step failures, remediation iterations, and review waits retain ownership with zero GitHub effects.
- Confirms writer-stop, settles push/PR/merge outcomes, preserves authoritative output via the admitted save/publication policy before any release.
- Ordered terminal effects: proposed comment (PR/branch revision, accepted + remaining requirements, outcome, retry history, next action) -> add-before-remove labels via #4176 -> close when `to_closed` -> read-back -> released comment update. Every unknown/failed step returns `released=False` with pendingSync and workspace retained.
- Evidence-driven disposition: recovery-needed / Available / code-review / completion-closure / needs-attention; cancellation/hold never auto-schedules replacement work; verified objective/merge never re-bought on reporting failure.
- Abrupt termination / disconnect / unknown mutations treated as potentially-unfinalized with recoverable local pending sync; retries reread shared state and respect observed successor/hold; PR-only and parent PR-and-merge handoffs integrated with no merge authority in failure cleanup.

## Verification outcome

Latest controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (high confidence) at candidate `3dcdc9675`. All 7 requirements plus the full acceptance row verified. Initial assessment was NOT_IMPLEMENTED, so this run publishes the implementation.

## Tests run

- Unit (new #4179 Activity/tool tests): `moonmind container python-tests tests/unit/workflows/temporal/test_github_issue_finalization_4179.py` — **80 passed**
- Unit (regression: lifecycle + attempt): `moonmind container python-tests tests/unit/workflows/temporal/test_github_issue_lifecycle.py tests/unit/workflows/temporal/test_github_issue_attempt.py` — **152 passed**
- Unit (regression: github_service): `moonmind container python-tests tests/unit/workflows/adapters/test_github_service.py` — **72 passed**
- Integration/workflow-boundary (advisory): Temporal test-server workflow-boundary test — NOT RUN per AGENTS.md taxonomy (time-skipping workflow tests excluded from required CI); acceptance satisfied at Activity/tool invocation boundary with replay/compat cases.

## Remaining risks

- Temporal test-server workflow-boundary coverage remains advisory-only; a future in-flight replay edge outside the covered legacy-blank-payload / successor-hold cases could need an additional compat case.
- GitHub outage / unknown mutation paths correctly stay pending (never false release) but leave reconciliation to the periodic reconciler consuming this terminal contract.

Closes MoonLadderStudios/MoonMind#4179
