### PR TITLE
[Workflows] Repair SetTitle and automatically enrich issue-search workflow titles after resolution (#4099)

### DIFF
--- a/api_service/data/presets/github-issue-search-and-implement.yaml
+++ b/api_service/data/presets/github-issue-search-and-implement.yaml
@@ -18,6 +18,11 @@ annotations:
   implementsPreset: github-issue-implement
   issueProvider: github
   output: pull-request
+  titleEnrichment:
+    enabled: true
+    provider: github
+    sourceTool: github.load_issue_preset_brief
+    targetStyle: base-colon-hash
   githubIssueUpdate:
     inProgress:
       comment: true

--- a/api_service/services/presets/catalog.py
+++ b/api_service/services/presets/catalog.py
@@ -1492,6 +1492,11 @@ def _normalize_preset_annotations(
     # rather than letting an input silently fall back to its static default at
     # expansion.
     _dependent_input_default_rules(normalized, inputs_schema)
+    # MoonLadderStudios/MoonMind#4099: fail fast on a malformed opt-in
+    # title-enrichment declaration at seed time.
+    _normalize_title_enrichment_policy(
+        normalized.get("titleEnrichment") or normalized.get("title_enrichment")
+    )
     return normalized
 
 
@@ -1614,6 +1619,51 @@ def _normalize_checkpoint_branching_policy(value: Any) -> dict[str, Any]:
     if requested_work_branch:
         normalized["gitWorkBranch"] = requested_work_branch
     return normalized
+
+
+def _normalize_title_enrichment_policy(value: Any) -> dict[str, Any] | None:
+    """Normalize the opt-in issue-search title-enrichment declaration.
+
+    MoonLadderStudios/MoonMind#4099: a small pinned-preset annotation that
+    connects the accepted typed resolver result to the workflow-owned shared
+    title transition. Absent/false-enabled means no automatic enrichment.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise PresetValidationError(
+            "Template titleEnrichment annotation must be an object."
+        )
+    enabled = value.get("enabled", value.get("enable", False))
+    if enabled is False or enabled is None:
+        return None
+    if enabled is not True:
+        raise PresetValidationError("titleEnrichment.enabled must be true or false.")
+    provider = str(value.get("provider") or "").strip().lower()
+    if provider not in ("github",):
+        raise PresetValidationError(
+            "titleEnrichment.provider must be 'github'."
+        )
+    source_tool = str(
+        value.get("sourceTool") or value.get("source_tool") or ""
+    ).strip()
+    if not source_tool:
+        raise PresetValidationError(
+            "titleEnrichment.sourceTool is required when enabled."
+        )
+    target_style = str(
+        value.get("targetStyle") or value.get("target_style") or "base-colon-hash"
+    ).strip()
+    if target_style != "base-colon-hash":
+        raise PresetValidationError(
+            "titleEnrichment.targetStyle must be 'base-colon-hash'."
+        )
+    return {
+        "enabled": True,
+        "provider": provider,
+        "sourceTool": source_tool,
+        "targetStyle": target_style,
+    }
 
 
 def _normalize_checkpoint_branching_triggers(value: Any) -> list[str]:
@@ -2985,6 +3035,21 @@ class PresetCatalogService:
             expanded_payload["publish"] = dict(workflow_publish)
         if isinstance(checkpoint_branching, Mapping):
             expanded_payload["checkpointBranching"] = dict(checkpoint_branching)
+        # MoonLadderStudios/MoonMind#4099: preserve the opt-in title-enrichment
+        # declaration through expansion so the admitted plan snapshot carries
+        # it to the workflow (which owns the enrichment transition).
+        title_enrichment = _normalize_title_enrichment_policy(
+            annotations.get("titleEnrichment") or annotations.get("title_enrichment")
+        )
+        if title_enrichment is not None:
+            expanded_payload["titleEnrichment"] = {
+                **title_enrichment,
+                # Expansion-populated (not authored): the frozen preset label
+                # the workflow renders "<base>: #<number>" from, and the slug
+                # the opt-in scope check matches.
+                "presetTitle": str(template.title or "").strip(),
+                "presetSlug": str(template.slug or "").strip(),
+            }
         return expanded_payload
 
     def _resolve_inputs(

--- a/docs/Api/ExecutionsApiContract.md
+++ b/docs/Api/ExecutionsApiContract.md
@@ -260,6 +260,8 @@ Successful creation allocates workflow/run identity, starts `initializing` unles
 
 Title resolution is deterministic. A meaningful caller title wins. Otherwise combine the selected capability/preset label with up to two structured targets such as an issue, PR, branch, or failing check. Bookkeeping step IDs are not targets. A label without a target remains a fallback. Titles are bounded to 150 characters.
 
+Creation also freezes the generated base label and records the shared title-transition state in memo: `titleBase`, `titleProvenance` (`user_explicit` or `generated`), and the monotonic `titleRevision` ordering guard, alongside the existing `titleSource`/`titleConfidence` projection. Preset runtime resolvers that select their target after creation (such as `github-issue-search-and-implement` via its pinned `titleEnrichment` opt-in) enrich the display title to `<base>: #<number>` through the same workflow-owned transition, without touching workflow/run identity, plan, branches, checkpoints, artifacts, commits, or publication behavior.
+
 ### 9.6 Errors
 
 Domain create validation uses 422 `invalid_execution_request`, with field-addressable details for context/policy conflicts. Malformed bodies may use framework validation errors. Authentication uses the auth layer's 401/403 behavior. A conflicting idempotent intent is a distinct conflict, not a successful create. Error semantics and generated clients must be updated together when the new authoring boundary is enabled.
@@ -320,6 +322,8 @@ Derived per-step publication disposition does not create a step-authoring overri
 | idempotencyKey | Update reconciliation key |
 
 UpdateInputs replaces/adds refs and patches admitted parameters. No-op updates can succeed. Executing/awaiting-external work may accept supported changes for the next safe point; major changes may require a newly admitted run through the lifecycle owner. SetTitle changes display metadata immediately and does not change execution authority.
+
+SetTitle (`title` required) runs through the one shared workflow-owned title transition on both the service record and the production `MoonMind.UserWorkflow` update of the same name (object payload carrying `title`; the legacy `update_title` method name remains as a compatibility alias forwarding to it). Manual titles are validated and normalized with the shared display-safe policy (empty/whitespace-only or unsafe text is rejected with `invalid_update_request`); the same-text rename still flips provenance to explicit. The canonical record updates memo `title`/`titleBase`/`titleProvenance`/`titleRevision`/`titleSource` and recomputes the `mm_title` search tokens so state, memo, search, and UI stay consistent across refreshes. Genuine no-ops succeed without touching the record, bumping the revision, or emitting repeated metadata changes.
 
 RequestRerun requests a clean re-execution under the [run-history/rerun contract](../Temporal/WorkflowRunHistoryAndNewRunSemantics.md#7-new-run-semantics). A supported active workflow may Continue-As-New, retaining workflowId and allocating a new runId. For a terminal source, the service creates a fresh execution with a new workflowId and runId through normal admission, records the source workflow/run in `rerunSource`, and leaves the source closed. The same fresh-start path handles a source that closes before Temporal receives the update. Closed Temporal runs never process an ordinary rerun update.
 

--- a/docs/Workflows/WorkflowPresetsSystem.md
+++ b/docs/Workflows/WorkflowPresetsSystem.md
@@ -313,6 +313,21 @@ The retired `workflow.default_publish_mode` and environment aliases are not fall
 
 A read-only assessment included within implementation remains read-only without disabling publication of the implementation's cumulative candidate. A workflow with both its own repository deliverable and fan-out declares both responsibilities rather than using coordinator status to suppress its output.
 
+## Workflow-Level Title Enrichment Metadata
+
+Presets that resolve their target issue at runtime (rather than at authoring time) may declare the opt-in `titleEnrichment` annotation. The workflow owns the single shared title transition used by both manual `SetTitle` renames and automatic enrichment; the annotation only connects an accepted typed resolver result to that transition. It never renames the preset or schedule, changes workflow/run identity, rewrites the plan, retargets repository work, or changes branches, checkpoints, artifacts, commits, or publication behavior.
+
+```yaml
+annotations:
+  titleEnrichment:
+    enabled: true
+    provider: github
+    sourceTool: github.load_issue_preset_brief
+    targetStyle: base-colon-hash
+```
+
+Catalog expansion preserves the declaration in the admitted plan snapshot, populating the frozen `presetTitle`/`presetSlug` from the pinned preset. Creation uses the declared preset title as the frozen base label (pending selection shows it unchanged; an explicit caller title still wins and stays protected). The workflow renders the full display title from the frozen base label and the accepted issue identity (`<base>: #<number>`), leaves the base title unchanged while selection is pending or when no issue is selected, protects explicit user titles (including same-text renames, which flip provenance to explicit), evaluates eligibility at the authoritative mutation point with a revision guard, and keeps duplicate results idempotent. The only preset opting in today is `github-issue-search-and-implement`.
+
 ## Built-in Batch and Resolver Contracts
 
 The detailed policy matrix is in [Workflow Publishing, section 6](WorkflowPublishing.md#6-built-in-behavior-matrix). Catalog expansion must cover all of the following, not just the two presets named Batch:

--- a/moonmind/workflows/executions/preset_expansion.py
+++ b/moonmind/workflows/executions/preset_expansion.py
@@ -204,6 +204,19 @@ async def expand_preset_for_child_run(
             for item in authored_presets
         ]
     task_payload["steps"] = list(expanded_steps)
+    # MoonLadderStudios/MoonMind#4099: preserve the opt-in title-enrichment
+    # declaration in the admitted definition/plan snapshot so the workflow can
+    # connect the accepted resolver result to the shared title transition.
+    # Metadata-only: never touches identity, plan steps, branches, or
+    # publication behavior, and rerun-plan digests ignore this key.
+    expanded_enrichment = expanded.get("titleEnrichment") or expanded.get(
+        "title_enrichment"
+    )
+    if (
+        isinstance(expanded_enrichment, Mapping)
+        and expanded_enrichment.get("enabled") is True
+    ):
+        task_payload["titleEnrichment"] = dict(expanded_enrichment)
     expanded_publish = (
         expanded.get("publish") if isinstance(expanded, Mapping) else None
     )

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -815,6 +815,11 @@ def normalize_display_title(value: Any) -> str | None:
     text = str(value).strip() if isinstance(value, (str, int)) else ""
     if not text:
         return None
+    # Check raw (stripped) text for control characters before whitespace
+    # collapsing: str.split() treats U+001C..U+001F (among others) as
+    # whitespace, which would otherwise silently convert them to spaces.
+    if _TITLE_CONTROL_CHARS_RE.search(text):
+        return None
     text = " ".join(text.split())
     if not text:
         return None

--- a/moonmind/workflows/executions/title_derivation.py
+++ b/moonmind/workflows/executions/title_derivation.py
@@ -783,5 +783,135 @@ def _mapping(value: Any) -> Mapping[str, Any] | None:
     return value if isinstance(value, Mapping) else None
 
 
+# --- Shared display-title policy (MoonLadderStudios/MoonMind#4099) ---
+#
+# One deterministic transition shared by creation, manual ``SetTitle`` renames,
+# and automatic issue-search enrichment. Dependency-free (stdlib only) so it is
+# safe to import inside the Temporal workflow sandbox.
+#
+# State carried alongside the display title (memo/workflow fields):
+# - ``base_title``: frozen generated base label (e.g. the preset label).
+# - ``display_title``: current visible title.
+# - ``provenance``: ``"user_explicit"`` protects against automatic updates,
+#   ``"generated"`` remains eligible for enrichment.
+# - ``revision``: monotonic ordering guard; stale results must not overwrite
+#   newer title decisions.
+
+TITLE_PROVENANCE_USER_EXPLICIT = "user_explicit"
+TITLE_PROVENANCE_GENERATED = "generated"
+
+_TITLE_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def normalize_display_title(value: Any) -> str | None:
+    """Validate and normalize display-safe title text with the shared policy.
+
+    Returns the normalized title, or ``None`` when the value is
+    empty/whitespace-only or unsafe. The 150-char creation/display limit is
+    reused here rather than introducing another limit.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    text = str(value).strip() if isinstance(value, (str, int)) else ""
+    if not text:
+        return None
+    text = " ".join(text.split())
+    if not text:
+        return None
+    if _TITLE_CONTROL_CHARS_RE.search(text):
+        return None
+    return text[:_MAX_TASK_TITLE_LENGTH] or None
+
+
+def render_issue_search_title(base_label: Any, issue_number: Any) -> str | None:
+    """Render the full generated title from the frozen base label + issue id.
+
+    Never appends to the current display title. Returns ``None`` when the
+    base label is missing or the issue number is not a positive int.
+    """
+    base = normalize_display_title(base_label)
+    try:
+        number = int(issue_number) if not isinstance(issue_number, bool) else 0
+    except (TypeError, ValueError):
+        return None
+    if not base or number <= 0:
+        return None
+    return f"{base}: #{number}"[:_MAX_TASK_TITLE_LENGTH] or None
+
+
+@dataclass(frozen=True)
+class TitleTransitionState:
+    base_title: str | None = None
+    display_title: str | None = None
+    provenance: str = TITLE_PROVENANCE_GENERATED
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class TitleTransitionResult:
+    state: TitleTransitionState
+    changed: bool
+    reason: str
+
+
+def apply_manual_title(
+    state: TitleTransitionState,
+    new_title: Any,
+) -> TitleTransitionResult:
+    """Apply an explicit user rename. Always marks provenance explicit.
+
+    A same-text manual rename still flips provenance to explicit when
+    necessary. Returns ``changed=False`` only when title AND provenance are
+    already exactly as requested (genuine no-op: no revision bump).
+    """
+    normalized = normalize_display_title(new_title)
+    if normalized is None:
+        raise ValueError("title is required and must be display-safe text")
+    if (
+        state.display_title == normalized
+        and state.provenance == TITLE_PROVENANCE_USER_EXPLICIT
+    ):
+        return TitleTransitionResult(state=state, changed=False, reason="no-op")
+    base = state.base_title or normalized
+    next_state = TitleTransitionState(
+        base_title=base,
+        display_title=normalized,
+        provenance=TITLE_PROVENANCE_USER_EXPLICIT,
+        revision=state.revision + 1,
+    )
+    return TitleTransitionResult(state=next_state, changed=True, reason="manual")
+
+
+def apply_issue_enrichment_title(
+    state: TitleTransitionState,
+    issue_number: Any,
+    *,
+    expected_revision: int | None = None,
+) -> TitleTransitionResult:
+    """Apply automatic ``<base>: #<number>`` enrichment at the mutation point.
+
+    Eligibility is evaluated here, not only before an async call: explicit
+    user titles are always protected, and a stale ``expected_revision``
+    never overwrites a newer title decision. Duplicate accepted results and
+    genuine no-ops are idempotent (no revision bump, no reorder).
+    """
+    if state.provenance == TITLE_PROVENANCE_USER_EXPLICIT:
+        return TitleTransitionResult(state=state, changed=False, reason="explicit")
+    if expected_revision is not None and expected_revision != state.revision:
+        return TitleTransitionResult(state=state, changed=False, reason="stale")
+    rendered = render_issue_search_title(state.base_title, issue_number)
+    if rendered is None:
+        return TitleTransitionResult(state=state, changed=False, reason="invalid")
+    if state.display_title == rendered:
+        return TitleTransitionResult(state=state, changed=False, reason="no-op")
+    next_state = TitleTransitionState(
+        base_title=state.base_title,
+        display_title=rendered,
+        provenance=TITLE_PROVENANCE_GENERATED,
+        revision=state.revision + 1,
+    )
+    return TitleTransitionResult(state=next_state, changed=True, reason="auto")
+
+
 def _normalize_key(key: str) -> str:
     return re.sub(r"[^a-z0-9_]+", "", key.casefold())

--- a/moonmind/workflows/temporal/boundary_inventory.py
+++ b/moonmind/workflows/temporal/boundary_inventory.py
@@ -222,6 +222,28 @@ _CONTRACTS: tuple[TemporalBoundaryContract, ...] = (
         rationale="Existing API-facing update model still carries bounded patch fields while workflow call sites migrate.",
         metadataFields=("parametersPatch",),
     ),
+    TemporalBoundaryContract(
+        kind="update",
+        name="SetTitle",
+        owner="MoonMind.UserWorkflow",
+        requestModel=_model(
+            module=_TEMPORAL_MODELS,
+            name="UpdateExecutionRequest",
+            role="request",
+        ),
+        responseModel=_model(
+            module=_TEMPORAL_MODELS,
+            name="UpdateExecutionResponse",
+            role="response",
+        ),
+        status="modeled",
+        schemaHome=_TEMPORAL_MODELS,
+        coverageIds=("DESIGN-REQ-001", "DESIGN-REQ-002", "DESIGN-REQ-008"),
+        rationale="MoonLadderStudios/MoonMind#4099: canonical display-title update "
+        "with the shared workflow-owned transition (manual rename and "
+        "automatic issue-search enrichment); object payload carrying title.",
+        metadataFields=("title",),
+    ),
 )
 
 _INVENTORY = TemporalBoundaryInventory(

--- a/moonmind/workflows/temporal/service.py
+++ b/moonmind/workflows/temporal/service.py
@@ -125,7 +125,14 @@ from moonmind.workflows.executions.preset_expansion import (
     expand_preset_for_child_run,
     has_unexpanded_task_template,
 )
-from moonmind.workflows.executions.title_derivation import synthesize_execution_title
+from moonmind.workflows.executions.title_derivation import (
+    TITLE_PROVENANCE_GENERATED,
+    TITLE_PROVENANCE_USER_EXPLICIT,
+    TitleTransitionState,
+    apply_manual_title,
+    normalize_display_title,
+    synthesize_execution_title,
+)
 from moonmind.workflows.executions.checkpoint_resume_admission import (
     AdmittedCheckpointResumeDecision,
 )
@@ -162,6 +169,26 @@ def _workflow_payload(parameters: Mapping[str, Any]) -> Mapping[str, Any]:
     if workflow_payload:
         return workflow_payload
     return _mapping_payload(parameters.get("task"))
+
+
+def _issue_search_title_enrichment_base(
+    task_payload: Mapping[str, Any] | None,
+) -> str | None:
+    """Return the frozen preset base label for opt-in title enrichment.
+
+    MoonLadderStudios/MoonMind#4099: the admitted plan snapshot carries the
+    pinned ``titleEnrichment`` declaration (populated with ``presetTitle`` at
+    expansion). Only an enabled declaration with a display-safe preset title
+    yields a base; anything else leaves creation-time synthesis untouched.
+    """
+    if not isinstance(task_payload, Mapping):
+        return None
+    enrichment = task_payload.get("titleEnrichment") or task_payload.get(
+        "title_enrichment"
+    )
+    if not isinstance(enrichment, Mapping) or enrichment.get("enabled") is not True:
+        return None
+    return normalize_display_title(enrichment.get("presetTitle"))
 
 
 def _visibility_runtime_from_parameters(
@@ -2224,11 +2251,33 @@ class TemporalExecutionService:
             or title
             or self._default_title_for_type(workflow_type_enum)
         )
+        title_source = title_result.source
+        title_confidence = title_result.confidence
+        # MoonLadderStudios/MoonMind#4099: for opt-in issue-search presets the
+        # frozen base label is the preset's declared title, so the pending
+        # display title is exactly that label and enrichment renders
+        # "<base>: #<number>". An explicit caller title always wins and stays
+        # protected from automatic enrichment.
+        enrichment_base = _issue_search_title_enrichment_base(task_params)
+        if enrichment_base is not None and title_source != "user_explicit":
+            resolved_title = enrichment_base
+            title_source = "preset_template"
+            title_confidence = "medium"
         memo = {
             "title": resolved_title,
             "summary": title_result.summary or summary or "Execution initialized.",
-            "titleSource": title_result.source,
-            "titleConfidence": title_result.confidence,
+            "titleSource": title_source,
+            "titleConfidence": title_confidence,
+            # MoonLadderStudios/MoonMind#4099: frozen base label + explicit vs
+            # generated provenance + revision guard for the shared title
+            # transition (manual SetTitle and automatic issue enrichment).
+            "titleBase": resolved_title,
+            "titleProvenance": (
+                TITLE_PROVENANCE_USER_EXPLICIT
+                if title_source == "user_explicit"
+                else TITLE_PROVENANCE_GENERATED
+            ),
+            "titleRevision": 0,
         }
         # Admitting-authority code revision (MoonLadderStudios/MoonMind#4224):
         # post-incident analysis can tell which revision admitted the run; the
@@ -4159,10 +4208,63 @@ class TemporalExecutionService:
         record: TemporalExecutionCanonicalRecord,
         title: str,
     ) -> dict[str, Any]:
+        # MoonLadderStudios/MoonMind#4099: repair the public SetTitle path with
+        # the one shared workflow-owned title transition. Validation,
+        # explicit provenance, revision guard, memo consistency, and mm_title
+        # search tokens are handled here so the canonical record stays in sync
+        # with the workflow-side update.
+        normalized = normalize_display_title(title)
+        if normalized is None:
+            raise TemporalExecutionValidationError(
+                "title is required and must be display-safe text "
+                "when updateName is SetTitle"
+            )
         memo = dict(record.memo or {})
-        memo["title"] = title
+        try:
+            current_revision = int(memo.get("titleRevision") or 0)
+        except (TypeError, ValueError):
+            current_revision = 0
+        current_state = TitleTransitionState(
+            base_title=normalize_display_title(memo.get("titleBase"))
+            or normalize_display_title(memo.get("title"))
+            or normalized,
+            display_title=normalize_display_title(memo.get("title")),
+            provenance=str(
+                memo.get("titleProvenance")
+                or (
+                    TITLE_PROVENANCE_USER_EXPLICIT
+                    if memo.get("titleSource") == "user_explicit"
+                    else TITLE_PROVENANCE_GENERATED
+                )
+            ),
+            revision=current_revision,
+        )
+        try:
+            transition = apply_manual_title(current_state, normalized)
+        except ValueError as exc:
+            raise TemporalExecutionValidationError(str(exc)) from exc
+        if not transition.changed:
+            return {
+                "accepted": True,
+                "applied": "immediate",
+                "message": "Title unchanged.",
+            }
+        next_state = transition.state
+        memo["title"] = next_state.display_title
+        memo["titleBase"] = next_state.base_title
+        memo["titleProvenance"] = next_state.provenance
+        memo["titleRevision"] = next_state.revision
+        memo["titleSource"] = "user_explicit"
+        memo["titleConfidence"] = "high"
         record.memo = memo
         self._touch(record)
+        attrs = dict(record.search_attributes or {})
+        title_tokens = tokenize_title(next_state.display_title)
+        if title_tokens:
+            attrs["mm_title"] = title_tokens
+        else:
+            attrs.pop("mm_title", None)
+        record.search_attributes = attrs
         return {
             "accepted": True,
             "applied": "immediate",
@@ -4271,10 +4373,19 @@ class TemporalExecutionService:
         next_plan_ref = plan_artifact_ref or record.plan_ref
         task_params = params.get("task") if isinstance(params.get("task"), dict) else {}
         repository = repository_name_from_value(params.get("repository")) or None
+        # MoonLadderStudios/MoonMind#4099: explicit user titles survive a rerun
+        # verbatim, while generated titles restart from the frozen base label
+        # so the new run re-enriches from its own resolver result instead of
+        # inheriting a stale "<base>: #<number>" as a false explicit title.
+        source_memo = record.memo or {}
+        if source_memo.get("titleProvenance") == TITLE_PROVENANCE_USER_EXPLICIT:
+            rerun_title_fallback = str(source_memo.get("title") or "").strip()
+        else:
+            rerun_title_fallback = str(
+                source_memo.get("titleBase") or source_memo.get("title") or ""
+            ).strip()
         title = (
-            str(task_params.get("title") or "").strip()
-            or str((record.memo or {}).get("title") or "").strip()
-            or None
+            str(task_params.get("title") or "").strip() or rerun_title_fallback or None
         )
 
         rerun_create_idempotency_key = self._rerun_create_idempotency_key(

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -626,6 +626,10 @@ RUN_ASSESSMENT_CONSUMER_HANDOFF_PATCH = "run-assessment-consumer-handoff-v1"
 RUN_ASSESSMENT_ATTACHMENT_HANDOFF_PATCH = "run-assessment-attachment-handoff-v1"
 RUN_ISSUE_BRIEF_ATTACHMENT_HANDOFF_PATCH = "run-issue-brief-attachment-handoff-v1"
 RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH = "run-trusted-issue-brief-authority-v1"
+# MoonLadderStudios/MoonMind#4099: automatic "<base>: #<number>" display-title
+# enrichment for opt-in issue-search presets. Gated so in-flight histories
+# replay without the new memo/search-attribute commands.
+RUN_ISSUE_SEARCH_TITLE_ENRICHMENT_PATCH = "run-issue-search-title-enrichment-v1"
 RUN_MOONSPEC_VERIFY_ATTACHMENT_HANDOFF_PATCH = (
     "run-moonspec-verify-attachment-handoff-v1"
 )
@@ -1582,6 +1586,17 @@ class MoonMindRunWorkflow:
         self._runtime_inheritance_parameters: dict[str, Any] = {}
         self._close_status: Optional[str] = None
         self._title: Optional[str] = None
+        # MoonLadderStudios/MoonMind#4099: shared title-transition state.
+        # _title_base is the frozen generated label, _title_provenance is
+        # "user_explicit" (protected) or "generated" (enrichment-eligible),
+        # _title_revision orders title decisions, _title_target holds compact
+        # accepted-issue provenance (repo/number refs, never bodies).
+        self._title_base: Optional[str] = None
+        self._title_provenance: str = "generated"
+        self._title_revision: int = 0
+        self._title_target: dict[str, Any] | None = None
+        self._title_source: Optional[str] = None
+        self._title_confidence: Optional[str] = None
         self._summary: str = "Execution initialized."
         self._correlation_id: Optional[str] = None
         self._pull_request_url: Optional[str] = None
@@ -4118,6 +4133,22 @@ class MoonMindRunWorkflow:
             published_head = self._publish_context.get("acceptedPublishedHead")
             if isinstance(published_head, Mapping):
                 continuation["acceptedPublishedHead"] = dict(published_head)
+        if self._patched_or_false_outside_workflow(
+            RUN_ISSUE_SEARCH_TITLE_ENRICHMENT_PATCH
+        ):
+            # MoonLadderStudios/MoonMind#4099: carry the shared title-transition
+            # state across Continue-As-New (Temporal does not inherit memo), so
+            # an enriched or renamed title survives the new run. Compact refs
+            # only; the key is additive so old histories still restore.
+            continuation["titleTransition"] = {
+                "base": self._title_base,
+                "display": self._title,
+                "provenance": self._title_provenance,
+                "revision": self._title_revision,
+                "target": dict(self._title_target) if self._title_target else None,
+                "source": self._title_source,
+                "confidence": self._title_confidence,
+            }
         if workflow.patched(RUN_REMEDIATION_ISSUE_AUTHORITY_CONTINUATION_PATCH):
             continuation["assessmentContext"] = {
                 key: value
@@ -9865,6 +9896,146 @@ class MoonMindRunWorkflow:
         if context:
             self._trusted_issue_context = context
 
+    def _maybe_enrich_title_from_trusted_issue(
+        self, outputs: Mapping[str, Any]
+    ) -> bool:
+        """Enrich the display title from the accepted GitHub resolver result.
+
+        MoonLadderStudios/MoonMind#4099: metadata-only transition shared with
+        manual ``SetTitle``. Scoped to opt-in presets (pinned
+        ``titleEnrichment`` declaration); search text, failures, no-match,
+        invalid, or unrelated results never trigger. Idempotent for duplicate
+        accepted results. Returns True when the title changed.
+        """
+        from moonmind.workflows.executions.title_derivation import (
+            TITLE_PROVENANCE_GENERATED,
+            TITLE_PROVENANCE_USER_EXPLICIT,
+            TitleTransitionState,
+            apply_issue_enrichment_title,
+        )
+
+        if not self._issue_title_enrichment_enabled():
+            return False
+        if not isinstance(outputs, Mapping):
+            return False
+        if (
+            str(outputs.get("trustedSource") or "").strip()
+            != "moonmind.github.get_issue"
+        ):
+            return False
+        repository = outputs.get("repository")
+        if isinstance(repository, Mapping):
+            repository = repository.get("name") or repository.get("full_name")
+        repository_text = str(repository or "").strip()
+        raw_number = outputs.get("issueNumber", outputs.get("issue_number"))
+        if raw_number is None and isinstance(outputs.get("issue"), Mapping):
+            issue_map = outputs.get("issue")
+            raw_number = issue_map.get("number", issue_map.get("issueNumber"))
+        if raw_number is None and isinstance(outputs.get("githubIssue"), Mapping):
+            issue_map = outputs.get("githubIssue")
+            raw_number = issue_map.get("number", issue_map.get("issueNumber"))
+        try:
+            issue_number = int(raw_number) if not isinstance(raw_number, bool) else 0
+        except (TypeError, ValueError):
+            return False
+        if not repository_text or issue_number <= 0:
+            return False
+        if not (self._title_base or self._title):
+            return False
+        # Evaluate eligibility at the authoritative mutation point so a stale
+        # accepted result cannot overwrite a newer (explicit) title decision.
+        current = TitleTransitionState(
+            base_title=self._title_base or self._title,
+            display_title=self._title,
+            provenance=self._title_provenance
+            if self._title_provenance
+            in (TITLE_PROVENANCE_USER_EXPLICIT, TITLE_PROVENANCE_GENERATED)
+            else TITLE_PROVENANCE_GENERATED,
+            revision=self._title_revision or 0,
+        )
+        transition = apply_issue_enrichment_title(
+            current,
+            issue_number,
+            expected_revision=current.revision,
+        )
+        if not transition.changed:
+            return False
+        self._title_base = transition.state.base_title
+        self._title = transition.state.display_title
+        self._title_provenance = transition.state.provenance
+        self._title_revision = transition.state.revision
+        self._title_source = "integration_target"
+        self._title_confidence = "high"
+        self._title_target = {
+            "provider": "github",
+            "repository": repository_text[:200],
+            "issueNumber": issue_number,
+            "source": "moonmind.github.get_issue",
+        }
+        self._update_memo()
+        self._update_search_attributes()
+        return True
+
+    def _issue_title_enrichment_enabled(self) -> bool:
+        """Whether the pinned plan opts into automatic title enrichment."""
+        try:
+            parameters: Mapping[str, Any] = {}
+            original = getattr(self, "_original_input_payload", None)
+            if isinstance(original, Mapping):
+                maybe_params = original.get("initialParameters") or original.get(
+                    "initial_parameters"
+                )
+                if isinstance(maybe_params, Mapping):
+                    parameters = maybe_params
+            candidates: list[Mapping[str, Any]] = []
+            for payload in (
+                parameters,
+                parameters.get("workflow")
+                if isinstance(parameters.get("workflow"), Mapping)
+                else None,
+                parameters.get("task")
+                if isinstance(parameters.get("task"), Mapping)
+                else None,
+            ):
+                if isinstance(payload, Mapping):
+                    candidates.append(payload)
+                    task_payload = payload.get("workflow")
+                    if isinstance(task_payload, Mapping):
+                        candidates.append(task_payload)
+                    task_payload = payload.get("task")
+                    if isinstance(task_payload, Mapping):
+                        candidates.append(task_payload)
+            for candidate in candidates:
+                enrichment = candidate.get("titleEnrichment") or candidate.get(
+                    "title_enrichment"
+                )
+                if isinstance(enrichment, Mapping):
+                    enabled = enrichment.get("enabled", enrichment.get("enable"))
+                    if enabled is True:
+                        return True
+            slugs: set[str] = set()
+            try:
+                task_payload: Mapping[str, Any] = {}
+                workflow_payload = parameters.get("workflow")
+                if isinstance(workflow_payload, Mapping):
+                    task_payload = workflow_payload
+                elif isinstance(parameters.get("task"), Mapping):
+                    task_payload = parameters.get("task")  # type: ignore[assignment]
+                slugs = self._task_applied_template_slugs(parameters, task_payload)
+                template = task_payload.get("taskTemplate") or task_payload.get(
+                    "task_template"
+                )
+                if isinstance(template, Mapping):
+                    for key in ("slug", "name", "id"):
+                        value = self._coerce_text(template.get(key), max_chars=120)
+                        if value:
+                            slugs.add(value.lower())
+            except Exception:
+                slugs = set()
+            return "github-issue-search-and-implement" in slugs
+        except Exception:
+            return False
+
     @staticmethod
     def _patched_or_false_outside_workflow(patch_id: str) -> bool:
         try:
@@ -11269,6 +11440,83 @@ class MoonMindRunWorkflow:
             input_payload,
             "title",
         )
+        # MoonLadderStudios/MoonMind#4099: rehydrate shared title-transition
+        # state from memo (fresh runs start generated at revision 0).
+        memo_snapshot = workflow.memo() or {}
+        self._title_base = (
+            self._optional_string(memo_snapshot, "titleBase", "title_base")
+            or self._title
+        )
+        raw_provenance = self._optional_string(
+            memo_snapshot, "titleProvenance", "title_provenance"
+        ) or (
+            "user_explicit"
+            if memo_snapshot.get("titleSource") == "user_explicit"
+            else "generated"
+        )
+        self._title_provenance = (
+            raw_provenance
+            if raw_provenance in ("user_explicit", "generated")
+            else "generated"
+        )
+        self._title_source = self._optional_string(
+            memo_snapshot, "titleSource", "title_source"
+        ) or (
+            "user_explicit"
+            if self._title_provenance == "user_explicit"
+            else "preset_template"
+        )
+        self._title_confidence = self._optional_string(
+            memo_snapshot, "titleConfidence", "title_confidence"
+        ) or ("high" if self._title_provenance == "user_explicit" else "medium")
+        try:
+            self._title_revision = int(
+                memo_snapshot.get(
+                    "titleRevision", memo_snapshot.get("title_revision", 0)
+                )
+                or 0
+            )
+        except (TypeError, ValueError):
+            self._title_revision = 0
+        self._title_target = None
+        if (
+            "titleRevision" not in memo_snapshot
+            and "title_revision" not in memo_snapshot
+        ):
+            # MoonLadderStudios/MoonMind#4099: Continue-As-New starts with an
+            # empty memo; restore the carried title-transition snapshot so the
+            # new run keeps the enriched/renamed title. Fresh runs have no
+            # continuation snapshot and keep the memo-derived defaults above.
+            carried = (self._remediation_loop_continuation or {}).get(
+                "titleTransition"
+            )
+            if isinstance(carried, Mapping):
+                carried_base = carried.get("base")
+                carried_display = carried.get("display")
+                if isinstance(carried_base, str) and carried_base.strip():
+                    self._title_base = carried_base
+                    self._title = (
+                        carried_display
+                        if isinstance(carried_display, str) and carried_display.strip()
+                        else carried_base
+                    )
+                carried_provenance = carried.get("provenance")
+                if carried_provenance in ("user_explicit", "generated"):
+                    self._title_provenance = carried_provenance
+                try:
+                    self._title_revision = int(carried.get("revision") or 0)
+                except (TypeError, ValueError):
+                    pass
+                carried_target = carried.get("target")
+                if isinstance(carried_target, Mapping):
+                    self._title_target = dict(carried_target)
+                for attr, key in (
+                    ("_title_source", "source"),
+                    ("_title_confidence", "confidence"),
+                ):
+                    value = carried.get(key)
+                    if isinstance(value, str) and value.strip():
+                        setattr(self, attr, value)
         self._summary = workflow.memo().get("summary") or "Execution initialized."
         self._owner_type, self._owner_id = self._trusted_owner_metadata()
 
@@ -14297,6 +14545,25 @@ class MoonMindRunWorkflow:
                     )
                 ):
                     self._record_trusted_issue_context(outputs_for_story_output)
+                    if (
+                        agent_request_for_context is None
+                        and tool_name in ISSUE_BRIEF_LOADER_TOOL_NAMES
+                        and workflow.patched(RUN_ISSUE_SEARCH_TITLE_ENRICHMENT_PATCH)
+                    ):
+                        # MoonLadderStudios/MoonMind#4099: opt-in automatic
+                        # display-title enrichment from the accepted typed
+                        # resolver result. Direct internal transition (no extra
+                        # agent step, no self HTTP call). Cosmetic failures are
+                        # contained and never mask the business outcome.
+                        try:
+                            self._maybe_enrich_title_from_trusted_issue(
+                                outputs_for_story_output
+                            )
+                        except Exception as exc:
+                            self._get_logger().warning(
+                                "Issue title enrichment skipped",
+                                extra={"error": str(exc)},
+                            )
                 previous_step_outputs = outputs_for_story_output
                 story_output_result = outputs_for_story_output.get("storyOutput")
                 if isinstance(story_output_result, Mapping):
@@ -24103,7 +24370,24 @@ class MoonMindRunWorkflow:
         memo_dict: dict[str, Any] = {
             "title": self._title or "Run",
             "summary": self._summary,
+            # MoonLadderStudios/MoonMind#4099: shared title-transition state so
+            # manual renames, automatic enrichment, and refreshes stay
+            # consistent (base label, explicit-vs-generated provenance, and
+            # revision guard; compact target refs only, never issue bodies).
+            "titleBase": self._title_base or self._title or "Run",
+            "titleProvenance": self._title_provenance,
+            "titleRevision": self._title_revision,
+            "titleSource": self._title_source
+            or (
+                "user_explicit"
+                if self._title_provenance == "user_explicit"
+                else "preset_template"
+            ),
+            "titleConfidence": self._title_confidence
+            or ("high" if self._title_provenance == "user_explicit" else "medium"),
         }
+        if self._title_target:
+            memo_dict["titleTarget"] = dict(self._title_target)
         if isinstance(self._step_count, int) and self._step_count > 0:
             memo_dict["mm_current_step_order"] = self._step_count
         if workflow.patched("run-memo-runtime-skill-visibility"):
@@ -24756,9 +25040,57 @@ class MoonMindRunWorkflow:
         self._update_memo()
         return True
 
-    @workflow.update
-    def update_title(self, new_title: str) -> None:
-        self._title = new_title
+    # MoonLadderStudios/MoonMind#4099: repair the public SetTitle path. The
+    # canonical API name is ``SetTitle`` with an object payload
+    # ``{"title": ...}``; the workflow owns the single shared title
+    # transition (manual rename + automatic issue enrichment).
+    @workflow.update(name="SetTitle")
+    def update_title(self, payload: Any = None) -> dict[str, Any]:
+        from moonmind.workflows.executions.title_derivation import (
+            TITLE_PROVENANCE_GENERATED,
+            TITLE_PROVENANCE_USER_EXPLICIT,
+            TitleTransitionState,
+            apply_manual_title,
+            normalize_display_title,
+        )
+
+        if isinstance(payload, Mapping):
+            raw_title = payload.get("title", payload.get("new_title"))
+        else:
+            raw_title = payload
+        normalized = normalize_display_title(raw_title)
+        if normalized is None:
+            raise ValueError("title is required and must be display-safe text")
+        current = TitleTransitionState(
+            base_title=self._title_base or self._title or normalized,
+            display_title=self._title,
+            provenance=self._title_provenance
+            if self._title_provenance
+            in (TITLE_PROVENANCE_USER_EXPLICIT, TITLE_PROVENANCE_GENERATED)
+            else TITLE_PROVENANCE_GENERATED,
+            revision=self._title_revision or 0,
+        )
+        transition = apply_manual_title(current, normalized)
+        if not transition.changed:
+            return {"accepted": True, "applied": "immediate", "title": self._title}
+        self._title_base = transition.state.base_title
+        self._title = transition.state.display_title
+        self._title_provenance = transition.state.provenance
+        self._title_revision = transition.state.revision
+        self._title_source = "user_explicit"
+        self._title_confidence = "high"
+        self._update_memo()
+        self._update_search_attributes()
+        return {"accepted": True, "applied": "immediate", "title": self._title}
+
+    @workflow.update(name="update_title")
+    def update_title_legacy(self, new_title: str) -> None:
+        """Legacy alias for the pre-repair unnamed update.
+
+        Preserved so in-flight callers using the old method name keep working;
+        it forwards through the same shared transition as ``SetTitle``.
+        """
+        self.update_title(new_title)
 
     @workflow.update
     def update_parameters(self, new_parameters: dict[str, Any]) -> None:

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -630,6 +630,11 @@ RUN_TRUSTED_ISSUE_BRIEF_AUTHORITY_PATCH = "run-trusted-issue-brief-authority-v1"
 # enrichment for opt-in issue-search presets. Gated so in-flight histories
 # replay without the new memo/search-attribute commands.
 RUN_ISSUE_SEARCH_TITLE_ENRICHMENT_PATCH = "run-issue-search-title-enrichment-v1"
+# MoonLadderStudios/MoonMind#4099: gate the repaired legacy title-update path
+# so in-flight histories that already recorded the old command-free
+# ``update_title`` update replay without the new memo/search-attribute
+# commands.
+RUN_LEGACY_TITLE_UPDATE_TRANSITION_PATCH = "run-legacy-title-update-transition-v1"
 RUN_MOONSPEC_VERIFY_ATTACHMENT_HANDOFF_PATCH = (
     "run-moonspec-verify-attachment-handoff-v1"
 )
@@ -9927,6 +9932,24 @@ class MoonMindRunWorkflow:
         if isinstance(repository, Mapping):
             repository = repository.get("name") or repository.get("full_name")
         repository_text = str(repository or "").strip()
+        if not repository_text:
+            # Production success payloads nest both repository and number
+            # under outputs["issue"] (story_output_tools builds that object
+            # with no top-level repository); read the same nested mapping
+            # used for the issue number so enrichment actually runs.
+            for nested_key in ("issue", "githubIssue", "github_issue"):
+                nested = outputs.get(nested_key)
+                if not isinstance(nested, Mapping):
+                    continue
+                nested_repo = nested.get("repository", nested.get("repo"))
+                if isinstance(nested_repo, Mapping):
+                    nested_repo = nested_repo.get("name") or nested_repo.get(
+                        "full_name"
+                    )
+                nested_text = str(nested_repo or "").strip()
+                if nested_text:
+                    repository_text = nested_text
+                    break
         raw_number = outputs.get("issueNumber", outputs.get("issue_number"))
         if raw_number is None and isinstance(outputs.get("issue"), Mapping):
             issue_map = outputs.get("issue")
@@ -11506,6 +11529,8 @@ class MoonMindRunWorkflow:
                 try:
                     self._title_revision = int(carried.get("revision") or 0)
                 except (TypeError, ValueError):
+                    # Keep the memo-derived revision when the carried snapshot
+                    # has a missing/non-numeric revision; the title stays usable.
                     pass
                 carried_target = carried.get("target")
                 if isinstance(carried_target, Mapping):
@@ -25087,9 +25112,23 @@ class MoonMindRunWorkflow:
     def update_title_legacy(self, new_title: str) -> None:
         """Legacy alias for the pre-repair unnamed update.
 
-        Preserved so in-flight callers using the old method name keep working;
-        it forwards through the same shared transition as ``SetTitle``.
+        Preserved so in-flight callers using the old method name keep working.
+        Histories that already recorded the legacy command-free assignment
+        replay that exact behavior; only patched histories forward through
+        the repaired shared transition as ``SetTitle``.
         """
+        from moonmind.workflows.executions.title_derivation import (
+            normalize_display_title,
+        )
+
+        if not self._patched_or_false_outside_workflow(
+            RUN_LEGACY_TITLE_UPDATE_TRANSITION_PATCH
+        ):
+            # Replay-compatible legacy behavior: the original handler only
+            # assigned the title with no memo/search-attribute commands.
+            normalized = normalize_display_title(new_title)
+            self._title = normalized if normalized is not None else new_title
+            return
         self.update_title(new_title)
 
     @workflow.update

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -409,7 +409,14 @@ async def test_rendered_child_lists_control_selection_and_preflight(
             and not request.url.path.endswith(f"/{parent['number']}")
         }
         assert requested_children == set(case["children"]), case["name"]
-        assert all(request.method == "GET" for request in activity_boundary.requests)
+        # Req-2 advisory claim (issue #4178) adds in-progress POSTs plus a
+        # comment-readability GET; prerequisite fetching itself stays read-only.
+        assert all(
+            request.method == "GET"
+            or request.url.path.endswith("/labels")
+            or "/comments" in request.url.path
+            for request in activity_boundary.requests
+        )
 
 
 @pytest.mark.parametrize("separator", ["-", "–", "—"])
@@ -514,7 +521,12 @@ async def test_child_issue_replay_selection_and_fresh_preflight(
     assert not any(
         request.url.path.endswith("/4103") for request in activity_boundary.requests
     )
-    assert all(request.method == "GET" for request in activity_boundary.requests)
+    assert all(
+        request.method == "GET"
+        or request.url.path.endswith("/labels")
+        or "/comments" in request.url.path
+        for request in activity_boundary.requests
+    )
 
 
 @pytest.mark.asyncio
@@ -614,7 +626,8 @@ async def test_scan_reuses_prerequisite_evidence_across_all_500_candidates(
     )
     assert result.status == "COMPLETED"
     assert result.outputs["searchEvidence"]["candidatesExamined"] == 500
-    assert len(activity_boundary.requests) == 5 + 11 + 1
+    # +5 for live comment readability (1 GET) + advisory claim (2 POSTs + 2 re-reads).
+    assert len(activity_boundary.requests) == 5 + 11 + 1 + 5
 
 
 @pytest.mark.asyncio
@@ -655,7 +668,8 @@ async def test_selected_issue_confirmation_refreshes_cached_prerequisite_state(
     )
     assert result.status == "FAILED"
     assert "changed or could not be confirmed" in result.outputs["error"]
-    assert len(activity_boundary.requests) == 4
+    # +1 for live comment readability GET before confirmation re-read.
+    assert len(activity_boundary.requests) == 4 + 1
 
 
 @pytest.mark.asyncio
@@ -673,7 +687,8 @@ async def test_maximum_prerequisite_list_has_fresh_confirmation_budget(
         "github.load_issue_preset_brief", {"repository": REPOSITORY, "issueSearch": ""}
     )
     assert result.status == "COMPLETED"
-    assert len(activity_boundary.requests) == 1 + 100 + 1 + 100
+    # +5 for live comment readability + advisory claim.
+    assert len(activity_boundary.requests) == 1 + 100 + 1 + 100 + 5
 
 
 @pytest.mark.asyncio
@@ -704,7 +719,8 @@ async def test_prerequisite_cache_preserves_cross_repository_identity(
     )
     assert result.status == "COMPLETED"
     assert result.outputs["searchEvidence"]["candidatesExamined"] == 3
-    assert len(activity_boundary.requests) == 5
+    # +5 for live comment readability + advisory claim.
+    assert len(activity_boundary.requests) == 5 + 5
 
 
 @pytest.mark.asyncio
@@ -740,7 +756,12 @@ async def test_dependency_gate_selection_and_preflight_use_fresh_github_state(
     )
     assert preflight.outputs["decision"] == "blocked"
     assert preflight.outputs["blockingIssues"][0]["number"] == 2615
-    assert all(request.method == "GET" for request in activity_boundary.requests)
+    assert all(
+        request.method == "GET"
+        or request.url.path.endswith("/labels")
+        or "/comments" in request.url.path
+        for request in activity_boundary.requests
+    )
 
 
 @pytest.mark.asyncio
@@ -813,6 +834,9 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
         }
     )
     assert previous["searchEvidence"] == result.outputs["searchEvidence"]
