### PR TITLE
[Qdrant removal] Remove Compose service, vector settings and bootstrap dependencies (MoonLadderStudios/MoonMind#4110)

### DIFF
--- a/api_service/retrieval_capabilities.py
+++ b/api_service/retrieval_capabilities.py
@@ -199,7 +199,7 @@ class RetrievalCapabilityRegistry:
         raise RetrievalCapabilityError(
             "retired",
             "Built-in vector retrieval has been retired "
-            "(MoonLadderStudios/MoonMind#4105, #4107). Remove followUpRetrieval "
+            "(MoonLadderStudios/MoonMind#4105, #4107). Remove retired retrieval fields "
             "and use explicit attachments, artifact refs, or scoped workspace "
             "access instead. Historical details remain readable.",
         )

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1079,15 +1079,17 @@ services:
       - control-plane-network
     restart: unless-stopped
 
-  # MoonLadderStudios/MoonMind#4115: the native Qdrant service is retired and
-  # intentionally absent from the vector-free release (no live or optional
-  # native Qdrant backend, no compatibility profile). The previous image was
-  # qdrant/qdrant:v1.17.1 with qdrant-storage:/qdrant/storage. Removing this
-  # YAML definition does not stop a running pre-cutover orphan: exact-container
-  # retirement is an explicit operator action with ownership checks (see
-  # docs/tmp/QdrantCutoverRunbook-4115.md). The qdrant-storage volume below is
-  # retained through the recovery window; its eventual deletion is a separate
-  # exact-resource operator action, never automatic.
+  # MoonLadderStudios/MoonMind#4110: the native Qdrant service and its
+  # qdrant-storage volume declaration are removed from the vector-free
+  # release (no live or optional native Qdrant backend, no compatibility
+  # profile). The previous image was qdrant/qdrant:v1.17.1 with
+  # qdrant-storage:/qdrant/storage. Removing this YAML definition does not
+  # stop a running pre-cutover orphan nor delete pre-cutover host data:
+  # exact-container retirement is an explicit operator action with ownership
+  # checks (see docs/tmp/QdrantCutoverRunbook-4115.md), and the pre-cutover
+  # volume persists as an unmanaged host orphan through the #4115
+  # recovery window; its eventual deletion is a separate exact-resource
+  # operator action, never automatic.
 
   omnigent-runtime-bootstrap:
     image: ${MOONMIND_IMAGE:-ghcr.io/moonladderstudios/moonmind:latest}
@@ -1630,12 +1632,13 @@ services:
     restart: unless-stopped
 
 volumes:
-  # MoonLadderStudios/MoonMind#4115: retained through the explicit
-  # recovery/retention window after the Qdrant service removal above. Never
-  # deleted by a normal upgrade; eventual deletion is a separate
-  # exact-resource operator action after export/restore verification.
+  # MoonLadderStudios/MoonMind#4110: the native Qdrant volume declaration is
+  # removed with the Qdrant service (no qdrant-storage declaration, mount, or
+  # product support remains). Pre-cutover operator data persists on the host
+  # as an unmanaged orphan outside this file through the #4115
+  # recovery/retention window; eventual deletion is a separate exact-resource
+  # operator action after export/restore verification, never automatic.
   # Distinct from moonmind_retrieval_state (classified by #4107).
-  qdrant-storage:
   omnigent-host-state:
   omnigent-host-claude-state:
   omnigent-host-claude-home:

--- a/tests/unit/config/test_vector_free_defaults_4115.py
+++ b/tests/unit/config/test_vector_free_defaults_4115.py
@@ -114,10 +114,12 @@ def test_compose_carries_no_qdrant_service_or_wiring() -> None:
         depends = service.get("depends_on", {})
         keys = depends.keys() if isinstance(depends, dict) else list(depends)
         assert "qdrant" not in keys, name
-    # The old volume is retained through the recovery window, distinctly
-    # from moonmind_retrieval_state (classified by #4107).
+    # MoonLadderStudios/MoonMind#4110: the Qdrant volume declaration is
+    # removed. Pre-cutover host data persists as an unmanaged orphan through
+    # the #4115 recovery window; only moonmind_retrieval_state (classified
+    # by #4107) remains declared.
     volumes = compose.get("volumes", {})
-    assert "qdrant-storage" in volumes
+    assert "qdrant-storage" not in volumes
     assert "moonmind_retrieval_state" in volumes
 
 

--- a/tests/unit/config/test_vector_free_regression_4114.py
+++ b/tests/unit/config/test_vector_free_regression_4114.py
@@ -104,10 +104,11 @@ _RETIRED_TOOL_DESCRIPTOR_RE = re.compile(
     r"qdrant|followUpRetrieval|follow_up_retrieval", re.IGNORECASE
 )
 
-# The native Qdrant volume is retained through the recovery window (#4115) and
-# ``moonmind_retrieval_state`` is classified by #4107. Any other
-# vector-named volume is a reintroduction.
-_KNOWN_VECTOR_FREE_VOLUMES = {"qdrant-storage", "moonmind_retrieval_state"}
+# MoonLadderStudios/MoonMind#4110: the native Qdrant volume declaration is
+# removed; only ``moonmind_retrieval_state`` (classified by #4107) is an
+# allowed vector-named volume. Any other vector-named volume is a
+# reintroduction.
+_KNOWN_VECTOR_FREE_VOLUMES = {"moonmind_retrieval_state"}
 
 
 def _env_items(service: dict) -> list[str]:
@@ -124,8 +125,7 @@ def check_compose_vector_free(compose: dict) -> list[str]:
     for name, service in services.items():
         service = service or {}
         if _VECTOR_SERVICE_NAME_RE.search(str(name)):
-            # The historical ``qdrant-storage`` *volume* is allowed; a live
-            # *service* with a vector name is never allowed.
+            # A live *service* with a vector name is never allowed.
             problems.append(f"service {name!r} carries a vector service name")
         image = str(service.get("image", ""))
         if _VECTOR_IMAGE_RE.search(image):
@@ -399,9 +399,16 @@ def test_compose_rejects_canonical_vector_store_images() -> None:
         )
 
 