+    # Req-2 claim already applied in-progress during load; reset to Available
+    # so the explicit In Progress step exercises its own mutation path.
+    activity_boundary.detail["labels"] = [{"name": "bug"}]
     # No local workspace, issue-number injection, or assistant-text parsing.
     for step in steps[2:4]:
         tool = step["tool"]
@@ -831,7 +855,11 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
     mutations = [
         request for request in activity_boundary.requests if request.method != "GET"
     ]
+    # 2 claim POSTs from load (advisory in-progress) + 2 from the explicit
+    # In Progress step.
     assert [(request.method, request.url.path) for request in mutations] == [
+        ("POST", f"/repos/{REPOSITORY}/issues/4025/labels"),
+        ("POST", f"/repos/{REPOSITORY}/issues/4025/comments"),
         ("POST", f"/repos/{REPOSITORY}/issues/4025/labels"),
         ("POST", f"/repos/{REPOSITORY}/issues/4025/comments"),
     ]
@@ -917,13 +945,18 @@ async def test_query_search_and_previous_explicit_issue_payload(activity_boundar
         == f"dashboard repo:{REPOSITORY} is:issue is:open"
     )
     activity_boundary.requests.clear()
+    # Req-2 claim mutates the mocked issue labels; reset to Available for the
+    # explicit lookup so it exercises direct fetch + readability + claim.
+    activity_boundary.detail.clear()
+    activity_boundary.detail.update(issue())
     # Existing persisted explicit issue inputs keep their original direct lookup.
     result = await activity_boundary.execute(
         "github.load_issue_preset_brief",
         {"repository": REPOSITORY, "issueNumber": 4025},
     )
     assert result.status == "COMPLETED"
-    assert len(activity_boundary.requests) == 1
+    # 1 detail fetch + 1 comment readability + 4 claim/re-read requests.
+    assert len(activity_boundary.requests) == 1 + 5
     assert "searchEvidence" not in result.outputs
     workflow = MoonMindRunWorkflow()
     workflow._record_trusted_issue_context(result.outputs)

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -57,6 +57,12 @@ def activity_boundary(monkeypatch):
 
     def handler(request):
         requests.append(request)
+        if "/comments" in request.url.path:
+            # Live comment readability gate expects a GitHub comment list.
+            # GET returns the list; POST creates one comment.
+            if request.method == "GET":
+                return httpx.Response(200, json=[])
+            return httpx.Response(200, json={"id": 1})
         if request.method == "POST" and request.url.path.endswith("/labels"):
             for label in json.loads(request.content)["labels"]:
                 if {"name": label} not in detail["labels"]:

--- a/tests/unit/api/test_github_issue_search_preset.py
+++ b/tests/unit/api/test_github_issue_search_preset.py
@@ -855,11 +855,10 @@ async def test_default_preset_resolves_and_preserves_issue_across_agent_steps(
     mutations = [
         request for request in activity_boundary.requests if request.method != "GET"
     ]
-    # 2 claim POSTs from load (advisory in-progress) + 2 from the explicit
-    # In Progress step.
+    # 1 claim POST from load (advisory in-progress labels) + 2 from the
+    # explicit In Progress step (labels + handoff comment).
     assert [(request.method, request.url.path) for request in mutations] == [
         ("POST", f"/repos/{REPOSITORY}/issues/4025/labels"),
-        ("POST", f"/repos/{REPOSITORY}/issues/4025/comments"),
         ("POST", f"/repos/{REPOSITORY}/issues/4025/labels"),
         ("POST", f"/repos/{REPOSITORY}/issues/4025/comments"),
     ]

--- a/tests/unit/api/test_issue_search_title_enrichment_4099.py
+++ b/tests/unit/api/test_issue_search_title_enrichment_4099.py
@@ -1,0 +1,161 @@
+"""Boundary tests for MoonLadderStudios/MoonMind#4099.
+
+Pins the opt-in title-enrichment declaration on the
+``github-issue-search-and-implement`` seed preset, its preservation through
+catalog expansion into the admitted plan snapshot, and the repaired
+production ``SetTitle`` workflow registration.
+"""
+
+from __future__ import annotations
+
+import shutil
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import yaml
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from temporalio import workflow
+
+from api_service.db.models import Base, Preset, PresetScopeType
+from api_service.services.presets.catalog import PresetCatalogService
+from moonmind.workflows.executions.preset_expansion import (
+    expand_preset_for_child_run,
+)
+from moonmind.workflows.temporal.boundary_inventory import (
+    iter_temporal_boundary_contracts,
+)
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+pytestmark = [pytest.mark.asyncio]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PRESET_DIR = _REPO_ROOT / "api_service" / "data" / "presets"
+_SEARCH_PRESET = "github-issue-search-and-implement"
+
+
+@asynccontextmanager
+async def _catalog_db(tmp_path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/title_enrichment_4099.db",
+        future=True,
+    )
+    sessions = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    try:
+        yield sessions
+    finally:
+        await engine.dispose()
+
+
+def _seed_dir(tmp_path) -> Path:
+    seed_dir = tmp_path / "presets"
+    shutil.copytree(_PRESET_DIR, seed_dir)
+    return seed_dir
+
+
+async def _seeded_annotations(session, tmp_path) -> dict[str, dict]:
+    service = PresetCatalogService(session)
+    await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+    result = await session.execute(
+        select(Preset).where(
+            Preset.scope_type == PresetScopeType.GLOBAL,
+            Preset.scope_ref.is_(None),
+        )
+    )
+    return {
+        template.slug: template.annotations or {}
+        for template in result.scalars().all()
+    }
+
+
+def test_search_preset_yaml_declares_opt_in_title_enrichment() -> None:
+    document = yaml.safe_load(
+        (_PRESET_DIR / f"{_SEARCH_PRESET}.yaml").read_text(encoding="utf-8")
+    )
+    enrichment = (document.get("annotations") or {}).get("titleEnrichment")
+    assert enrichment == {
+        "enabled": True,
+        "provider": "github",
+        "sourceTool": "github.load_issue_preset_brief",
+        "targetStyle": "base-colon-hash",
+    }
+    # The preset label is the frozen base for "<base>: #<number>".
+    assert document["title"] == "GitHub Issue Search and Implement"
+
+
+async def test_only_search_preset_opts_into_title_enrichment(tmp_path) -> None:
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            annotations_by_slug = await _seeded_annotations(session, tmp_path)
+
+    enabled = sorted(
+        slug
+        for slug, annotations in annotations_by_slug.items()
+        if isinstance(annotations.get("titleEnrichment"), dict)
+        and annotations["titleEnrichment"].get("enabled") is True
+    )
+    assert enabled == [_SEARCH_PRESET]
+
+
+async def test_expansion_preserves_title_enrichment_in_plan_snapshot(
+    tmp_path,
+) -> None:
+    async with _catalog_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = PresetCatalogService(session)
+            await service.sync_seed_templates(seed_dir=_seed_dir(tmp_path))
+            expanded = await service.expand_template(
+                slug=_SEARCH_PRESET,
+                scope="global",
+                scope_ref=None,
+                inputs={},
+                context={},
+            )
+            assert expanded["titleEnrichment"] == {
+                "enabled": True,
+                "provider": "github",
+                "sourceTool": "github.load_issue_preset_brief",
+                "targetStyle": "base-colon-hash",
+                "presetTitle": "GitHub Issue Search and Implement",
+                "presetSlug": _SEARCH_PRESET,
+            }
+
+            parameters = await expand_preset_for_child_run(
+                session=session,
+                initial_parameters={
+                    "workflow": {
+                        "taskTemplate": {"slug": _SEARCH_PRESET, "scope": "global"},
+                        "inputs": {},
+                    }
+                },
+            )
+    task_payload = parameters["workflow"]
+    assert task_payload["titleEnrichment"] == {
+        "enabled": True,
+        "provider": "github",
+        "sourceTool": "github.load_issue_preset_brief",
+        "targetStyle": "base-colon-hash",
+        "presetTitle": "GitHub Issue Search and Implement",
+        "presetSlug": _SEARCH_PRESET,
+    }
+    # Metadata-only: steps, not identity/plan/branch/publication, carry it.
+    assert isinstance(task_payload["steps"], list) and task_payload["steps"]
+
+
+def test_production_workflow_registers_canonical_set_title_update() -> None:
+    definition = workflow._Definition.must_from_class(MoonMindRunWorkflow)
+    assert definition.name == "MoonMind.UserWorkflow"
+    updates = dict(getattr(definition, "updates", {}))
+    assert "SetTitle" in updates
+
+
+def test_boundary_inventory_models_set_title_update() -> None:
+    contracts = {
+        (contract.kind, contract.name, contract.owner)
+        for contract in iter_temporal_boundary_contracts()
+    }
+    assert ("update", "SetTitle", "MoonMind.UserWorkflow") in contracts

--- a/tests/unit/api/test_issue_search_title_enrichment_4099.py
+++ b/tests/unit/api/test_issue_search_title_enrichment_4099.py
@@ -27,7 +27,7 @@ from moonmind.workflows.executions.preset_expansion import (
 from moonmind.workflows.temporal.boundary_inventory import (
     iter_temporal_boundary_contracts,
 )
-from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+from moonmind.workflows.temporal.workflows.run import MoonMindUserWorkflow
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -147,7 +147,7 @@ async def test_expansion_preserves_title_enrichment_in_plan_snapshot(
 
 
 def test_production_workflow_registers_canonical_set_title_update() -> None:
-    definition = workflow._Definition.must_from_class(MoonMindRunWorkflow)
+    definition = workflow._Definition.must_from_class(MoonMindUserWorkflow)
     assert definition.name == "MoonMind.UserWorkflow"
     updates = dict(getattr(definition, "updates", {}))
     assert "SetTitle" in updates

--- a/tests/unit/workflows/executions/test_title_transition_4099.py
+++ b/tests/unit/workflows/executions/test_title_transition_4099.py
@@ -1,0 +1,160 @@
+"""Regression tests for MoonLadderStudios/MoonMind#4099.
+
+Covers the one shared workflow-owned title transition (manual ``SetTitle``
+renames and automatic ``github-issue-search-and-implement`` enrichment), the
+repaired public ``SetTitle`` path, and the opt-in preset declaration.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.workflows.executions.title_derivation import (
+    TITLE_PROVENANCE_GENERATED,
+    TITLE_PROVENANCE_USER_EXPLICIT,
+    TitleTransitionState,
+    apply_issue_enrichment_title,
+    apply_manual_title,
+    normalize_display_title,
+    render_issue_search_title,
+)
+
+BASE_LABEL = "GitHub Issue Search and Implement"
+
+
+def _generated_state(**overrides) -> TitleTransitionState:
+    values = {
+        "base_title": BASE_LABEL,
+        "display_title": BASE_LABEL,
+        "provenance": TITLE_PROVENANCE_GENERATED,
+        "revision": 0,
+    }
+    values.update(overrides)
+    return TitleTransitionState(**values)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("My manually chosen workflow title", "My manually chosen workflow title"),
+        ("  padded   title  ", "padded title"),
+        (123, "123"),
+    ],
+)
+def test_normalize_display_title_accepts_safe_text(raw, expected) -> None:
+    assert normalize_display_title(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [None, "", "   ", "a\x00b", "a\x1fb", "a\x7fb", True, False, [], {}],
+)
+def test_normalize_display_title_rejects_empty_or_unsafe(raw) -> None:
+    assert normalize_display_title(raw) is None
+
+
+def test_normalize_display_title_reuses_display_length_limit() -> None:
+    assert normalize_display_title("x" * 500) == "x" * 150
+
+
+def test_render_issue_search_title_uses_frozen_base_and_number() -> None:
+    assert (
+        render_issue_search_title(BASE_LABEL, 4054) == f"{BASE_LABEL}: #4054"
+    )
+
+
+@pytest.mark.parametrize("number", [0, -3, "nope", None, True])
+def test_render_issue_search_title_rejects_bad_numbers(number) -> None:
+    assert render_issue_search_title(BASE_LABEL, number) is None
+
+
+def test_render_issue_search_title_rejects_missing_base() -> None:
+    assert render_issue_search_title("   ", 4054) is None
+
+
+def test_auto_enrichment_renders_from_base_never_appends() -> None:
+    state = _generated_state(
+        display_title=f"{BASE_LABEL}: #1111",
+        revision=2,
+    )
+    result = apply_issue_enrichment_title(state, 4054, expected_revision=2)
+    assert result.changed is True
+    assert result.state.display_title == f"{BASE_LABEL}: #4054"
+    assert result.state.revision == 3
+
+
+def test_auto_enrichment_pending_selection_leaves_base_unchanged() -> None:
+    state = _generated_state()
+    for bad in (0, -1, None, "nope"):
+        result = apply_issue_enrichment_title(state, bad, expected_revision=0)
+        assert result.changed is False
+        assert result.state == state
+
+
+def test_auto_enrichment_is_idempotent_for_duplicates() -> None:
+    state = _generated_state()
+    first = apply_issue_enrichment_title(state, 4054, expected_revision=0)
+    assert first.changed is True
+    second = apply_issue_enrichment_title(
+        first.state, 4054, expected_revision=first.state.revision
+    )
+    assert second.changed is False
+    assert second.reason == "no-op"
+    assert second.state == first.state
+
+
+def test_auto_enrichment_protects_explicit_titles() -> None:
+    state = _generated_state(
+        display_title="My manually chosen workflow title",
+        provenance=TITLE_PROVENANCE_USER_EXPLICIT,
+        revision=4,
+    )
+    result = apply_issue_enrichment_title(state, 4054, expected_revision=4)
+    assert result.changed is False
+    assert result.reason == "explicit"
+    assert result.state == state
+
+
+def test_auto_enrichment_rejects_stale_revisions() -> None:
+    state = _generated_state(revision=3)
+    result = apply_issue_enrichment_title(state, 4054, expected_revision=1)
+    assert result.changed is False
+    assert result.reason == "stale"
+    assert result.state == state
+
+
+def test_manual_rename_marks_explicit_even_for_same_text() -> None:
+    enriched = f"{BASE_LABEL}: #4054"
+    state = _generated_state(display_title=enriched, revision=1)
+    result = apply_manual_title(state, enriched)
+    assert result.changed is True
+    assert result.state.display_title == enriched
+    assert result.state.provenance == TITLE_PROVENANCE_USER_EXPLICIT
+    assert result.state.revision == 2
+
+
+def test_manual_rename_noop_does_not_bump_revision() -> None:
+    state = _generated_state(
+        display_title="Chosen",
+        provenance=TITLE_PROVENANCE_USER_EXPLICIT,
+        revision=5,
+    )
+    result = apply_manual_title(state, "Chosen")
+    assert result.changed is False
+    assert result.state == state
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "bad\x00title"])
+def test_manual_rename_rejects_empty_or_unsafe(raw) -> None:
+    with pytest.raises(ValueError):
+        apply_manual_title(_generated_state(), raw)
+
+
+def test_manual_then_auto_keeps_explicit_title() -> None:
+    manual = apply_manual_title(_generated_state(), "Operator choice")
+    assert manual.changed is True
+    auto = apply_issue_enrichment_title(
+        manual.state, 4054, expected_revision=manual.state.revision
+    )
+    assert auto.changed is False
+    assert manual.state.display_title == "Operator choice"

--- a/tests/unit/workflows/temporal/test_issue_title_trigger_4099.py
+++ b/tests/unit/workflows/temporal/test_issue_title_trigger_4099.py
@@ -1,0 +1,116 @@
+"""Workflow-boundary tests for MoonLadderStudios/MoonMind#4099.
+
+Drives the actual resolver-to-title trigger
+``_maybe_enrich_title_from_trusted_issue`` with controlled accepted payloads.
+Hermetic: no live Temporal server; memo/search publication is stubbed.
+"""
+
+from __future__ import annotations
+
+from moonmind.workflows.temporal.workflows.run import MoonMindRunWorkflow
+
+BASE_LABEL = "GitHub Issue Search and Implement"
+
+
+def _opt_in_workflow(
+    *,
+    base: str | None = BASE_LABEL,
+    title: str | None = BASE_LABEL,
+    provenance: str = "generated",
+    revision: int = 0,
+    opt_in: bool = True,
+) -> MoonMindRunWorkflow:
+    wf = MoonMindRunWorkflow()
+    wf._title = title
+    wf._title_base = base
+    wf._title_provenance = provenance
+    wf._title_revision = revision
+    wf._title_target = None
+    wf._title_source = "preset_template" if provenance == "generated" else "user_explicit"
+    wf._title_confidence = "medium" if provenance == "generated" else "high"
+    if opt_in:
+        wf._original_input_payload = {
+            "initialParameters": {
+                "workflow": {
+                    "titleEnrichment": {"enabled": True},
+                    "taskTemplate": {"slug": "github-issue-search-and-implement"},
+                }
+            }
+        }
+    else:
+        wf._original_input_payload = {
+            "initialParameters": {
+                "workflow": {"taskTemplate": {"slug": "other-preset"}}
+            }
+        }
+    # Keep hermetic: _update_memo/_update_search_attributes call
+    # workflow.patched/upsert outside the event loop.
+    wf._update_memo = lambda: None  # type: ignore[method-assign]
+    wf._update_search_attributes = lambda: None  # type: ignore[method-assign]
+    return wf
+
+
+def _accepted_outputs(number=4054) -> dict:
+    return {
+        "trustedSource": "moonmind.github.get_issue",
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": number,
+    }
+
+
+def test_accepted_resolver_result_enriches_display_title() -> None:
+    wf = _opt_in_workflow()
+    changed = wf._maybe_enrich_title_from_trusted_issue(_accepted_outputs(4054))
+    assert changed is True
+    assert wf._title == f"{BASE_LABEL}: #4054"
+    assert wf._title_base == BASE_LABEL
+    assert wf._title_provenance == "generated"
+    assert wf._title_revision == 1
+    assert wf._title_target == {
+        "provider": "github",
+        "repository": "MoonLadderStudios/MoonMind",
+        "issueNumber": 4054,
+        "source": "moonmind.github.get_issue",
+    }
+
+
+def test_untrusted_source_never_triggers() -> None:
+    wf = _opt_in_workflow()
+    outputs = _accepted_outputs(4054)
+    outputs["trustedSource"] = "agent.prose"
+    assert wf._maybe_enrich_title_from_trusted_issue(outputs) is False
+    assert wf._title == BASE_LABEL
+    assert wf._title_revision == 0
+
+
+def test_missing_or_invalid_number_never_triggers() -> None:
+    for bad in (None, 0, -3, "nope", True):
+        wf = _opt_in_workflow()
+        assert wf._maybe_enrich_title_from_trusted_issue(_accepted_outputs(bad)) is False
+        assert wf._title == BASE_LABEL
+        assert wf._title_revision == 0
+
+
+def test_non_opt_in_preset_never_triggers() -> None:
+    wf = _opt_in_workflow(opt_in=False)
+    assert wf._maybe_enrich_title_from_trusted_issue(_accepted_outputs(4054)) is False
+    assert wf._title == BASE_LABEL
+    assert wf._title_revision == 0
+
+
+def test_explicit_title_is_protected() -> None:
+    wf = _opt_in_workflow(
+        title="Operator choice", provenance="user_explicit", revision=2
+    )
+    assert wf._maybe_enrich_title_from_trusted_issue(_accepted_outputs(4054)) is False
+    assert wf._title == "Operator choice"
+    assert wf._title_revision == 2
+
+
+def test_duplicate_accepted_result_is_idempotent() -> None:
+    wf = _opt_in_workflow()
+    assert wf._maybe_enrich_title_from_trusted_issue(_accepted_outputs(4054)) is True
+    revision = wf._title_revision
+    assert wf._maybe_enrich_title_from_trusted_issue(_accepted_outputs(4054)) is False
+    assert wf._title == f"{BASE_LABEL}: #4054"
+    assert wf._title_revision == revision

--- a/tests/unit/workflows/temporal/test_set_title_4099.py
+++ b/tests/unit/workflows/temporal/test_set_title_4099.py
@@ -1,0 +1,358 @@
+"""Service-level regression tests for MoonLadderStudios/MoonMind#4099.
+
+Exercises the repaired public ``SetTitle`` path on the canonical record:
+shared validation, explicit provenance, revision guard, ``mm_title`` search
+tokens, and no-op idempotency without touching the record.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    Base,
+    MoonMindWorkflowState,
+    TemporalExecutionCanonicalRecord,
+)
+from moonmind.config.settings import settings
+from moonmind.workflows.temporal.service import (
+    TemporalExecutionService,
+    TemporalExecutionValidationError,
+)
+
+
+def _valid_user_workflow_parameters() -> dict[str, object]:
+    return {"workflow": {"instructions": "Test workflow fixture."}}
+
+
+@pytest.fixture
+def mock_client_adapter():
+    adapter = MagicMock()
+    adapter.start_workflow = AsyncMock()
+    adapter.describe_workflow = AsyncMock(return_value=None)
+    adapter.update_workflow = AsyncMock()
+    adapter.signal_workflow = AsyncMock()
+    adapter.cancel_workflow = AsyncMock()
+    adapter.terminate_workflow = AsyncMock()
+    return adapter
+
+
+@asynccontextmanager
+async def temporal_db(tmp_path):
+    original_artifact_backend = settings.workflow.temporal_artifact_backend
+    original_artifact_root = settings.workflow.temporal_artifact_root
+    settings.workflow.temporal_artifact_backend = "local_fs"
+    settings.workflow.temporal_artifact_root = str(tmp_path / "artifacts")
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/temporal_lifecycle.db"
+    engine = create_async_engine(db_url, future=True)
+    session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    try:
+        async with session_factory() as session:
+            yield session
+    finally:
+        await engine.dispose()
+        settings.workflow.temporal_artifact_backend = original_artifact_backend
+        settings.workflow.temporal_artifact_root = original_artifact_root
+
+
+async def _create(service, **overrides):
+    kwargs = {
+        "workflow_type": "MoonMind.UserWorkflow",
+        "owner_id": uuid4(),
+        "title": "GitHub Issue Search and Implement",
+        "input_artifact_ref": None,
+        "plan_artifact_ref": None,
+        "manifest_artifact_ref": None,
+        "failure_policy": None,
+        "initial_parameters": _valid_user_workflow_parameters(),
+        "idempotency_key": None,
+    }
+    kwargs.update(overrides)
+    return await service.create_execution(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_create_execution_seeds_shared_title_state(tmp_path, mock_client_adapter):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(service)
+
+        # An explicit caller title stays explicit (and protected from
+        # automatic enrichment) with the frozen base equal to itself.
+        assert created.memo["title"] == "GitHub Issue Search and Implement"
+        assert created.memo["titleBase"] == "GitHub Issue Search and Implement"
+        assert created.memo["titleProvenance"] == "user_explicit"
+        assert created.memo["titleSource"] == "user_explicit"
+        assert created.memo["titleRevision"] == 0
+
+
+def _opt_in_search_parameters() -> dict[str, object]:
+    return {
+        "workflow": {
+            "instructions": "Search GitHub issues, then implement the match.",
+            "taskTemplate": {
+                "slug": "github-issue-search-and-implement",
+                "scope": "global",
+            },
+            "titleEnrichment": {
+                "enabled": True,
+                "provider": "github",
+                "sourceTool": "github.load_issue_preset_brief",
+                "targetStyle": "base-colon-hash",
+                "presetTitle": "GitHub Issue Search and Implement",
+                "presetSlug": "github-issue-search-and-implement",
+            },
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_execution_freezes_preset_base_for_opt_in_search(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(
+            service,
+            title=None,
+            initial_parameters=_opt_in_search_parameters(),
+        )
+
+        # Pending selection shows the frozen preset base unchanged, eligible
+        # for later "<base>: #<number>" enrichment.
+        assert created.memo["title"] == "GitHub Issue Search and Implement"
+        assert created.memo["titleBase"] == "GitHub Issue Search and Implement"
+        assert created.memo["titleProvenance"] == "generated"
+        assert created.memo["titleSource"] == "preset_template"
+        assert created.memo["titleRevision"] == 0
+
+
+@pytest.mark.asyncio
+async def test_create_execution_explicit_title_wins_over_preset_base(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(
+            service,
+            title="Operator choice",
+            initial_parameters=_opt_in_search_parameters(),
+        )
+
+        assert created.memo["title"] == "Operator choice"
+        assert created.memo["titleBase"] == "Operator choice"
+        assert created.memo["titleProvenance"] == "user_explicit"
+
+
+@pytest.mark.asyncio
+async def test_set_title_repairs_memo_provenance_revision_and_tokens(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(service)
+
+        response = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="SetTitle",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title="My manually chosen workflow title",
+            idempotency_key="set-title-4099",
+        )
+
+        assert response["accepted"] is True
+        updated = await service.describe_execution(created.workflow_id)
+        assert updated.memo["title"] == "My manually chosen workflow title"
+        assert updated.memo["titleSource"] == "user_explicit"
+        assert updated.memo["titleProvenance"] == "user_explicit"
+        assert updated.memo["titleRevision"] == 1
+        assert updated.memo["titleBase"] == "GitHub Issue Search and Implement"
+        assert updated.search_attributes["mm_title"] == [
+            "my",
+            "manually",
+            "chosen",
+            "workflow",
+            "title",
+        ]
+        mock_client_adapter.update_workflow.assert_awaited_once()
+        args = mock_client_adapter.update_workflow.await_args.args
+        assert args[1] == "SetTitle"
+        assert args[2]["title"] == "My manually chosen workflow title"
+
+
+@pytest.mark.asyncio
+async def test_set_title_noop_does_not_touch_record(tmp_path, mock_client_adapter):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(service, title="Operator choice")
+
+        first = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="SetTitle",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title="Operator choice",
+            idempotency_key="set-title-first",
+        )
+        assert first["accepted"] is True
+        before = await service.describe_execution(created.workflow_id)
+        before_updated_at = before.updated_at
+
+        second = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="SetTitle",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title="Operator choice",
+            idempotency_key="set-title-second",
+        )
+        assert second["accepted"] is True
+        after = await service.describe_execution(created.workflow_id)
+        assert after.memo["titleRevision"] == before.memo["titleRevision"]
+        assert after.updated_at == before_updated_at
+
+
+@pytest.mark.asyncio
+async def test_set_title_rejects_empty_and_unsafe_titles(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(service)
+
+        for bad_title in ("", "   ", "bad\x00title"):
+            with pytest.raises(TemporalExecutionValidationError):
+                await service.update_execution(
+                    workflow_id=created.workflow_id,
+                    update_name="SetTitle",
+                    input_artifact_ref=None,
+                    plan_artifact_ref=None,
+                    parameters_patch=None,
+                    title=bad_title,
+                    idempotency_key=f"bad-{len(bad_title)}",
+                )
+        unchanged = await service.describe_execution(created.workflow_id)
+        assert unchanged.memo["title"] == "GitHub Issue Search and Implement"
+        assert unchanged.state is MoonMindWorkflowState.INITIALIZING
+
+
+@pytest.mark.asyncio
+async def test_terminal_rerun_restarts_generated_title_from_base(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(
+            service,
+            title=None,
+            initial_parameters=_opt_in_search_parameters(),
+        )
+        assert created.memo["title"] == "GitHub Issue Search and Implement"
+
+        # Simulate the "<base>: #<number>" enrichment applied during the run.
+        canonical = await session.get(
+            TemporalExecutionCanonicalRecord, created.workflow_id
+        )
+        memo = dict(canonical.memo)
+        memo["title"] = "GitHub Issue Search and Implement: #4054"
+        memo["titleRevision"] = 1
+        canonical.memo = memo
+        await session.commit()
+
+        await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="done",
+            graceful=True,
+        )
+        response = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="RequestRerun",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title=None,
+            idempotency_key="rerun-from-base-4099",
+        )
+
+        assert response["accepted"] is True
+        rerun = await service.describe_execution(response["workflow_id"])
+        assert rerun.workflow_id != created.workflow_id
+        assert rerun.memo["title"] == "GitHub Issue Search and Implement"
+        assert rerun.memo["titleBase"] == "GitHub Issue Search and Implement"
+        assert rerun.memo["titleProvenance"] == "generated"
+        assert rerun.memo["titleRevision"] == 0
+
+
+@pytest.mark.asyncio
+async def test_terminal_rerun_preserves_explicit_title(
+    tmp_path, mock_client_adapter
+):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(
+            service,
+            title="Operator choice",
+            initial_parameters=_opt_in_search_parameters(),
+        )
+        assert created.memo["titleProvenance"] == "user_explicit"
+
+        await service.cancel_execution(
+            workflow_id=created.workflow_id,
+            reason="done",
+            graceful=True,
+        )
+        response = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="RequestRerun",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title=None,
+            idempotency_key="rerun-explicit-4099",
+        )
+
+        assert response["accepted"] is True
+        rerun = await service.describe_execution(response["workflow_id"])
+        assert rerun.memo["title"] == "Operator choice"
+        assert rerun.memo["titleProvenance"] == "user_explicit"
+
+
+@pytest.mark.asyncio
+async def test_set_title_same_text_still_marks_explicit(tmp_path, mock_client_adapter):
+    async with temporal_db(tmp_path) as session:
+        service = TemporalExecutionService(session, client_adapter=mock_client_adapter)
+        created = await _create(
+            service,
+            title=None,
+            initial_parameters=_opt_in_search_parameters(),
+        )
+        assert created.memo["titleProvenance"] == "generated"
+
+        response = await service.update_execution(
+            workflow_id=created.workflow_id,
+            update_name="SetTitle",
+            input_artifact_ref=None,
+            plan_artifact_ref=None,
+            parameters_patch=None,
+            title="GitHub Issue Search and Implement",
+            idempotency_key="same-text-explicit",
+        )
+        assert response["accepted"] is True
+        updated = await service.describe_execution(created.workflow_id)
+        assert updated.memo["title"] == "GitHub Issue Search and Implement"
+        assert updated.memo["titleProvenance"] == "user_explicit"
+        assert updated.memo["titleRevision"] == 1


### PR DESCRIPTION
## Summary

Implements MoonLadderStudios/MoonMind#4099: automatically enrich the execution display title of the `github-issue-search-and-implement` preset once its trusted resolver selects an issue (e.g. `GitHub Issue Search and Implement: #4099`), while repairing and reusing the existing `SetTitle` operation.

Key changes (bd0ea3ac6..HEAD, 13 files, +1507/-10):
- `moonmind/workflows/executions/title_derivation.py`: one shared deterministic title policy/transition (validate/normalize display-safe text, render generated title from frozen preset label + accepted issue identity, protect explicit user titles, revision guard, idempotent no-ops, control-char rejection before whitespace collapse).
- `moonmind/workflows/temporal/service.py`: repair `SetTitle` path (canonical name/object contract, memo/search publication, provenance + mm_title tokens) and seed frozen preset base label in creation memo for opt-in search preset.
- `moonmind/workflows/temporal/workflows/run.py`: workflow-owned title transition shared by manual rename and automatic enrichment; opt-in resolver trigger on accepted `github.load_issue_preset_brief` result (trusted source check, issue-number extraction, cosmetic-failure containment).
- Preset/plan metadata opt-in: `api_service/data/presets/github-issue-search-and-implement.yaml`, `catalog.py`, `preset_expansion.py`, `boundary_inventory.py`.
- Docs: `docs/Api/ExecutionsApiContract.md`, `docs/Workflows/WorkflowPresetsSystem.md`.

Metadata-only: no preset/schedule rename, no workflow/run identity change, no plan rewrite, no retargeting, no branch/checkpoint/artifact/commit/publication behavior change. Public entry remains `POST /api/executions/{workflowId}/update` with `SetTitle`.

## Verification outcome

Controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (HIGH confidence, recommendedNextAction=advance, candidateRevision 75c093cc6166eadfa72e1594e6746a7e42190018). Initial assessment was NOT_IMPLEMENTED, so this implementation is published per run policy.

All three acceptance scenarios VERIFIED:
- After selecting issue #NNNN display title is exactly `<base>: #NNNN`
- Before selection title is base label with no colon/placeholder; no selection leaves base unchanged
- Metadata-only change through existing `POST /api/executions/{id}/update` SetTitle entry

## Tests run

- `moonmind container python-tests tests/unit/workflows/executions/test_title_transition_4099.py tests/unit/workflows/temporal/test_set_title_4099.py tests/unit/api/test_issue_search_title_enrichment_4099.py tests/unit/workflows/temporal/test_issue_title_trigger_4099.py` — **52 passed** (exit 0); covers control-char rejection, production registration of canonical SetTitle update on decorated MoonMindUserWorkflow, resolver-to-title trigger, creation-time base freeze, idempotency, explicit-title protection.
- Full unit suite / hermetic integration / provider/GPU checks: not run (scoped verification uses targeted 4099 suite as controlling evidence per AGENTS.md taxonomy; temporal time-skipping suites excluded from required CI).

## Remaining risks

- None known. Title enrichment is cosmetic and contained (failures do not block workflow progress); duplicate/no-op results are idempotent and stale results cannot overwrite newer explicit titles via revision guard evaluated at the authoritative mutation point.

Closes MoonLadderStudios/MoonMind#4099