-def test_compose_allows_retained_recovery_volume() -> None:
+def test_compose_has_no_qdrant_storage_volume() -> None:
+    """#4110: the Qdrant volume declaration is removed, not retained."""
     compose = yaml.safe_load((REPO_ROOT / "docker-compose.yaml").read_text())
-    assert "qdrant-storage" in (compose.get("volumes", {}) or {})
+    assert "qdrant-storage" not in (compose.get("volumes", {}) or {})
+    assert any(
+        "reintroduces vector state" in problem
+        for problem in check_compose_vector_free(
+            {"services": {}, "volumes": {"qdrant-storage": {}}}
+        )
+    )
     fixture = {"services": {}, "volumes": {"pgvector-data": {}}}
     assert any(
         "reintroduces vector state" in problem

--- a/tools/qdrant_cutover_rehearsal.py
+++ b/tools/qdrant_cutover_rehearsal.py
@@ -383,7 +383,12 @@ def collect_inventory_survey(repo_root: Path = REPO_ROOT) -> dict[str, Any]:
             survey["qdrant_surfaces"].append("docker-compose.yaml: QDRANT_URL wiring")
         if re.search(r"(?m)^  qdrant-storage:", code):
             survey["qdrant_storage_volume"] = (
-                "qdrant-storage declared (retained through recovery window)"
+                "qdrant-storage declared (violates #4110 removal; "
+                "pre-cutover host data retention is an unmanaged orphan, "
+                "never a Compose declaration)"
+            )
+            survey["qdrant_surfaces"].append(
+                "docker-compose.yaml: qdrant-storage volume declaration"
             )
         else:
             survey["qdrant_storage_volume"] = "qdrant-storage absent"
@@ -804,6 +809,12 @@ def check_upgrade_fixture(
             "upgrade-fixture", "failed",
             "Upgrade fixture fails: compose still wires QDRANT_URL into "
             "application services.",
+        )
+    if re.search(r"(?m)^  qdrant-storage:", code):
+        return StepResult(
+            "upgrade-fixture", "failed",
+            "Upgrade fixture fails: compose still declares the obsolete "
+            "qdrant-storage volume (MoonLadderStudios/MoonMind#4110).",
         )
     _, detail = _vector_free_deployment_present(repo_root)
     # MoonLadderStudios/MoonMind#4192: probe the boolean, not prose


### PR DESCRIPTION
## Summary

Resolves MoonLadderStudios/MoonMind#4110 — removes the built-in Qdrant vector database from the supported deployment.

Head commit `882df3ce` deletes the top-level `qdrant-storage` volume declaration from `docker-compose.yaml` (the single gap left by the PARTIALLY_IMPLEMENTED assessment at `bd0ea3ac`), updates the surrounding comments to state that pre-cutover host data persists as an unmanaged orphan (never a Compose declaration), and tightens the topology contract so `qdrant-storage` is again flagged as a vector-state reintroduction:

- `docker-compose.yaml`: no `qdrant` service, image, ports 6333/6334, mounts, `depends_on`, `QDRANT_URL` wiring, or `qdrant-storage` declaration; only historical comments remain.
- `tests/unit/config/test_vector_free_defaults_4115.py`: asserts `qdrant-storage` is absent while `moonmind_retrieval_state` (classified by #4107) remains.
- `tests/unit/config/test_vector_free_regression_4114.py`: allowed vector-named volumes reduced to `{moonmind_retrieval_state}`; renamed test proves a `qdrant-storage` declaration is rejected.
- `tools/qdrant_cutover_rehearsal.py`: inventory survey surfaces a `qdrant-storage` declaration and the upgrade-fixture check fails on it.

## Verification outcome

Latest controlling post-remediation `moonspec-verify` verdict: **FULLY_IMPLEMENTED** (candidate `882df3ce781d3fe3b8a49e29f5b8c4ddb778a08f`, confidence MEDIUM). All 8 issue requirements met by direct production-code inspection plus hermetic test evidence. Initial assessment was PARTIALLY_IMPLEMENTED (retained `qdrant-storage` declaration); this run's implementation deletes it, so publication proceeds per workflow policy.

## Tests run

- `moonmind container python-tests tests/unit/config/test_vector_free_defaults_4115.py` — **19/19 PASS** via repo-documented managed runner (compose wiring, AppSettings, inert obsolete env, removed modules).
- `moonmind container python-tests tests/unit/config/test_vector_free_regression_4114.py` — NOT RUN in sandbox (container-backend timeouts, environment-only); key compose assertions replicated by direct YAML inspection (ALL PASS).
- `docker compose config --quiet` / rendered topology combinations and real startup — NOT RUN (no Docker daemon in sandbox, advisory per controlling/advisory split); static YAML inspection + hermetic topology tests substitute.
- Secret scan of `bd0ea3ac..HEAD` diff for `ghp_`, `github_pat_`, `AIza`, `AKIA`, private-key blocks, `token=`/`password=` — clean.

## Remaining risks

- Full regression file and real Compose-render/startup journeys were not executed in this sandbox (no Docker daemon; container-backend timeouts). CI should re-run the integration runner and `docker compose config` matrix.
- Pre-cutover operator data lifecycle remains an operator action via the cutover runbook (#4115 recovery window); this change only removes the declaration and must not be combined with generic `down -v`/prune cleanup.
- Sibling coordination (parent #4103, callers #4105–#4109) may need atomic landing with this removal.

Closes MoonLadderStudios/MoonMind#4110
