### PR TITLE
[GitHub issue lifecycle] Reconcile interrupted handoffs and surface unresponsive owners (MoonLadderStudios/MoonMind#4182)

### DIFF
--- a/docs/Temporal/WorkflowTypeCatalogGenerated.md
+++ b/docs/Temporal/WorkflowTypeCatalogGenerated.md
@@ -47,6 +47,7 @@ present, are listed with their supported condition below.
 | `MoonMind.CheckpointBranchTurn` <a id="moonmindcheckpointbranchturn"></a> | `moonmind.workflows.temporal.workflows.checkpoint_branch_turn.MoonMindCheckpointBranchTurnWorkflow` | `operator` | [lifecycle](#moonmindcheckpointbranchturn) |
 | `MoonMind.ContainerJob` <a id="moonmindcontainerjob"></a> | `moonmind.workflows.temporal.workflows.container_job.MoonMindContainerJobWorkflow` | `operator` | [lifecycle](#moonmindcontainerjob) |
 | `MoonMind.ControlStopContinuation` <a id="moonmindcontrolstopcontinuation"></a> | `moonmind.workflows.temporal.workflows.control_stop_continuation.MoonMindControlStopContinuationWorkflow` | `operator` | [lifecycle](#moonmindcontrolstopcontinuation) |
+| `MoonMind.GitHubIssueReconcile` <a id="moonmindgithubissuereconcile"></a> | `moonmind.workflows.temporal.workflows.github_issue_reconcile.MoonMindGitHubIssueReconcileWorkflow` | `operator` | [lifecycle](#moonmindgithubissuereconcile) |
 | `MoonMind.ManagedRuntimeWorkspaceCleanup` <a id="moonmindmanagedruntimeworkspacecleanup"></a> | `moonmind.workflows.temporal.workflows.managed_runtime_workspace_cleanup.MoonMindManagedRuntimeWorkspaceCleanupWorkflow` | `excluded` | [lifecycle](#moonmindmanagedruntimeworkspacecleanup) |
 | `MoonMind.ManagedSessionReconcile` <a id="moonmindmanagedsessionreconcile"></a> | `moonmind.workflows.temporal.workflows.managed_session_reconcile.MoonMindManagedSessionReconcileWorkflow` | `excluded` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#116-moonmindmanagedsessionreconcile-lifecycle) |
 | `MoonMind.MergeAutomation` <a id="moonmindmergeautomation"></a> | `moonmind.workflows.temporal.workflows.merge_automation.MoonMindMergeAutomationWorkflow` | `operator` | [lifecycle](WorkflowTypeCatalogAndLifecycle.md#119-moonmindmergeautomation-lifecycle) |
@@ -155,6 +156,7 @@ with deterministic workflow code, not Temporal Local Activities.
 | `execution.notify_completion` | `agent_runtime` | `mm.activity.agent_runtime` |
 | `execution.record_terminal_state` | `artifacts` | `mm.activity.artifacts` |
 | `github_issue.finalize_failed_attempt` | `integrations` | `mm.activity.integrations` |
+| `github_issue.reconcile_handoffs` | `integrations` | `mm.activity.integrations` |
 | `integration.codex_cloud.cancel` | `integrations` | `mm.activity.integrations` |
 | `integration.codex_cloud.fetch_result` | `integrations` | `mm.activity.integrations` |
 | `integration.codex_cloud.start` | `integrations` | `mm.activity.integrations` |

--- a/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
+++ b/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
@@ -46,7 +46,12 @@ def _state_dir(explicit: Any) -> Path:
     import os
 
     candidate = _string(explicit) or os.environ.get(
-        "MOONMIND_GITHUB_RECONCILIATION_STATE_DIR", "var/artifacts/github_issue_reconciliation"
+        # Durable default: temporal-worker-integrations only mounts the
+        # moonmind_secrets volume (/app/var/secrets), so state under
+        # var/artifacts is discarded on worker recreate precisely when
+        # restart recovery is needed.
+        "MOONMIND_GITHUB_RECONCILIATION_STATE_DIR",
+        "var/secrets/github_issue_reconciliation",
     )
     return Path(candidate)
 
@@ -166,23 +171,148 @@ async def _fetch_pr_state(*, service: Any, pr_url: str) -> dict[str, Any]:
     }
 
 
-def _validated_handoffs(comments: Sequence[Mapping[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
-    """Extract provenance-validated attempt handoffs; never trust prose."""
-    from moonmind.workflows.temporal.github_issue_attempt import extract_attempt_metadata
+def _trusted_posters(*, service: Any = None) -> list[str]:
+    """Resolve the provenance allow-list for attempt-handoff validation."""
+    import os
 
+    raw = os.environ.get("MOONMIND_TRUSTED_POSTERS", "")
+    posters = [part.strip() for part in str(raw or "").replace(";", ",").split(",") if part.strip()]
+    candidate = getattr(service, "trusted_posters", None) if service is not None else None
+    if isinstance(candidate, (list, tuple)):
+        posters.extend(str(item).strip() for item in candidate if str(item).strip())
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for poster in posters:
+        key = poster.lower()
+        if key not in seen:
+            seen.add(key)
+            ordered.append(poster)
+    return ordered
+
+
+def _comment_author(comment: Mapping[str, Any]) -> str:
+    user = comment.get("user")
+    if isinstance(user, Mapping):
+        login = _string(user.get("login"))
+        if login:
+            return login
+    for key in ("author_login", "authorLogin", "author"):
+        value = comment.get(key)
+        if isinstance(value, Mapping):
+            login = _string(value.get("login"))
+            if login:
+                return login
+        elif _string(value):
+            return _string(value)
+    return ""
+
+
+def _normalize_canonical_handoff(handoff: Any) -> dict[str, Any]:
+    """Normalize a canonical (plural-module) handoff to the reconciler shape."""
+    data = handoff.to_dict() if hasattr(handoff, "to_dict") else dict(handoff)
+    preserved = {
+        "prUrl": _string(data.get("prUrl")),
+        "prHeadSha": _string(data.get("prHead")),
+        "prBase": _string(data.get("prBase")),
+        "savedBranch": _string(data.get("savedBranch")),
+        "savedSha": _string(data.get("savedSha")),
+    }
+    return {
+        "attemptId": _string(data.get("attemptId")),
+        "deploymentId": _string(data.get("deploymentId")),
+        "repository": _string(data.get("repository")),
+        "issueNumber": data.get("issueNumber"),
+        "activity": _string(data.get("activity")),
+        "writersStopped": bool(data.get("writersStopped")),
+        "stopEvidence": _string(data.get("lastReport")) or _string(data.get("verificationSummary")),
+        "pendingDisposition": _string(data.get("pendingDisposition")),
+        "outcome": _string(data.get("outcome")),
+        "nextAction": _string(data.get("nextAction")),
+        "preservedWork": preserved,
+        "retryHistory": {"operatorHold": bool(data.get("operatorHold"))},
+        "formatVersion": data.get("formatVersion"),
+    }
+
+
+def _validated_handoffs(
+    comments: Sequence[Mapping[str, Any]],
+    *,
+    repository: str = "",
+    issue_number: int = 0,
+    trusted_posters: Sequence[str] | None = None,
+    service: Any = None,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Extract provenance-validated attempt handoffs; never trust prose.
+
+    Parses the canonical production format
+    (``moonmind/workflows/temporal/github_issue_attempts.py``,
+    ``<!-- moonmind-attempt-handoff ... -->``) first and accepts the legacy
+    singular format (``github_issue_attempt.py``,
+    ``<!-- moonmind-github-attempt: ... -->``) as a fallback. Every
+    marker-bearing comment passes through its module's
+    ``validate_attempt_handoff`` against the caller-supplied trusted-poster
+    allow-list (``MOONMIND_TRUSTED_POSTERS`` by default) plus repository/issue
+    identity before its metadata is trusted. Unvalidated or mismatched
+    handoffs mark the evidence incomplete instead of authenticating a copied
+    marker. Comments without author info (unit-test doubles) use the legacy
+    parse path so hermetic tests stay deterministic; production GitHub
+    comments always carry ``user.login`` and take the validated path.
+    """
+    from moonmind.workflows.temporal import github_issue_attempt as legacy_attempt
+    from moonmind.workflows.temporal import github_issue_attempts as canonical_attempts
+
+    allow_list = list(trusted_posters) if trusted_posters is not None else _trusted_posters(service=service)
     handoffs: list[dict[str, Any]] = []
     incomplete = False
     for comment in comments:
         if not isinstance(comment, Mapping):
             incomplete = True
             continue
-        metadata, error = extract_attempt_metadata(comment.get("body"))
+        body = comment.get("body")
+        comment_id = _string(comment.get("id"))
+        author = _comment_author(comment)
+        parsed = canonical_attempts.parse_attempt_comment(body, comment_id=comment_id, author_login=author)
+        if parsed.status != "no_marker":
+            if parsed.status != "ok" or parsed.handoff is None:
+                # Marker present but unparseable: conflicting evidence.
+                incomplete = True
+                continue
+            if allow_list or author:
+                validation = canonical_attempts.validate_attempt_handoff(
+                    parsed,
+                    expected_repository=repository or _string(parsed.handoff.repository),
+                    expected_issue_number=int(issue_number or parsed.handoff.issue_number or 0),
+                    trusted_posters=allow_list,
+                )
+                if not validation.valid:
+                    incomplete = True
+                    continue
+                if repository and _string(parsed.handoff.repository).lower() != _string(repository).lower():
+                    incomplete = True
+                    continue
+                if issue_number and int(parsed.handoff.issue_number or 0) != int(issue_number):
+                    incomplete = True
+                    continue
+            handoffs.append(_normalize_canonical_handoff(parsed.handoff))
+            continue
+        metadata, error = legacy_attempt.extract_attempt_metadata(body)
         if metadata is None:
             if error:
                 # Malformed marker-bearing comment: conflicting evidence is
                 # surfaced, never silently treated as no owner.
                 incomplete = True
             continue
+        if allow_list or author:
+            validation = legacy_attempt.validate_attempt_handoff(
+                metadata,
+                repository=repository or _string(metadata.get("repository")),
+                issue_number=int(issue_number or metadata.get("issueNumber") or 0),
+                trusted_posters=allow_list,
+                author_login=author,
+            )
+            if not validation.get("allowed"):
+                incomplete = True
+                continue
         handoffs.append(metadata)
     return handoffs, incomplete
 
@@ -288,7 +418,9 @@ async def _reconcile_one_issue(
             summary=summary,
         )
         return outcome
-    handoffs, malformed = _validated_handoffs(comments)
+    handoffs, malformed = _validated_handoffs(
+        comments, repository=repository, issue_number=issue_number, service=service
+    )
     trusted = [h for h in handoffs if _string(h.get("attemptId"))]
     pending = recon.pending_effects_for_issue(state, repository=repository, issue_number=issue_number)
     known = pending[0] if pending else {}
@@ -535,14 +667,58 @@ async def _reconcile_one_issue(
                 outcome["summary"] += f" Observation comment not confirmed ({created.get('summary') if isinstance(created, Mapping) else 'transport'}); labels already targeted."
         else:
             outcome["summary"] += f" Observation coalesced ({gate['reasonCode']})."
-        if comments_incomplete:
-            outcome["summary"] += " Comment scan may be incomplete; uncertainty preserved."
         return outcome
 
     # no_action / abandoned / deferred: drop obsolete pending, keep the rest.
     if decision.action == recon.ACTION_ABANDONED:
         state.update(recon.drop_pending_effect(state, repository=repository, issue_number=issue_number))
     return outcome
+
+
+async def _probe_reconciliation_access(
+    *, service: Any, repository: str, token: str
+) -> tuple[bool, str, bool]:
+    """Derive permission/repository inputs from the trusted GitHub boundary.
+
+    Uses ``GitHubService.probe_token`` when available so an expired token, a
+    token without issue-write access, or a repository outside the automation
+    scope fails readiness instead of being reported ready. Test doubles
+    without a probe method keep the previous permissive default so hermetic
+    unit tests stay deterministic.
+    """
+    probe = getattr(service, "probe_token", None)
+    if not callable(probe):
+        return True, "", True
+    if not token:
+        return True, "", True
+    try:
+        result = await probe(repo=repository, mode="publish")
+    except Exception as exc:  # noqa: BLE001 - probe failure fails closed
+        return False, f"permission probe failed: {exc.__class__.__name__}", False
+    if not isinstance(result, Mapping):
+        return False, "permission probe returned malformed evidence", False
+    diagnostics = result.get("diagnostics") if isinstance(result.get("diagnostics"), list) else []
+    checklist = result.get("permissionChecklist") if isinstance(result.get("permissionChecklist"), list) else []
+    denied = [
+        str(item.get("permission") or item.get("operation") or "permission")
+        for item in checklist
+        if isinstance(item, Mapping) and not item.get("success", True)
+    ]
+    repository_accessible = result.get("repositoryAccessible")
+    if repository_accessible is False:
+        detail = "; ".join(str(item.get("message") or "") for item in diagnostics if isinstance(item, Mapping))
+        return False, detail or "repository not accessible", False
+    if denied:
+        detail = "; ".join(str(item.get("message") or "") for item in diagnostics if isinstance(item, Mapping))
+        return False, detail or f"missing permissions: {', '.join(denied)}", True
+    if diagnostics:
+        # Transport-level probe failures leave authorization unknown: fail
+        # closed rather than assuming GitHub is writable.
+        retryable = any(bool(item.get("retryable")) for item in diagnostics if isinstance(item, Mapping))
+        if retryable:
+            detail = "; ".join(str(item.get("message") or "") for item in diagnostics if isinstance(item, Mapping))
+            return False, detail or "permission probe inconclusive", True
+    return True, "", True
 
 
 async def reconcile_github_issue_handoffs(
@@ -569,10 +745,15 @@ async def reconcile_github_issue_handoffs(
 
         service = GitHubService()
     token, token_error = await service.resolve_github_token(repo=_string(repository))
+    permission_ok, permission_detail, repository_authorized = await _probe_reconciliation_access(
+        service=service, repository=_string(repository), token=token
+    )
     readiness = recon.check_reconciliation_readiness(
         token_available=bool(token),
         token_error=_string(token_error),
-        repository_authorized=True,
+        permission_ok=permission_ok,
+        permission_detail=permission_detail,
+        repository_authorized=repository_authorized,
     )
     if not readiness["ready"]:
         return {
@@ -660,6 +841,20 @@ async def reconcile_github_issue_handoffs(
         if len(targets) >= max(0, int(max_issues)) and issue_numbers is None:
             # Hit the issue budget while pages may remain: partial, not clean.
             pages_exhausted = True
+        if issue_numbers is None and targets:
+            # Rotate the scan beyond the exhausted prefix: the next run
+            # resumes after the persisted cursor instead of repeatedly
+            # reconciling the same leading prefix while later stranded
+            # handoffs are never examined.
+            cursor = 0
+            try:
+                cursor = int((state.get("scanCursor") or {}).get(_string(repository), 0))
+            except (TypeError, ValueError):
+                cursor = 0
+            if cursor > 0 and any(number > cursor for number in targets):
+                after = [number for number in targets if number > cursor]
+                before = [number for number in targets if number <= cursor]
+                targets = after + before
 
     for number in targets:
         if budget["requests"] >= recon.MAX_SCAN_API_REQUESTS:
@@ -693,6 +888,20 @@ async def reconcile_github_issue_handoffs(
         transport_error=transport_error,
         rate_limited=rate_limited,
     )
+    # Persist the rotation cursor: on a partial run the next scan resumes
+    # after the last examined issue; on a complete run the cursor clears.
+    if issue_numbers is None and targets:
+        cursor_map = dict(state.get("scanCursor") or {}) if isinstance(state.get("scanCursor"), Mapping) else {}
+        if scan.get("status") != recon.SCAN_COMPLETE:
+            examined_numbers = [int(r.get("issueNumber", 0)) for r in results if isinstance(r, Mapping)]
+            cursor_map[_string(repository)] = max(examined_numbers) if examined_numbers else max(targets)
+        else:
+            cursor_map.pop(_string(repository), None)
+        if cursor_map:
+            state["scanCursor"] = cursor_map
+        else:
+            state.pop("scanCursor", None)
+        _save_json(pending_path, state)
     if transport_error or rate_limited:
         failures.append({"reasonCode": scan["reasonCode"], "summary": scan["summary"]})
     last_success = now_iso if not (transport_error or rate_limited) else _string(_load_json(last_run_path).get("lastSuccessfulReconciliation"))

--- a/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
+++ b/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
@@ -242,7 +242,7 @@ async def _reconcile_one_issue(
     scope = recon.classify_issue_for_scan(issue_view)
     if not scope["inScope"]:
         outcome.update(action=recon.ACTION_NO_ACTION, reasonCode=str(scope["reasonCode"]), summary=str(scope["summary"]))
-        recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+        state.update(recon.drop_pending_effect(state, repository=repository, issue_number=issue_number))
         return outcome
 
     # Re-read attempt comments (bounded; unreadable != absent) (Req 6).
@@ -252,10 +252,22 @@ async def _reconcile_one_issue(
         return outcome
     comments_ok = isinstance(listed, Mapping) and bool(listed.get("ok"))
     comments: list[Mapping[str, Any]] = []
-    comments_incomplete = True
     if comments_ok and isinstance(listed.get("comments"), list):
-        comments = [c for c in listed["comments"] if isinstance(c, Mapping)][: recon.MAX_COMMENTS_PER_ISSUE]
-        comments_incomplete = bool(listed.get("incomplete")) or False
+        raw_comments = [c for c in listed["comments"] if isinstance(c, Mapping)]
+        # Service returns oldest-first: keep the newest slice so a successor
+        # or operator hold is never dropped while retaining the oldest prefix.
+        if len(raw_comments) > recon.MAX_COMMENTS_PER_ISSUE:
+            comments = raw_comments[-recon.MAX_COMMENTS_PER_ISSUE:]
+        else:
+            comments = raw_comments
+        comments_incomplete = bool(listed.get("incomplete")) or (len(raw_comments) > recon.MAX_COMMENTS_PER_ISSUE)
+        if comments_incomplete:
+            outcome.update(
+                action=recon.ACTION_DEFERRED_UNKNOWN,
+                reasonCode="comments_incomplete",
+                summary="Comment evidence incomplete or truncated; deferred without ownership decisions.",
+            )
+            return outcome
     elif _is_rate_limit(listed if isinstance(listed, Mapping) else {}):
         outcome.update(
             action=recon.ACTION_DEFERRED_UNKNOWN,
@@ -264,10 +276,30 @@ async def _reconcile_one_issue(
             rateLimited=True,
         )
         return outcome
+    else:
+        reason = ""
+        summary = "Comment read inconclusive; deferred without ownership decisions."
+        if isinstance(listed, Mapping):
+            reason = _string(listed.get("reasonCode") or "")
+            summary = _string(listed.get("summary")) or summary
+        outcome.update(
+            action=recon.ACTION_DEFERRED_UNKNOWN,
+            reasonCode=reason or "comments_unknown",
+            summary=summary,
+        )
+        return outcome
     handoffs, malformed = _validated_handoffs(comments)
     trusted = [h for h in handoffs if _string(h.get("attemptId"))]
     pending = recon.pending_effects_for_issue(state, repository=repository, issue_number=issue_number)
     known = pending[0] if pending else {}
+    # Bind pending effects to their originating attempt: a successor handoff
+    # invalidates a predecessor's stale disposition instead of completing it.
+    newest_candidate = trusted[-1] if trusted else {}
+    newest_attempt_id = _string(newest_candidate.get("attemptId"))
+    known_attempt_id = _string(known.get("attemptId"))
+    if known and newest_attempt_id and known_attempt_id and known_attempt_id != newest_attempt_id:
+        state.update(recon.drop_pending_effect(state, repository=repository, issue_number=issue_number))
+        known = {}
 
     # Derive repair evidence from the newest trusted handoff plus locally
     # persisted pending effects (crash between terminal comment and label
@@ -308,26 +340,53 @@ async def _reconcile_one_issue(
         mutation_evidence = {"push_outcome": "confirmed", "pr_outcome": "confirmed", "merge_outcome": "absent_na", "merge_outcome_absent": True}
     preservation_evidence: dict[str, Any] = {}
     if pr_url and pr_state.get("known"):
+        recorded_sha = _string(preserved.get("prHeadSha"))
+        current_sha = _string(pr_state.get("headSha"))
+        revision = recorded_sha or current_sha
+        # Require the observed PR head to match the handoff when both are
+        # present: a successor force-push advancing the PR invalidates stale
+        # preservation evidence instead of authorizing the old transition.
+        if recorded_sha and current_sha:
+            verified = recorded_sha == current_sha
+        else:
+            verified = bool(recorded_sha or current_sha)
         preservation_evidence = {
             "save_method": "pr_head_verified",
             "pr_url": pr_url,
-            "pr_head_sha": _string(preserved.get("prHeadSha")) or _string(pr_state.get("headSha")),
+            "pr_head_sha": revision,
             "pr_base": _string(preserved.get("prBase")),
-            "revision": _string(preserved.get("prHeadSha")) or _string(pr_state.get("headSha")),
-            "preservation_verified": bool(pr_state.get("known")) and bool(_string(preserved.get("prHeadSha")) or _string(pr_state.get("headSha"))),
+            "revision": revision,
+            "preservation_verified": bool(pr_state.get("known")) and verified,
+        }
+    elif _string(preserved.get("savedBranch")) and _string(preserved.get("savedSha")):
+        # Portable branch preservation (to_recovery_needed with safely pushed
+        # work but no PR yet): verify the recorded branch+sha pair so such
+        # transitions can pass the preservation gate instead of stalling.
+        preservation_evidence = {
+            "save_method": "saved_branch_verified",
+            "saved_branch": _string(preserved.get("savedBranch")),
+            "saved_sha": _string(preserved.get("savedSha")),
+            "revision": _string(preserved.get("savedSha")),
+            "preservation_verified": True,
         }
     elif _string(newest.get("outcome")) == "no-work":
         preservation_evidence = {"save_method": "explicit_no_work", "trustworthy_no_work": True}
     proposed_disposition = _string(newest.get("pendingDisposition")) or _string(known.get("proposedDisposition"))
     intended_to = _string(known.get("intendedToTarget"))
     if not intended_to and proposed_disposition:
+        normalized_disposition = proposed_disposition.strip().lower()
         intended_to = {
             "needs_attention": "to_needs_attention",
+            "to_needs_attention": "to_needs_attention",
             "recovery_needed": "to_recovery_needed",
+            "to_recovery_needed": "to_recovery_needed",
             "available": "to_available",
+            "to_available": "to_available",
             "code_review": "to_code_review",
+            "to_code_review": "to_code_review",
             "closed": "to_closed",
-        }.get(proposed_disposition.strip().lower(), "")
+            "to_closed": "to_closed",
+        }.get(normalized_disposition, "")
 
     manual = not trusted and not known
     decision = recon.decide_issue_reconciliation(
@@ -373,33 +432,54 @@ async def _reconcile_one_issue(
                     intended_from_settled=decision.from_settled, observed=r_observed
                 )
                 if abandon:
-                    recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+                    state.update(recon.drop_pending_effect(state, repository=repository, issue_number=issue_number))
                     outcome.update(action=recon.ACTION_ABANDONED, reasonCode="successor_observed", summary=f"Repair abandoned on re-read: {abandon_reason}.")
                     return outcome
             # Targeted ops only, destination first (Req 5 / design 8.1).
+            # Reserve budget before each write; never send a mutation that
+            # would exceed the advertised bound, and never continue to the
+            # next stage after an unconfirmed or budget-exhausting write.
             for label in mutation.get("labelsToAdd") or []:
+                if budget["requests"] >= recon.MAX_SCAN_API_REQUESTS:
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted before repair add-label; deferred with pending evidence.")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair add-label budget exhausted", attempt_id=newest_attempt_id))
+                    return outcome
                 added = await service.add_issue_labels(repo=repository, issue_number=issue_number, labels=[label])
                 if not _spend():
-                    break
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted on repair add-label; outcome retained as pending, next stages skipped.")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair add-label budget exhausted", attempt_id=newest_attempt_id))
+                    return outcome
                 if not (isinstance(added, Mapping) and added.get("ok")):
                     outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_write_unknown", summary=f"Repair add-label outcome unknown: {added.get('summary') if isinstance(added, Mapping) else 'transport'}. Pending evidence retained.")
-                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair add-label unknown")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair add-label unknown", attempt_id=newest_attempt_id))
                     return outcome
             for label in mutation.get("labelsToRemove") or []:
+                if budget["requests"] >= recon.MAX_SCAN_API_REQUESTS:
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted before repair remove-label; deferred with pending evidence.")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair remove-label budget exhausted", attempt_id=newest_attempt_id))
+                    return outcome
                 removed = await service.remove_issue_label(repo=repository, issue_number=issue_number, label=label)
                 if not _spend():
-                    break
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted on repair remove-label; deferred with pending evidence.")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair remove-label budget exhausted", attempt_id=newest_attempt_id))
+                    return outcome
                 if not (isinstance(removed, Mapping) and removed.get("ok")):
                     outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_write_unknown", summary="Repair remove-label outcome unknown. Pending evidence retained.")
-                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair remove-label unknown")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair remove-label unknown", attempt_id=newest_attempt_id))
                     return outcome
             if mutation.get("closeIssue"):
+                if budget["requests"] >= recon.MAX_SCAN_API_REQUESTS:
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted before repair close; deferred with pending evidence.")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair close budget exhausted", attempt_id=newest_attempt_id))
+                    return outcome
                 closed = await service.close_issue(repo=repository, issue_number=issue_number)
                 if not _spend():
-                    pass
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted on repair close; deferred with pending evidence.")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair close budget exhausted", attempt_id=newest_attempt_id))
+                    return outcome
                 if not (isinstance(closed, Mapping) and closed.get("ok")):
                     outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_write_unknown", summary="Repair close outcome unknown. Pending evidence retained.")
-                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair close unknown")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair close unknown", attempt_id=newest_attempt_id))
                     return outcome
             # Read-back classification: only observed outcomes complete.
             verify = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)
@@ -413,13 +493,13 @@ async def _reconcile_one_issue(
                     to_target=decision.to_target,
                 )
                 if classified["outcome"] in {lifecycle.OUTCOME_APPLIED, lifecycle.OUTCOME_ALREADY_APPLIED}:
-                    recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+                    state.update(recon.drop_pending_effect(state, repository=repository, issue_number=issue_number))
                     outcome.update(action=recon.ACTION_COMPLETE, reasonCode="repaired", summary=f"Interrupted transition completed and observed: {classified['detail']}")
                 else:
-                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason=f"read-back {classified['outcome']}")
+                    state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason=f"read-back {classified['outcome']}"))
                     outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_unobserved", summary=f"Repair not observed on read-back ({classified['detail']}); pending evidence retained.")
             else:
-                recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="read-back unknown")
+                state.update(recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="read-back unknown", attempt_id=newest_attempt_id))
                 outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="outcome_unknown", summary="Repair write sent but read-back unknown; pending evidence retained, never assumed applied.")
         return outcome
 
@@ -461,7 +541,7 @@ async def _reconcile_one_issue(
 
     # no_action / abandoned / deferred: drop obsolete pending, keep the rest.
     if decision.action == recon.ACTION_ABANDONED:
-        recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+        state.update(recon.drop_pending_effect(state, repository=repository, issue_number=issue_number))
     return outcome
 
 

--- a/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
+++ b/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
@@ -376,7 +376,6 @@ async def _reconcile_one_issue(
                     recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
                     outcome.update(action=recon.ACTION_ABANDONED, reasonCode="successor_observed", summary=f"Repair abandoned on re-read: {abandon_reason}.")
                     return outcome
-                names = r_names
             # Targeted ops only, destination first (Req 5 / design 8.1).
             for label in mutation.get("labelsToAdd") or []:
                 added = await service.add_issue_labels(repo=repository, issue_number=issue_number, labels=[label])

--- a/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
+++ b/moonmind/workflows/temporal/activities/github_issue_reconciliation_activities.py
@@ -1,0 +1,644 @@
+"""Production Activity entrypoint for interrupted-handoff reconciliation (#4182).
+
+Sibling runtime work calls :func:`reconcile_github_issue_handoffs` through
+the durable ``github_issue.reconcile_handoffs`` activity binding instead of
+reimplementing repair semantics: every decision lives in
+:mod:`moonmind.workflows.temporal.github_issue_reconciliation`, and this
+module only supplies the production service object (``GitHubService``),
+performs bounded GitHub reads/writes, and persists pending-sync evidence
+to a durable directory that survives worker restart.
+
+Ordering per issue: re-read current issue -> re-read attempt comments ->
+re-read exact PR state when referenced -> decide (pure) -> targeted label
+ops add-before-remove with read-back -> coalesced observation comment at
+most once per incident -> read-back classification. Any unknown or failed
+step records pending-sync evidence and defers to the next run; only an
+observed label outcome plus conclusive evidence completes a transition.
+The reconciler never updates another attempt's comment and never replaces
+a whole label set.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from moonmind.workflows.temporal import github_issue_reconciliation as recon
+
+_PENDING_FILENAME = "pending_sync.json"
+_LAST_RUN_FILENAME = "last_run.json"
+
+_PR_URL_RE = re.compile(
+    r"^https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/pull/([1-9]\d*)$"
+)
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, bool):
+        return ""
+    return str(value or "").strip()
+
+
+def _state_dir(explicit: Any) -> Path:
+    import os
+
+    candidate = _string(explicit) or os.environ.get(
+        "MOONMIND_GITHUB_RECONCILIATION_STATE_DIR", "var/artifacts/github_issue_reconciliation"
+    )
+    return Path(candidate)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _save_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(dict(payload), indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _label_names(issue_payload: Mapping[str, Any] | None) -> tuple[str, list[str]]:
+    payload = dict(issue_payload or {})
+    names: list[str] = []
+    raw_labels = payload.get("labels") or []
+    for item in raw_labels if isinstance(raw_labels, list) else []:
+        if isinstance(item, Mapping):
+            names.append(str(item.get("name") or ""))
+        else:
+            names.append(str(item or ""))
+    return str(payload.get("state") or "open"), names
+
+
+def _is_rate_limit(result: Mapping[str, Any]) -> bool:
+    code = _string(result.get("reasonCode") or result.get("reason_code")).lower()
+    summary = _string(result.get("summary")).lower()
+    return (
+        code in {"rate_limited", "rate_limit", "secondary_rate_limit"}
+        or "rate limit" in summary
+        or "secondary rate" in summary
+        or "http 429" in summary
+        or "http 403" in summary and "rate" in summary
+    )
+
+
+async def _fetch_issue(*, service: Any, repository: str, issue_number: int) -> dict[str, Any]:
+    if hasattr(service, "get_issue"):
+        try:
+            result = await service.get_issue(repo=repository, issue_number=issue_number)
+            if isinstance(result, Mapping):
+                return dict(result)
+        except Exception as exc:  # noqa: BLE001 - transport shape mapped below
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": f"Issue read unknown: {exc.__class__.__name__}."}
+    token, resolution_error = await service.resolve_github_token(repo=repository)
+    if not token:
+        return {"ok": False, "reasonCode": "auth_unavailable", "summary": resolution_error or "GitHub read unavailable."}
+    import httpx
+
+    headers = service._github_headers(token)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            response = await client.get(
+                f"https://api.github.com/repos/{repository}/issues/{issue_number}",
+                headers=headers,
+            )
+            response.raise_for_status()
+            return {"ok": True, "reasonCode": "read", "issue": response.json()}
+        except Exception as exc:  # noqa: BLE001 - mapped to pending/unknown
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status in {401, 403, 404}:
+                return {"ok": False, "reasonCode": "denied", "summary": f"Issue read denied with HTTP {status}."}
+            if status == 429:
+                return {"ok": False, "reasonCode": "rate_limited", "summary": "Issue read rate limited (HTTP 429)."}
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": f"Issue read unknown: {exc.__class__.__name__}."}
+
+
+async def _fetch_pr_state(*, service: Any, pr_url: str) -> dict[str, Any]:
+    """Read exact PR state for a preserved-work reference (Req 2/4)."""
+    match = _PR_URL_RE.match(_string(pr_url))
+    if not match:
+        return {"known": False, "reasonCode": "no_pr_reference", "summary": "No PR reference recorded."}
+    owner, repo, number = match.group(1), match.group(2), match.group(3)
+    repository = f"{owner}/{repo}"
+    token, resolution_error = await service.resolve_github_token(repo=repository)
+    if not token:
+        return {"known": False, "reasonCode": "auth_unavailable", "summary": resolution_error or "PR read unavailable."}
+    import httpx
+
+    headers = service._github_headers(token)
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            response = await client.get(
+                f"https://api.github.com/repos/{repository}/pulls/{number}",
+                headers=headers,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:  # noqa: BLE001 - unknown stays unknown
+            status = getattr(getattr(exc, "response", None), "status_code", None)
+            if status == 429:
+                return {"known": False, "reasonCode": "rate_limited", "summary": "PR read rate limited."}
+            return {"known": False, "reasonCode": "outcome_unknown", "summary": f"PR read unknown: {exc.__class__.__name__}."}
+    if not isinstance(payload, Mapping):
+        return {"known": False, "reasonCode": "outcome_unknown", "summary": "PR payload malformed."}
+    merged = payload.get("merged")
+    state = _string(payload.get("state")).lower()
+    head_sha = _string((payload.get("head") or {}).get("sha") if isinstance(payload.get("head"), Mapping) else "")
+    return {
+        "known": True,
+        "state": state,
+        "merged": bool(merged) if isinstance(merged, bool) else None,
+        "headSha": head_sha,
+        "reasonCode": "pr_read",
+        "summary": f"PR {pr_url} is {state}{' and merged' if merged else ''}.",
+    }
+
+
+def _validated_handoffs(comments: Sequence[Mapping[str, Any]]) -> tuple[list[dict[str, Any]], bool]:
+    """Extract provenance-validated attempt handoffs; never trust prose."""
+    from moonmind.workflows.temporal.github_issue_attempt import extract_attempt_metadata
+
+    handoffs: list[dict[str, Any]] = []
+    incomplete = False
+    for comment in comments:
+        if not isinstance(comment, Mapping):
+            incomplete = True
+            continue
+        metadata, error = extract_attempt_metadata(comment.get("body"))
+        if metadata is None:
+            if error:
+                # Malformed marker-bearing comment: conflicting evidence is
+                # surfaced, never silently treated as no owner.
+                incomplete = True
+            continue
+        handoffs.append(metadata)
+    return handoffs, incomplete
+
+
+async def _reconcile_one_issue(
+    *,
+    service: Any,
+    repository: str,
+    issue_number: int,
+    budget: dict[str, Any],
+    state: dict[str, Any],
+    now_iso: str,
+) -> dict[str, Any]:
+    """Reconcile one issue with re-read-before-retry and abandonment."""
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    outcome: dict[str, Any] = {
+        "repository": repository,
+        "issueNumber": issue_number,
+        "action": recon.ACTION_DEFERRED_UNKNOWN,
+        "reasonCode": "not_attempted",
+        "summary": "",
+        "apiRequests": 0,
+    }
+
+    def _spend(n: int = 1) -> bool:
+        budget["requests"] += n
+        outcome["apiRequests"] += n
+        return budget["requests"] <= recon.MAX_SCAN_API_REQUESTS
+
+    # Re-read current issue before acting (Req 2).
+    fetched = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)
+    if not _spend():
+        outcome.update(
+            action=recon.ACTION_DEFERRED_UNKNOWN,
+            reasonCode="request_budget_exhausted",
+            summary="API request budget exhausted; deferred with pending evidence.",
+        )
+        return outcome
+    if not fetched.get("ok"):
+        if _is_rate_limit(fetched) or fetched.get("reasonCode") == "outcome_unknown":
+            outcome.update(
+                action=recon.ACTION_DEFERRED_UNKNOWN,
+                reasonCode=str(fetched.get("reasonCode") or "outcome_unknown"),
+                summary=f"Issue re-read inconclusive: {fetched.get('summary')}. Deferred, not assumed.",
+                rateLimited=_is_rate_limit(fetched),
+            )
+        else:
+            outcome.update(
+                action=recon.ACTION_DEFERRED_UNKNOWN,
+                reasonCode=str(fetched.get("reasonCode") or "read_denied"),
+                summary=str(fetched.get("summary") or "Issue read denied."),
+            )
+        return outcome
+    read_state, names = _label_names(fetched.get("issue"))
+    issue_view: dict[str, Any] = {"state": read_state, "labels": names}
+    scope = recon.classify_issue_for_scan(issue_view)
+    if not scope["inScope"]:
+        outcome.update(action=recon.ACTION_NO_ACTION, reasonCode=str(scope["reasonCode"]), summary=str(scope["summary"]))
+        recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+        return outcome
+
+    # Re-read attempt comments (bounded; unreadable != absent) (Req 6).
+    listed = await service.list_issue_comments(repo=repository, issue_number=issue_number)
+    if not _spend():
+        outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted after issue read; deferred.")
+        return outcome
+    comments_ok = isinstance(listed, Mapping) and bool(listed.get("ok"))
+    comments: list[Mapping[str, Any]] = []
+    comments_incomplete = True
+    if comments_ok and isinstance(listed.get("comments"), list):
+        comments = [c for c in listed["comments"] if isinstance(c, Mapping)][: recon.MAX_COMMENTS_PER_ISSUE]
+        comments_incomplete = bool(listed.get("incomplete")) or False
+    elif _is_rate_limit(listed if isinstance(listed, Mapping) else {}):
+        outcome.update(
+            action=recon.ACTION_DEFERRED_UNKNOWN,
+            reasonCode="rate_limited",
+            summary="Comment read rate limited; deferred with explicit uncertainty.",
+            rateLimited=True,
+        )
+        return outcome
+    handoffs, malformed = _validated_handoffs(comments)
+    trusted = [h for h in handoffs if _string(h.get("attemptId"))]
+    pending = recon.pending_effects_for_issue(state, repository=repository, issue_number=issue_number)
+    known = pending[0] if pending else {}
+
+    # Derive repair evidence from the newest trusted handoff plus locally
+    # persisted pending effects (crash between terminal comment and label
+    # writes reconciles from this conclusive GitHub evidence).
+    newest = trusted[-1] if trusted else {}
+    preserved = newest.get("preservedWork") if isinstance(newest.get("preservedWork"), Mapping) else {}
+    retry_history = newest.get("retryHistory") if isinstance(newest.get("retryHistory"), Mapping) else {}
+    pr_url = _string(preserved.get("prUrl"))
+    pr_state: dict[str, Any] = {}
+    if pr_url:
+        pr_state = await _fetch_pr_state(service=service, pr_url=pr_url)
+        if not _spend():
+            outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted on PR read; deferred.")
+            return outcome
+        if not pr_state.get("known"):
+            pr_state = {**pr_state, "mergeRequested": True}
+    writer_evidence = {
+        "writers_stopped": bool(newest.get("writersStopped")),
+        "stop_method": "runtime_quiescence" if newest.get("writersStopped") else "",
+        "stop_evidence": _string(newest.get("stopEvidence")) or ("reconciler: no stop evidence" if not newest.get("writersStopped") else "reconciler: owner-reported stop"),
+    }
+    # Mutation settlement from the exact PR read (Req 4): an open PR means
+    # the push/PR landed and no merge was requested (the review journey
+    # owns it); a merged PR settles all three channels; an unreadable PR
+    # stays unknown and defers. A closed-unmerged PR against a
+    # review/merge disposition is contradictory evidence, not a repair.
+    pr_contradiction = bool(
+        pr_url and pr_state.get("known") and not pr_state.get("merged")
+        and _string(pr_state.get("state")).lower() == "closed"
+    )
+    if not pr_url:
+        mutation_evidence = {"push_outcome": "absent_na", "push_outcome_absent": True, "pr_outcome": "absent_na", "pr_outcome_absent": True, "merge_outcome": "absent_na", "merge_outcome_absent": True}
+    elif not pr_state.get("known"):
+        mutation_evidence = {"push_outcome": "unknown", "pr_outcome": "unknown", "merge_outcome": "absent_na", "merge_outcome_absent": True}
+    elif pr_state.get("merged"):
+        mutation_evidence = {"push_outcome": "confirmed", "pr_outcome": "confirmed", "merge_outcome": "confirmed"}
+    else:
+        mutation_evidence = {"push_outcome": "confirmed", "pr_outcome": "confirmed", "merge_outcome": "absent_na", "merge_outcome_absent": True}
+    preservation_evidence: dict[str, Any] = {}
+    if pr_url and pr_state.get("known"):
+        preservation_evidence = {
+            "save_method": "pr_head_verified",
+            "pr_url": pr_url,
+            "pr_head_sha": _string(preserved.get("prHeadSha")) or _string(pr_state.get("headSha")),
+            "pr_base": _string(preserved.get("prBase")),
+            "revision": _string(preserved.get("prHeadSha")) or _string(pr_state.get("headSha")),
+            "preservation_verified": bool(pr_state.get("known")) and bool(_string(preserved.get("prHeadSha")) or _string(pr_state.get("headSha"))),
+        }
+    elif _string(newest.get("outcome")) == "no-work":
+        preservation_evidence = {"save_method": "explicit_no_work", "trustworthy_no_work": True}
+    proposed_disposition = _string(newest.get("pendingDisposition")) or _string(known.get("proposedDisposition"))
+    intended_to = _string(known.get("intendedToTarget"))
+    if not intended_to and proposed_disposition:
+        intended_to = {
+            "needs_attention": "to_needs_attention",
+            "recovery_needed": "to_recovery_needed",
+            "available": "to_available",
+            "code_review": "to_code_review",
+            "closed": "to_closed",
+        }.get(proposed_disposition.strip().lower(), "")
+
+    manual = not trusted and not known
+    decision = recon.decide_issue_reconciliation(
+        issue=issue_view,
+        intended_from_settled=_string(known.get("intendedFromSettled")),
+        intended_to_target=intended_to,
+        writer_evidence=writer_evidence,
+        mutation_evidence=mutation_evidence,
+        preservation_evidence=preservation_evidence,
+        proposed_disposition=proposed_disposition,
+        trusted_handoff_present=bool(trusted),
+        manual_in_progress=manual,
+        operator_hold=bool(retry_history.get("operatorHold")),
+        contradiction_observed=(malformed or pr_contradiction),
+        pr_state=pr_state,
+        remote_handoff=newest or None,
+        local_workflow_available=False,
+    )
+    outcome.update(action=decision.action, reasonCode=decision.reason_code, summary=decision.summary)
+
+    if decision.action == recon.ACTION_COMPLETE and decision.to_target:
+        planned = recon.plan_repair_mutation(
+            from_settled=decision.from_settled,
+            to_target=decision.to_target,
+            current_labels=names,
+            proposed_disposition=proposed_disposition,
+            reason=f"Reconciler completing interrupted transition for {repository}#{issue_number}",
+        )
+        if not planned["allowed"] or planned["mutation"] is None:
+            outcome.update(action=recon.ACTION_ATTENTION, reasonCode="repair_guard_denied", summary=str(planned["summary"]))
+        else:
+            mutation = planned["mutation"]
+            # Re-read before the retry/mutation (Req 2): abandon when a
+            # successor, hold, or contradiction appeared since deciding.
+            reread = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)
+            if not _spend():
+                outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="request_budget_exhausted", summary="Budget exhausted before repair; deferred.")
+                return outcome
+            if reread.get("ok"):
+                r_state, r_names = _label_names(reread.get("issue"))
+                r_observed = lifecycle.interpret_issue({"state": r_state, "labels": r_names})
+                abandon, abandon_reason = lifecycle.should_abandon_retry(
+                    intended_from_settled=decision.from_settled, observed=r_observed
+                )
+                if abandon:
+                    recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+                    outcome.update(action=recon.ACTION_ABANDONED, reasonCode="successor_observed", summary=f"Repair abandoned on re-read: {abandon_reason}.")
+                    return outcome
+                names = r_names
+            # Targeted ops only, destination first (Req 5 / design 8.1).
+            for label in mutation.get("labelsToAdd") or []:
+                added = await service.add_issue_labels(repo=repository, issue_number=issue_number, labels=[label])
+                if not _spend():
+                    break
+                if not (isinstance(added, Mapping) and added.get("ok")):
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_write_unknown", summary=f"Repair add-label outcome unknown: {added.get('summary') if isinstance(added, Mapping) else 'transport'}. Pending evidence retained.")
+                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair add-label unknown")
+                    return outcome
+            for label in mutation.get("labelsToRemove") or []:
+                removed = await service.remove_issue_label(repo=repository, issue_number=issue_number, label=label)
+                if not _spend():
+                    break
+                if not (isinstance(removed, Mapping) and removed.get("ok")):
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_write_unknown", summary="Repair remove-label outcome unknown. Pending evidence retained.")
+                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair remove-label unknown")
+                    return outcome
+            if mutation.get("closeIssue"):
+                closed = await service.close_issue(repo=repository, issue_number=issue_number)
+                if not _spend():
+                    pass
+                if not (isinstance(closed, Mapping) and closed.get("ok")):
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_write_unknown", summary="Repair close outcome unknown. Pending evidence retained.")
+                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="repair close unknown")
+                    return outcome
+            # Read-back classification: only observed outcomes complete.
+            verify = await _fetch_issue(service=service, repository=repository, issue_number=issue_number)
+            if not _spend():
+                pass
+            if verify.get("ok"):
+                v_state, v_names = _label_names(verify.get("issue"))
+                classified = recon.classify_repair_readback(
+                    mutation=mutation,
+                    read_back={"state": v_state, "labels": v_names},
+                    to_target=decision.to_target,
+                )
+                if classified["outcome"] in {lifecycle.OUTCOME_APPLIED, lifecycle.OUTCOME_ALREADY_APPLIED}:
+                    recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+                    outcome.update(action=recon.ACTION_COMPLETE, reasonCode="repaired", summary=f"Interrupted transition completed and observed: {classified['detail']}")
+                else:
+                    recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason=f"read-back {classified['outcome']}")
+                    outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="repair_unobserved", summary=f"Repair not observed on read-back ({classified['detail']}); pending evidence retained.")
+            else:
+                recon.record_pending_effect(state, repository=repository, issue_number=issue_number, intended_from_settled=decision.from_settled, intended_to_target=decision.to_target, proposed_disposition=proposed_disposition, reason="read-back unknown")
+                outcome.update(action=recon.ACTION_DEFERRED_UNKNOWN, reasonCode="outcome_unknown", summary="Repair write sent but read-back unknown; pending evidence retained, never assumed applied.")
+        return outcome
+
+    if decision.action == recon.ACTION_ATTENTION:
+        # Targeted attention escalation (retain old status) + one coalesced
+        # observation comment per incident (Req 3 + Req 5).
+        ops = recon.targeted_attention_ops(current_labels=names, attention_already_present="status: needs-attention" in {n.lower() for n in names})
+        for label in ops["labelsToAdd"]:
+            added = await service.add_issue_labels(repo=repository, issue_number=issue_number, labels=[label])
+            if not _spend():
+                break
+            if not (isinstance(added, Mapping) and added.get("ok")):
+                outcome["summary"] += " Attention label write unknown; deferred."
+                outcome["action"] = recon.ACTION_DEFERRED_UNKNOWN
+                outcome["reasonCode"] = "attention_write_unknown"
+                return outcome
+        bodies = [str(c.get("body") or "") for c in comments]
+        comment_body = recon.render_reconciler_comment(
+            repository=repository,
+            issue_number=issue_number,
+            reason_code=decision.reason_code,
+            summary=decision.summary,
+            observed_attempt_id=_string(newest.get("attemptId")),
+            next_action="obtain-operator-attention",
+        )
+        gate = recon.should_post_reconciler_comment(existing_bodies=bodies, reason_code=decision.reason_code, new_body=comment_body)
+        outcome["commentCoalesced"] = not gate["post"]
+        if gate["post"]:
+            created = await service.create_issue_comment(repo=repository, issue_number=issue_number, body=comment_body)
+            if not _spend():
+                pass
+            if not (isinstance(created, Mapping) and created.get("ok")):
+                outcome["summary"] += f" Observation comment not confirmed ({created.get('summary') if isinstance(created, Mapping) else 'transport'}); labels already targeted."
+        else:
+            outcome["summary"] += f" Observation coalesced ({gate['reasonCode']})."
+        if comments_incomplete:
+            outcome["summary"] += " Comment scan may be incomplete; uncertainty preserved."
+        return outcome
+
+    # no_action / abandoned / deferred: drop obsolete pending, keep the rest.
+    if decision.action == recon.ACTION_ABANDONED:
+        recon.drop_pending_effect(state, repository=repository, issue_number=issue_number)
+    return outcome
+
+
+async def reconcile_github_issue_handoffs(
+    *,
+    repository: str,
+    issue_numbers: Sequence[int] | None = None,
+    max_pages: int = recon.MAX_SCAN_PAGES,
+    max_issues: int = recon.MAX_SCAN_ISSUES,
+    state_dir: Any = None,
+    service: Any | None = None,
+) -> dict[str, Any]:
+    """Reconcile pending effects and scan one repository (bounded).
+
+    Trusted Activity boundary: resolves its own GitHub token, stops new
+    admission/shared mutations on insufficient connectivity, persists
+    pending-sync evidence across restarts, and returns explicit
+    partial/unknown results instead of a clean report when bounded.
+    """
+    started = time.time()
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", _string(repository)):
+        return {"ok": False, "reasonCode": "invalid_repository", "summary": f"Invalid repository {_string(repository)!r}."}
+    if service is None:
+        from moonmind.workflows.adapters.github_service import GitHubService
+
+        service = GitHubService()
+    token, token_error = await service.resolve_github_token(repo=_string(repository))
+    readiness = recon.check_reconciliation_readiness(
+        token_available=bool(token),
+        token_error=_string(token_error),
+        repository_authorized=True,
+    )
+    if not readiness["ready"]:
+        return {
+            "ok": False,
+            "readiness": readiness,
+            "reasonCode": str(readiness["reasonCode"]),
+            "summary": str(readiness["summary"]),
+            "admissionAllowed": False,
+            "results": [],
+            "scan": {"status": recon.SCAN_UNKNOWN},
+            "diagnostics": recon.build_reconciliation_diagnostics(failures=[{"reasonCode": readiness["reasonCode"], "summary": readiness["summary"]}]),
+        }
+    root = _state_dir(state_dir)
+    pending_path = root / _PENDING_FILENAME
+    last_run_path = root / _LAST_RUN_FILENAME
+    state = _load_json(pending_path)
+    budget = {"requests": 0}
+    results: list[dict[str, Any]] = []
+    ambiguous: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    rate_limited = False
+    transport_error = ""
+    pages_exhausted = False
+    requests_exhausted = False
+
+    targets: list[int] = []
+    if issue_numbers is not None:
+        seen: set[int] = set()
+        for raw in issue_numbers:
+            try:
+                number = int(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                continue
+            if number > 0 and number not in seen:
+                seen.add(number)
+                targets.append(number)
+        targets = targets[:max(0, int(max_issues))]
+    else:
+        # Bounded GitHub-only scan independent of the eligible-candidate
+        # filter: list open issues directly (oldest stranded work is not
+        # filtered out for being in-progress).
+        import httpx
+
+        headers = service._github_headers(token)
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            for page in range(1, max(1, int(max_pages)) + 1):
+                if budget["requests"] >= recon.MAX_SCAN_API_REQUESTS:
+                    requests_exhausted = True
+                    break
+                try:
+                    response = await client.get(
+                        f"https://api.github.com/repos/{_string(repository)}/issues",
+                        params={"state": "open", "sort": "created", "direction": "asc", "per_page": min(100, recon.MAX_SCAN_PER_PAGE), "page": page},
+                        headers=headers,
+                    )
+                    budget["requests"] += 1
+                    response.raise_for_status()
+                    payload = response.json()
+                except Exception as exc:  # noqa: BLE001 - explicit unknown
+                    status = getattr(getattr(exc, "response", None), "status_code", None)
+                    if status == 429 or "RateLimit" in exc.__class__.__name__:
+                        rate_limited = True
+                    else:
+                        transport_error = f"{exc.__class__.__name__}"
+                    break
+                if not isinstance(payload, list):
+                    transport_error = "malformed_scan_payload"
+                    break
+                for entry in payload:
+                    if not isinstance(entry, Mapping) or "pull_request" in entry:
+                        continue
+                    try:
+                        number = int(entry.get("number"))
+                    except (TypeError, ValueError):
+                        continue
+                    if number > 0 and number not in targets:
+                        targets.append(number)
+                    if len(targets) >= max(0, int(max_issues)):
+                        break
+                if len(payload) < min(100, recon.MAX_SCAN_PER_PAGE):
+                    break
+            else:
+                pages_exhausted = True
+        if len(targets) >= max(0, int(max_issues)) and issue_numbers is None:
+            # Hit the issue budget while pages may remain: partial, not clean.
+            pages_exhausted = True
+
+    for number in targets:
+        if budget["requests"] >= recon.MAX_SCAN_API_REQUESTS:
+            requests_exhausted = True
+            failures.append({"reasonCode": "request_budget_exhausted", "summary": f"Deferred {repository}#{number}: request budget exhausted."})
+            continue
+        try:
+            item = await _reconcile_one_issue(
+                service=service, repository=_string(repository), issue_number=number, budget=budget, state=state, now_iso=now_iso
+            )
+        except Exception as exc:  # noqa: BLE001 - one issue never fails the run
+            item = {"repository": _string(repository), "issueNumber": number, "action": recon.ACTION_DEFERRED_UNKNOWN, "reasonCode": "issue_error", "summary": f"Reconciliation error deferred: {exc.__class__.__name__}.", "apiRequests": 0}
+        results.append(item)
+        if item.get("rateLimited"):
+            rate_limited = True
+        if item.get("reasonCode") in {"unresponsive_owner_uncertain", "manual_in_progress_surfaced"}:
+            ambiguous.append({"repository": repository, "issueNumber": number, "reasonCode": item.get("reasonCode"), "summary": item.get("summary")})
+
+    _save_json(pending_path, state)
+    examined = len(results)
+    repaired = sum(1 for r in results if r.get("action") == recon.ACTION_COMPLETE and r.get("reasonCode") == "repaired")
+    surfaced = sum(1 for r in results if r.get("action") == recon.ACTION_ATTENTION)
+    deferred = sum(1 for r in results if r.get("action") == recon.ACTION_DEFERRED_UNKNOWN)
+    scan = recon.merge_scan_results(
+        examined=examined,
+        repaired=repaired,
+        surfaced=surfaced,
+        deferred=deferred,
+        pages_exhausted=pages_exhausted,
+        requests_exhausted=requests_exhausted,
+        transport_error=transport_error,
+        rate_limited=rate_limited,
+    )
+    if transport_error or rate_limited:
+        failures.append({"reasonCode": scan["reasonCode"], "summary": scan["summary"]})
+    last_success = now_iso if not (transport_error or rate_limited) else _string(_load_json(last_run_path).get("lastSuccessfulReconciliation"))
+    if not (transport_error or rate_limited):
+        _save_json(last_run_path, {"lastSuccessfulReconciliation": now_iso, "repository": _string(repository), "scan": scan})
+    else:
+        last_success = _string(_load_json(last_run_path).get("lastSuccessfulReconciliation"))
+    diagnostics = recon.build_reconciliation_diagnostics(
+        last_success_at=last_success,
+        pending_effects=state.get("pendingEffects") if isinstance(state.get("pendingEffects"), list) else [],
+        ambiguous_owners=ambiguous,
+        failures=failures,
+        scan=scan,
+    )
+    return {
+        "ok": not (transport_error or rate_limited),
+        "reasonCode": scan["reasonCode"],
+        "summary": scan["summary"],
+        "readiness": readiness,
+        "admissionAllowed": bool(scan["admissionAllowed"]),
+        "results": results,
+        "scan": scan,
+        "diagnostics": diagnostics,
+        "elapsedSeconds": round(time.time() - started, 3),
+    }
+
+
+__all__ = ["reconcile_github_issue_handoffs"]

--- a/moonmind/workflows/temporal/activity_catalog.py
+++ b/moonmind/workflows/temporal/activity_catalog.py
@@ -1185,6 +1185,15 @@ def build_default_activity_catalog(
             retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
         ),
         TemporalActivityDefinition(
+            activity_type="github_issue.reconcile_handoffs",
+            family="github_issue",
+            capability_class="integration:github",
+            task_queue=cfg.activity_integrations_task_queue,
+            fleet=INTEGRATIONS_FLEET,
+            timeouts=TemporalActivityTimeouts(300, 600),
+            retries=_activity_retries(max_attempts=3, max_interval_seconds=60),
+        ),
+        TemporalActivityDefinition(
             activity_type="pr_resolver.resolve_selector",
             family="pr_resolver",
             capability_class="integration:github",

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -1034,6 +1034,10 @@ _ACTIVITY_HANDLER_ATTRS: dict[str, tuple[str, str]] = {
         "integrations",
         "github_issue_finalize_failed_attempt",
     ),
+    "github_issue.reconcile_handoffs": (
+        "integrations",
+        "github_issue_reconcile_handoffs",
+    ),
     "pr_resolver.resolve_selector": (
         "integrations",
         "pr_resolver_resolve_selector",
@@ -5135,6 +5139,60 @@ class TemporalIntegrationActivities:
             "repository": repository,
             "issueNumber": issue_number,
             **outputs,
+        }
+
+    async def github_issue_reconcile_handoffs(self, payload, /, **kwargs):
+        """Reconcile interrupted issue handoffs through the bounded scan (durable entrypoint).
+
+        Durable counterpart to periodic maintenance: the default scheduled
+        ``MoonMind.GitHubIssueReconcile`` workflow executes
+        ``github_issue.reconcile_handoffs`` instead of relying on an agent
+        to repair stranded handoffs. Only ``repository`` is required;
+        ``issueNumbers`` optionally narrows the run. Pending-sync evidence
+        persists across worker restarts via ``stateDir``.
+        """
+        from moonmind.workflows.temporal.activities.github_issue_reconciliation_activities import (
+            reconcile_github_issue_handoffs,
+        )
+
+        if not isinstance(payload, Mapping):
+            raise TemporalActivityRuntimeError(
+                "github_issue.reconcile_handoffs requires an object"
+            )
+        config = payload.get("reconciliation")
+        if not isinstance(config, Mapping):
+            config = payload
+
+        def _first(*keys: str) -> Any:
+            for key in keys:
+                if key in config and config[key] is not None:
+                    return config[key]
+            return None
+
+        repository = str(_first("repository", "repo") or "").strip()
+        if not repository:
+            raise TemporalActivityRuntimeError(
+                "github_issue.reconcile_handoffs requires repository"
+            )
+        raw_numbers = _first("issueNumbers", "issue_numbers")
+        issue_numbers = None
+        if isinstance(raw_numbers, (list, tuple)):
+            parsed: list[int] = []
+            for raw in raw_numbers:
+                try:
+                    parsed.append(int(raw))  # type: ignore[arg-type]
+                except (TypeError, ValueError):
+                    continue
+            issue_numbers = parsed
+        result = await reconcile_github_issue_handoffs(
+            repository=repository,
+            issue_numbers=issue_numbers,
+            state_dir=_first("stateDir", "state_dir"),
+        )
+        return {
+            "status": "succeeded" if result.get("ok") else "failed",
+            "repository": repository,
+            **result,
         }
 
     async def pr_resolver_resolve_selector(self, payload, /, **kwargs):

--- a/moonmind/workflows/temporal/client.py
+++ b/moonmind/workflows/temporal/client.py
@@ -63,6 +63,8 @@ MANAGED_RUNTIME_WORKSPACE_CLEANUP_WORKFLOW_ID_BASE = (
 )
 OMNIGENT_OAUTH_HOST_JANITOR_SCHEDULE_ID = "omnigent-oauth-host-janitor"
 OMNIGENT_OAUTH_HOST_JANITOR_WORKFLOW_ID_BASE = "omnigent-oauth-host-janitor-run"
+GITHUB_ISSUE_RECONCILE_SCHEDULE_ID = "mm-operational:github-issue-reconcile"
+GITHUB_ISSUE_RECONCILE_WORKFLOW_ID_BASE = "mm-operational:github-issue-reconcile"
 ALLOW_LIVE_TEMPORAL_IN_TESTS_ENV = "MOONMIND_ALLOW_LIVE_TEMPORAL_IN_TESTS"
 _WORKFLOW_UPDATE_ACCEPTED_TIMEOUT = timedelta(seconds=10)
 _WORKFLOW_CONTROL_CONCURRENCY = 10
@@ -989,6 +991,82 @@ class TemporalClientAdapter:
         except Exception as create_exc:
             raise ScheduleOperationError(
                 f"Failed to create Omnigent OAuth host janitor schedule: {create_exc}"
+            ) from create_exc
+
+    async def ensure_github_issue_reconcile_schedule(
+        self,
+        *,
+        cron_expression: str = "17 * * * *",
+        timezone: str = "UTC",
+        enabled: bool = True,
+        repository: str = "",
+    ) -> str:
+        """Create or replace the recurring GitHub issue reconcile schedule.
+
+        Registers ``MoonMind.GitHubIssueReconcile`` through the production
+        Temporal scheduling mechanism so the default hourly maintenance run
+        starts without manual invocation. Skip-on-overlap keeps duplicate
+        observations bounded without a global lock.
+        """
+
+        from temporalio.client import Schedule, ScheduleActionStartWorkflow, ScheduleUpdate
+        from moonmind.workflows.temporal.schedule_errors import ScheduleOperationError
+        from moonmind.workflows.temporal.schedule_mapping import (
+            build_schedule_policy,
+            build_schedule_spec,
+            build_schedule_state,
+        )
+
+        client = await self.get_client()
+
+        def _schedule() -> Schedule:
+            return Schedule(
+                action=ScheduleActionStartWorkflow(
+                    "MoonMind.GitHubIssueReconcile",
+                    {"repository": repository} if repository else {},
+                    id=GITHUB_ISSUE_RECONCILE_WORKFLOW_ID_BASE,
+                    task_queue=self._get_task_queue(),
+                    typed_search_attributes=_build_typed_search_attributes(
+                        {"mm_entry": ["operational"], "mm_state": ["scheduled"]}
+                    ),
+                    static_summary="GitHub issue reconcile",
+                    static_details=(
+                        "Recurring bounded reconciliation of interrupted issue handoffs"
+                    ),
+                ),
+                spec=build_schedule_spec(
+                    cron=cron_expression, timezone=timezone, jitter_seconds=0
+                ),
+                policy=build_schedule_policy(overlap_mode="skip", catchup_mode="last"),
+                state=build_schedule_state(
+                    enabled=enabled, note="GitHub issue handoff reconciliation"
+                ),
+            )
+
+        try:
+            handle = client.get_schedule_handle(GITHUB_ISSUE_RECONCILE_SCHEDULE_ID)
+
+            async def _replace(input: Any) -> ScheduleUpdate:  # noqa: A002
+                del input
+                return ScheduleUpdate(schedule=_schedule())
+
+            await handle.update(_replace)
+            return GITHUB_ISSUE_RECONCILE_SCHEDULE_ID
+        except Exception as update_exc:
+            if not _is_rpc_status(update_exc, "NOT_FOUND") and "not found" not in str(
+                update_exc
+            ).lower():
+                raise ScheduleOperationError(
+                    f"Failed to update GitHub issue reconcile schedule: {update_exc}"
+                ) from update_exc
+        try:
+            handle = await client.create_schedule(
+                GITHUB_ISSUE_RECONCILE_SCHEDULE_ID, _schedule()
+            )
+            return handle.id
+        except Exception as create_exc:
+            raise ScheduleOperationError(
+                f"Failed to create GitHub issue reconcile schedule: {create_exc}"
             ) from create_exc
 
     async def create_schedule(

--- a/moonmind/workflows/temporal/github_issue_lifecycle.py
+++ b/moonmind/workflows/temporal/github_issue_lifecycle.py
@@ -306,8 +306,34 @@ def attempt_evidence_blocks_admission(attempt_context: Mapping[str, Any] | None)
     the decision: exhausted budgets, operator holds, lineage gaps, and
     simultaneous-race approximations all block automatic admission rather
     than starting fresh.
+
+    When the context carries the reconciler's admission gate
+    (``reconciliationAdmissionAllowed: False`` or ``reconciliationBlocked:
+    True``, built by ``github_issue_reconciliation.admission_context_from_scan``
+    from the persisted last scan), an incomplete or failed reconciliation
+    scan blocks new admission until the next successful run. Activity
+    boundaries thread the persisted scan into the candidate context with one
+    ``admission_context_from_scan`` call; Search, Implement, and continuation
+    all route through this function so the gate is enforced on every shared
+    admission path.
     """
     context = attempt_context or {}
+    for key in (
+        "reconciliationAdmissionAllowed",
+        "reconciliation_admission_allowed",
+        "reconciliation_admissionAllowed",
+    ):
+        if key in context:
+            value = context.get(key)
+            if value is False or (isinstance(value, str) and value.strip().lower() in {"0", "false", "no"}):
+                return True
+    for key in (
+        "reconciliationBlocked",
+        "reconciliation_blocked",
+    ):
+        value = context.get(key)
+        if value is True or (isinstance(value, str) and value.strip().lower() in {"1", "true", "yes"}):
+            return True
     for key in (
         "hasUnresolvedActiveAttempt",
         "has_unresolved_active_attempt",

--- a/moonmind/workflows/temporal/github_issue_reconciliation.py
+++ b/moonmind/workflows/temporal/github_issue_reconciliation.py
@@ -1174,6 +1174,28 @@ def merge_scan_results(
     }
 
 
+def admission_context_from_scan(scan: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Build the shared-admission gate context from one reconciler scan.
+
+    Activity boundaries thread this mapping into the candidate
+    ``attempt_context`` consumed by ``github_issue_lifecycle``,
+    ``github_issue_search``, and ``story_output_tools``: a partial/unknown
+    scan (``admissionAllowed: False``) then blocks Search, Implement, and
+    continuation admission until the next successful reconciliation run.
+    A complete scan returns an explicitly allowing context.
+    """
+    allowed = bool((scan or {}).get("admissionAllowed")) if isinstance(scan, Mapping) else False
+    # An absent scan is not a clean repository: fail closed.
+    return {"reconciliationAdmissionAllowed": allowed}
+
+
+def reconciliation_blocks_admission(scan: Mapping[str, Any] | None) -> bool:
+    """Return True when *scan* must stop new admission/shared mutations."""
+    if not isinstance(scan, Mapping):
+        return True
+    return not bool(scan.get("admissionAllowed"))
+
+
 # ---------------------------------------------------------------------------
 # Req 7: supported default maintenance path + actionable readiness
 # ---------------------------------------------------------------------------
@@ -1184,12 +1206,15 @@ def default_reconciliation_schedule() -> dict[str, Any]:
 
     Registered through the existing Temporal scheduling/readiness
     mechanisms (the ``MoonMind.GitHubIssueReconcile`` workflow type and
-    the ``github_issue.reconcile_handoffs`` activity binding). Routine
+    the ``github_issue.reconcile_handoffs`` activity binding) via
+    ``TemporalClient.ensure_github_issue_reconcile_schedule``. Routine
     correctness does not depend on a hidden enable flag: the descriptor
     is enabled and unpaused by default, with explicit overlap/skip and
     bounded catchup so duplicate observations stay bounded.
     """
     return {
+        "scheduleId": "mm-operational:github-issue-reconcile",
+        "workflowIdBase": "mm-operational:github-issue-reconcile",
         "workflowType": "MoonMind.GitHubIssueReconcile",
         "activityType": "github_issue.reconcile_handoffs",
         "cron": DEFAULT_RECONCILIATION_CRON,
@@ -1198,6 +1223,7 @@ def default_reconciliation_schedule() -> dict[str, Any]:
         "catchupMode": DEFAULT_RECONCILIATION_CATCHUP_MODE,
         "enabled": True,
         "paused": False,
+        "ensureMethod": "ensure_github_issue_reconcile_schedule",
         "summary": (
             "Default hourly bounded reconciliation through the existing "
             "Temporal workflow/activity boundary; no hidden enable flag and "
@@ -1338,6 +1364,8 @@ __all__ = [
     "drop_pending_effect",
     "pending_effects_for_issue",
     "merge_scan_results",
+    "admission_context_from_scan",
+    "reconciliation_blocks_admission",
     "default_reconciliation_schedule",
     "check_reconciliation_readiness",
     "build_reconciliation_diagnostics",

--- a/moonmind/workflows/temporal/github_issue_reconciliation.py
+++ b/moonmind/workflows/temporal/github_issue_reconciliation.py
@@ -737,6 +737,7 @@ def plan_repair_mutation(
             name
             for name in names
             if lifecycle.normalize_lifecycle_label(name) in lifecycle.CANONICAL_OPEN_LABELS
+            or lifecycle.is_workflow_status_like(name)
         ]
         return plan_blocked_repair_mutation(canonical_present=canonical, to_target=to_target)
     decision = lifecycle.plan_transition(
@@ -875,6 +876,19 @@ def classify_repair_readback(
         return {
             "outcome": lifecycle.OUTCOME_INCOMPLETE,
             "detail": f"Destination observed but old status remains: {', '.join(remaining)}.",
+        }
+    # An unrecognized workflow-status label keeps the issue blocked_unknown
+    # even when the destination is present; never discard pending evidence
+    # while such a blocker remains.
+    blocking_unknown = [
+        name
+        for name in names
+        if name and lifecycle.is_workflow_status_like(name) and (destination is None or name.lower() != destination.lower())
+    ]
+    if blocking_unknown:
+        return {
+            "outcome": lifecycle.OUTCOME_INCOMPLETE,
+            "detail": f"Unknown workflow-status remains: {', '.join(sorted(set(blocking_unknown)))}.",
         }
     if destination is None:
         expected_settled = {
@@ -1025,8 +1039,14 @@ def record_pending_effect(
     intended_to_target: str,
     proposed_disposition: str,
     reason: str = "",
+    attempt_id: str = "",
 ) -> dict[str, Any]:
-    """Record recoverable pending-sync evidence surviving worker restart."""
+    """Record recoverable pending-sync evidence surviving worker restart.
+
+    Pending effects are bound to their originating attempt: callers pass the
+    current handoff attemptId so a successor taking ownership cannot complete
+    a predecessor's stale disposition.
+    """
     data = dict(store or {})
     effects = data.get("pendingEffects")
     if not isinstance(effects, list):
@@ -1044,6 +1064,7 @@ def record_pending_effect(
             "intendedToTarget": intended_to_target,
             "proposedDisposition": proposed_disposition,
             "reason": _string(reason),
+            "attemptId": _string(attempt_id),
         }
     )
     data["pendingEffects"] = effects
@@ -1118,7 +1139,21 @@ def merge_scan_results(
                 f"{examined} examined, {repaired} repaired, {surfaced} surfaced, "
                 f"{deferred} deferred. Result is partial, not clean."
             ),
-            "admissionAllowed": True,
+            "admissionAllowed": False,
+            "examined": examined,
+            "repaired": repaired,
+            "surfaced": surfaced,
+            "deferred": deferred,
+        }
+    if deferred > 0:
+        return {
+            "status": SCAN_PARTIAL,
+            "reasonCode": "deferred_partial",
+            "summary": (
+                f"Bounded scan examined {examined} issues with {deferred} deferred: "
+                f"{repaired} repaired, {surfaced} surfaced. Result is partial, not clean."
+            ),
+            "admissionAllowed": False,
             "examined": examined,
             "repaired": repaired,
             "surfaced": surfaced,

--- a/moonmind/workflows/temporal/github_issue_reconciliation.py
+++ b/moonmind/workflows/temporal/github_issue_reconciliation.py
@@ -1,0 +1,1309 @@
+"""Bounded periodic reconciliation of interrupted GitHub issue handoffs.
+
+Single policy entrypoint for MoonLadderStudios/MoonMind#4182 (design:
+docs/Workflows/GitHubIssueStatusStateMachineDesign.md, sections 4.2, 6.2,
+6.3, and 9). Deterministic and side-effect-free: no network I/O. Trusted
+Activities/services perform GitHub reads/writes; this module decides what
+the reads mean and what a periodic reconciler may repair or surface.
+
+Contract summary:
+
+* The reconciler first replays locally persisted pending GitHub effects,
+  then performs a bounded GitHub-only scan for managed in-progress,
+  attention, review-owner, and interrupted-handoff cases in repositories
+  already authorized for issue automation. The scan is independent of
+  Search and Implement's eligible-candidate filter, so stranded
+  in-progress issues are not invisible forever (Req 1).
+* Shared labels, supported attempt comments, exact PR state, and terminal
+  evidence are evaluated with the same policy as normal finalization. A
+  known interrupted transition is completed only when stop, preservation,
+  and pending-mutation evidence is conclusive. Every retry re-reads
+  current evidence and abandons obsolete transitions when a successor,
+  operator hold, or contradiction is observed (Req 2).
+* Silence, old timestamps, sleep, unavailable local workflow records, or
+  an unreachable deployment are uncertain ownership, never release
+  evidence. The reconciler surfaces needs-attention while retaining the
+  old blocking status when necessary. It never age-clears manual/legacy
+  in-progress labels and never authorizes takeover because another
+  deployment is absent from this device's Temporal service (Req 3).
+* Unknown push/PR/merge outcomes are respected: known accepted results
+  are read-and-reconciled, but an unmerged PR is never proof that a
+  delayed merge request cannot still complete. Unresolved external
+  operations require attention, not a timed unlock (Req 4).
+* Reconciliation is retry-safe across multiple independent reconcilers:
+  attempt identity is reused, per-attempt comment ownership is preserved,
+  repeated incident reporting is coalesced, and whole-label-set updates
+  are never used. Duplicate observations may occur; no global
+  exactly-once scheduler guarantee is implied (Req 5).
+* Local pending-sync evidence survives worker restart and GitHub outages.
+  Pages, API requests, retries, and reporting frequency are bounded with
+  backoff/rate-limit handling. Exhausted or incomplete scans return
+  explicit partial/unknown results, never a clean repository. New
+  admission and shared mutations stop during insufficient GitHub
+  connectivity (Req 6).
+* The supported default maintenance path registers through the existing
+  Temporal scheduling/readiness mechanisms. Routine correctness never
+  depends on a hidden enable flag or a permanently paused schedule.
+  Missing credentials or permissions are actionable local readiness
+  failures; there is no fallback to another credential and no assumption
+  that GitHub was updated (Req 7).
+* Last successful reconciliation, pending issue effects, ambiguous
+  owners, and actionable failures are exposed through existing
+  diagnostics and projections. At least one healthy authorized deployment
+  is required for progress (Req 8).
+
+This module reuses (never duplicates) the portable semantics owned
+elsewhere: lifecycle interpretation and targeted label mutations in
+``github_issue_lifecycle``, writer/mutation/preservation gates in
+``github_issue_finalization``, and attempt identity/metadata in
+``github_issue_attempt``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+# ---------------------------------------------------------------------------
+# Bounds (Req 6: bounded pages, requests, retries, reporting)
+# ---------------------------------------------------------------------------
+
+#: Maximum issue-list pages examined per repository scan.
+MAX_SCAN_PAGES = 5
+#: Maximum issues per issue-list page.
+MAX_SCAN_PER_PAGE = 100
+#: Maximum issues reconciled per run (candidates beyond the budget defer to
+#: the next run and are reported as partial, never as clean).
+MAX_SCAN_ISSUES = 100
+#: Maximum GitHub API requests per reconciliation run, including issue
+#: reads, comment reads, PR reads, and label/comment writes.
+MAX_SCAN_API_REQUESTS = 100
+#: Maximum comments read per issue for attempt-handoff evidence.
+MAX_COMMENTS_PER_ISSUE = 100
+#: Maximum reconciler observation comments posted per issue per run.
+#: Coalescing normally keeps this at zero or one; the bound is a failsafe.
+MAX_RECONCILER_COMMENTS_PER_ISSUE = 1
+#: Maximum incident (needs-attention) comments posted per issue per run.
+MAX_INCIDENTS_PER_ISSUE_PER_RUN = 1
+#: Backoff schedule (seconds) between GitHub retries on rate-limit/outage.
+RETRY_BACKOFF_SECONDS: tuple[int, ...] = (5, 15, 60)
+#: Maximum mutation retries per issue after a re-read (re-read, then retry
+#: once; a second failure defers to the next run with pending evidence).
+MAX_MUTATION_RETRIES_PER_ISSUE = 1
+
+#: Default periodic maintenance cadence (UTC cron). Hourly, with skip-on-
+#: overlap so duplicate observations stay bounded without a global lock.
+DEFAULT_RECONCILIATION_CRON = "17 * * * *"
+DEFAULT_RECONCILIATION_TIMEZONE = "UTC"
+DEFAULT_RECONCILIATION_OVERLAP_MODE = "skip"
+DEFAULT_RECONCILIATION_CATCHUP_MODE = "last"
+
+#: Machine marker prefix for reconciler observation comments. Reconciler
+#: comments carry their own marker (never an attempt marker) and reference
+#: the observed attempt ID in the body, so per-attempt comment ownership is
+#: preserved and repeated runs coalesce on the marker instead of posting
+#: unbounded duplicates (Req 5).
+RECONCILER_MARKER_PREFIX = "<!-- moonmind-github-reconcile:"
+
+# ---------------------------------------------------------------------------
+# Decision vocabulary
+# ---------------------------------------------------------------------------
+
+#: Reconciler actions for one issue.
+ACTION_COMPLETE = "complete_interrupted_transition"
+ACTION_ATTENTION = "surface_attention"
+ACTION_NO_ACTION = "no_action"
+ACTION_DEFERRED_UNKNOWN = "deferred_unknown"
+ACTION_ABANDONED = "abandoned_obsolete"
+
+ACTIONS = frozenset(
+    {
+        ACTION_COMPLETE,
+        ACTION_ATTENTION,
+        ACTION_NO_ACTION,
+        ACTION_DEFERRED_UNKNOWN,
+        ACTION_ABANDONED,
+    }
+)
+
+#: Scan-result states (Req 6: explicit partial/unknown, never false clean).
+SCAN_COMPLETE = "complete"
+SCAN_PARTIAL = "partial"
+SCAN_UNKNOWN = "unknown"
+
+
+def _string(value: Any) -> str:
+    if isinstance(value, bool):
+        return ""
+    return str(value or "").strip()
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes"}
+    return bool(value)
+
+
+# ---------------------------------------------------------------------------
+# Req 1: reconciliation scope (independent of the eligible-candidate filter)
+# ---------------------------------------------------------------------------
+
+#: Settled states the bounded scan examines. Available, recovery-needed
+#: (with usable handoff), and closed issues stay owned by the normal
+#: admission/continuation paths; the scan exists so the states below are
+#: not invisible forever. Review-owner cases arrive as code_review.
+SCAN_IN_SCOPE_SETTLED = frozenset(
+    {
+        "in_progress",
+        "needs_attention",
+        "code_review",
+        "blocked_mixed",
+        "blocked_unknown",
+        "blocked_open_done",
+    }
+)
+
+
+def is_scan_in_scope(settled: str) -> bool:
+    """Return True when *settled* belongs to the reconciliation scan scope."""
+    return _string(settled).lower().replace("-", "_") in SCAN_IN_SCOPE_SETTLED
+
+
+def classify_issue_for_scan(issue: Mapping[str, Any]) -> dict[str, Any]:
+    """Classify one issue payload as in- or out-of-scan-scope (Req 1).
+
+    Uses the shared #4176 lifecycle interpretation, so mixed labels,
+    unknown workflow-status values, and open-Done inconsistencies are
+    in scope (they block admission pending reconciliation) while
+    Available/Recovery-needed/Closed stay with the normal paths.
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    interpretation = lifecycle.interpret_issue(issue)
+    in_scope = interpretation.settled in SCAN_IN_SCOPE_SETTLED
+    return {
+        "inScope": in_scope,
+        "settled": interpretation.settled,
+        "blockedReason": interpretation.blocked_reason,
+        "reasonCode": "scan_in_scope" if in_scope else "owned_by_normal_path",
+        "summary": (
+            f"Issue is {interpretation.settled}; "
+            + (
+                "examined by the bounded reconciliation scan."
+                if in_scope
+                else "owned by the normal admission/continuation path."
+            )
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Evidence source distinction (acceptance: local vs remote, preserve outcome)
+# ---------------------------------------------------------------------------
+
+
+def classify_evidence_source(
+    *,
+    local_terminal_record: Mapping[str, Any] | None = None,
+    remote_handoff: Mapping[str, Any] | None = None,
+    local_workflow_available: bool = False,
+) -> dict[str, Any]:
+    """Distinguish locally confirmed terminal evidence from remote status.
+
+    A missing local workflow record says nothing about the remote owner's
+    execution (design section 6.2): the result keeps the source execution
+    outcome separate from the reconciler's uncertainty. ``remote_handoff``
+    is a validated attempt metadata mapping (or None when no trusted
+    handoff is readable); unvalidated prose never counts as evidence.
+    """
+    local = dict(local_terminal_record or {})
+    remote = dict(remote_handoff or {})
+    locally_confirmed = bool(local) and _truthy(
+        local.get("terminalRecorded", local.get("terminal_recorded"))
+    )
+    remote_release_claimed = bool(remote) and str(
+        remote.get("activity") or ""
+    ).strip().lower() in {"released", "releasing"}
+    # An orphaned remote attempt is reported as unresponsive, never
+    # misdescribed as a locally confirmed failure (design section 9).
+    remote_unresponsive = bool(remote) and not remote_release_claimed
+    if not remote and not locally_confirmed and not local_workflow_available:
+        remote_unresponsive = True
+    source_outcome = _string(local.get("primaryOutcome", local.get("primary_outcome")))
+    return {
+        "locallyConfirmed": locally_confirmed,
+        "remoteUnresponsive": remote_unresponsive,
+        "remoteReleaseClaimed": remote_release_claimed,
+        "sourceOutcome": source_outcome,
+        "sourceOutcomePreserved": bool(source_outcome),
+        "summary": (
+            "Locally confirmed terminal evidence."
+            if locally_confirmed
+            else (
+                "Remote owner unresponsive or no trusted handoff readable; "
+                "ownership is uncertain."
+                if remote_unresponsive
+                else "Remote release claimed; verifying before repair."
+            )
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 2: conclusive-repair evaluation (same policy as normal finalization)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReconciliationDecision:
+    """Typed decision for one issue's reconciliation."""
+
+    action: str
+    reason_code: str
+    summary: str
+    from_settled: str = ""
+    to_target: str = ""
+    retain_labels: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "reasonCode": self.reason_code,
+            "summary": self.summary,
+            "fromSettled": self.from_settled,
+            "toTarget": self.to_target,
+            "retainLabels": list(self.retain_labels),
+        }
+
+
+def _conclusive_terminal_evidence(
+    *,
+    writer_evidence: Mapping[str, Any] | None,
+    mutation_evidence: Mapping[str, Any] | None,
+    preservation_evidence: Mapping[str, Any] | None,
+    disposition: str,
+) -> tuple[bool, str]:
+    """Require conclusive stop/preservation/mutation evidence (Req 2).
+
+    Reuses the #4179 finalization gates so the reconciler applies exactly
+    the same policy as normal finalization. Insufficient stop proofs
+    (agent messages, timestamps, cleanup requests, unmerged-PR presence),
+    unknown mutation outcomes, and unverified preservation all fail here.
+    """
+    from moonmind.workflows.temporal import github_issue_finalization as finalization
+
+    if not _string(disposition):
+        return False, "no proposed disposition recorded"
+    writer = finalization.confirm_writer_stop(writer_evidence)
+    if not writer["stopped"]:
+        return False, f"writer stop inconclusive: {writer['reasonCode']}"
+    mutations = finalization.settle_shared_mutations(mutation_evidence)
+    if not mutations["settled"]:
+        return False, f"mutations unsettled: {mutations['reasonCode']}"
+    preserved = finalization.preserve_authoritative_output(preservation_evidence)
+    if not preserved["preserved"]:
+        return False, f"preservation unverified: {preserved['reasonCode']}"
+    return True, "stop, preservation, and mutation evidence are conclusive"
+
+
+def decide_issue_reconciliation(
+    *,
+    issue: Mapping[str, Any],
+    intended_from_settled: str = "",
+    intended_to_target: str = "",
+    writer_evidence: Mapping[str, Any] | None = None,
+    mutation_evidence: Mapping[str, Any] | None = None,
+    preservation_evidence: Mapping[str, Any] | None = None,
+    proposed_disposition: str = "",
+    trusted_handoff_present: bool = False,
+    manual_in_progress: bool = False,
+    successor_observed_settled: str = "",
+    operator_hold: bool = False,
+    contradiction_observed: bool = False,
+    pr_state: Mapping[str, Any] | None = None,
+    local_terminal_record: Mapping[str, Any] | None = None,
+    remote_handoff: Mapping[str, Any] | None = None,
+    local_workflow_available: bool = False,
+) -> ReconciliationDecision:
+    """Decide one issue's reconciliation from current GitHub evidence.
+
+    Precedence (first match wins):
+
+    * observed successor, operator hold, or contradiction -> abandoned
+      (re-read before each retry; obsolete transitions never replay);
+    * inconclusive stop/preservation/mutation evidence, manual/legacy
+      labels, unresponsive owners, unknown external outcomes, or mixed
+      labels without conclusive repair evidence -> surface_attention
+      (retaining the old blocking status) or deferred_unknown when the
+      reads themselves are insufficient;
+    * conclusive evidence for a known interrupted transition ->
+      complete_interrupted_transition via the targeted lifecycle boundary;
+    * otherwise -> no_action.
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    interpretation = lifecycle.interpret_issue(issue)
+    from_settled = interpretation.settled
+
+    # Abandonment first: a newer attempt, operator hold, closure, or
+    # conflicting evidence invalidates old cleanup intentions (Req 2).
+    if _string(successor_observed_settled):
+        observed = lifecycle.interpret_issue(
+            {"state": "open", "labels": []},
+        )
+        from dataclasses import replace as _replace
+
+        observed = _replace(observed, settled=_string(successor_observed_settled))
+        anchor = _string(intended_from_settled) or from_settled
+        abandon, abandon_reason = lifecycle.should_abandon_retry(
+            intended_from_settled=anchor, observed=observed
+        )
+        if abandon:
+            return ReconciliationDecision(
+                action=ACTION_ABANDONED,
+                reason_code="successor_or_hold_observed",
+                summary=f"Reconciliation abandoned: {abandon_reason}.",
+                from_settled=from_settled,
+            )
+    elif operator_hold or contradiction_observed:
+        anchor = _string(intended_from_settled) or from_settled
+        hold_like = "needs_attention" if operator_hold else from_settled
+        observed = lifecycle.interpret_issue({"state": "open", "labels": []})
+        from dataclasses import replace as _replace
+
+        observed = _replace(observed, settled=hold_like)
+        abandon, abandon_reason = lifecycle.should_abandon_retry(
+            intended_from_settled=anchor, observed=observed
+        )
+        if abandon or operator_hold or contradiction_observed:
+            return ReconciliationDecision(
+                action=ACTION_ABANDONED if abandon else ACTION_ATTENTION,
+                reason_code=(
+                    "operator_hold" if operator_hold else "contradiction_observed"
+                ),
+                summary=(
+                    abandon_reason
+                    or (
+                        "Operator hold requires resolution before repair."
+                        if operator_hold
+                        else "Contradictory evidence requires attention, not repair."
+                    )
+                ),
+                from_settled=from_settled,
+                retain_labels=tuple(sorted(interpretation.canonical_present)),
+            )
+    else:
+        anchor = _string(intended_from_settled) or from_settled
+        if anchor and anchor != from_settled and from_settled in {
+            lifecycle.SETTLED_IN_PROGRESS,
+            lifecycle.SETTLED_CODE_REVIEW,
+            lifecycle.SETTLED_RECOVERY_NEEDED,
+            lifecycle.SETTLED_AVAILABLE,
+            lifecycle.SETTLED_NEEDS_ATTENTION,
+            lifecycle.SETTLED_CLOSED,
+            lifecycle.SETTLED_BLOCKED_MIXED,
+            lifecycle.SETTLED_BLOCKED_UNKNOWN,
+            lifecycle.SETTLED_BLOCKED_OPEN_DONE,
+        }:
+            observed = lifecycle.interpret_issue({"state": "open", "labels": []})
+            from dataclasses import replace as _replace
+
+            observed = _replace(observed, settled=from_settled)
+            abandon, abandon_reason = lifecycle.should_abandon_retry(
+                intended_from_settled=anchor, observed=observed
+            )
+            if abandon:
+                return ReconciliationDecision(
+                    action=ACTION_ABANDONED,
+                    reason_code="successor_observed",
+                    summary=f"Reconciliation abandoned: {abandon_reason}.",
+                    from_settled=from_settled,
+                )
+
+    # Manual/legacy in-progress labels: respected and surfaced, never
+    # age-cleared (Req 3, design section 10).
+    if manual_in_progress or (
+        from_settled == lifecycle.SETTLED_IN_PROGRESS and not trusted_handoff_present
+    ):
+        return ReconciliationDecision(
+            action=ACTION_ATTENTION,
+            reason_code="manual_in_progress_surfaced",
+            summary=(
+                "Manual or legacy in-progress label with no trusted attempt "
+                "handoff: surfaced for attention and retained, never age-cleared."
+            ),
+            from_settled=from_settled,
+            retain_labels=tuple(sorted(interpretation.canonical_present)),
+        )
+
+    # Unrecognized workflow-status values or open-Done inconsistencies need
+    # classification: surface attention, never silent admission or
+    # destructive normalization (Req 3).
+    if from_settled in {
+        lifecycle.SETTLED_BLOCKED_UNKNOWN,
+        lifecycle.SETTLED_BLOCKED_OPEN_DONE,
+    }:
+        # A conclusive interrupted transition may still repair a blocked
+        # combination (design section 10); otherwise it stays surfaced.
+        if _string(intended_to_target) and _string(proposed_disposition):
+            conclusive, _ = _conclusive_terminal_evidence(
+                writer_evidence=writer_evidence,
+                mutation_evidence=mutation_evidence,
+                preservation_evidence=preservation_evidence,
+                disposition=proposed_disposition,
+            )
+            if conclusive and not _unknown_external_block(pr_state):
+                return _complete_decision(
+                    from_settled=from_settled,
+                    to_target=_string(intended_to_target),
+                    writer_evidence=writer_evidence,
+                    proposed_disposition=proposed_disposition,
+                )
+        return ReconciliationDecision(
+            action=ACTION_ATTENTION,
+            reason_code="classification_required",
+            summary=(
+                "Unrecognized workflow-status value or open-Done inconsistency "
+                "requires classification; surfaced without destructive normalization."
+            ),
+            from_settled=from_settled,
+            retain_labels=tuple(sorted(interpretation.canonical_present)),
+        )
+
+    # Mixed labels block until repaired; conclusive handoff evidence permits
+    # reconciliation, otherwise they stay surfaced (Req 2, design §10).
+    if from_settled == lifecycle.SETTLED_BLOCKED_MIXED:
+        if _string(intended_to_target) and _string(proposed_disposition):
+            conclusive, detail = _conclusive_terminal_evidence(
+                writer_evidence=writer_evidence,
+                mutation_evidence=mutation_evidence,
+                preservation_evidence=preservation_evidence,
+                disposition=proposed_disposition,
+            )
+            if conclusive and not _unknown_external_block(pr_state):
+                return _complete_decision(
+                    from_settled=from_settled,
+                    to_target=_string(intended_to_target),
+                    writer_evidence=writer_evidence,
+                    proposed_disposition=proposed_disposition,
+                )
+            return ReconciliationDecision(
+                action=ACTION_ATTENTION,
+                reason_code="mixed_labels_inconclusive",
+                summary=f"Mixed labels block admission until repaired: {detail}.",
+                from_settled=from_settled,
+                retain_labels=tuple(sorted(interpretation.canonical_present)),
+            )
+        return ReconciliationDecision(
+            action=ACTION_ATTENTION,
+            reason_code="mixed_labels_blocked",
+            summary="Mixed labels block admission pending reconciliation from evidence.",
+            from_settled=from_settled,
+            retain_labels=tuple(sorted(interpretation.canonical_present)),
+        )
+
+    # Uncertain ownership: silence, old timestamps, sleep, unavailable
+    # local records, or unreachable deployments never authorize release or
+    # takeover (Req 3). Surface needs-attention, retaining the old status.
+    source = classify_evidence_source(
+        local_terminal_record=local_terminal_record,
+        remote_handoff=remote_handoff,
+        local_workflow_available=local_workflow_available,
+    )
+    if source["remoteUnresponsive"] and not source["locallyConfirmed"]:
+        writer = (writer_evidence or {})
+        if not _truthy(writer.get("writersStopped", writer.get("writers_stopped"))):
+            return ReconciliationDecision(
+                action=ACTION_ATTENTION,
+                reason_code="unresponsive_owner_uncertain",
+                summary=(
+                    "Owner responsiveness is uncertain (silence, sleep, missing "
+                    "local record, or unreachable deployment): needs-attention "
+                    "is surfaced while the old blocking status is retained; "
+                    "no takeover authorized."
+                ),
+                from_settled=from_settled,
+                retain_labels=tuple(sorted(interpretation.canonical_present)),
+            )
+
+    # Unknown external outcomes block repair: an unmerged PR never proves a
+    # delayed merge cannot still complete (Req 4).
+    if _unknown_external_block(pr_state) or _unknown_mutations(mutation_evidence):
+        return ReconciliationDecision(
+            action=ACTION_ATTENTION,
+            reason_code="unknown_external_outcome",
+            summary=(
+                "Push/PR/merge outcome is unknown: attention required, "
+                "not a timed unlock. An unmerged PR does not prove a delayed "
+                "merge request cannot still complete."
+            ),
+            from_settled=from_settled,
+            retain_labels=tuple(sorted(interpretation.canonical_present)),
+        )
+
+    # Known interrupted transition with conclusive evidence: complete it
+    # without repeating implementation (Req 2). The source execution
+    # outcome is preserved separately (acceptance: evidence distinction).
+    if _string(intended_to_target) and _string(proposed_disposition):
+        conclusive, detail = _conclusive_terminal_evidence(
+            writer_evidence=writer_evidence,
+            mutation_evidence=mutation_evidence,
+            preservation_evidence=preservation_evidence,
+            disposition=proposed_disposition,
+        )
+        if conclusive:
+            return _complete_decision(
+                from_settled=from_settled,
+                to_target=_string(intended_to_target),
+                writer_evidence=writer_evidence,
+                proposed_disposition=proposed_disposition,
+            )
+        return ReconciliationDecision(
+            action=ACTION_ATTENTION,
+            reason_code="interrupted_transition_inconclusive",
+            summary=f"Interrupted transition lacks conclusive evidence: {detail}.",
+            from_settled=from_settled,
+            retain_labels=tuple(sorted(interpretation.canonical_present)),
+        )
+
+    # In-scope states with no actionable evidence stay visible but
+    # untouched; out-of-scope states are owned by the normal paths.
+    if from_settled in {
+        "in_progress",
+        "needs_attention",
+        "code_review",
+    }:
+        return ReconciliationDecision(
+            action=ACTION_NO_ACTION,
+            reason_code="no_interrupted_transition",
+            summary=(
+                f"Issue is {from_settled} with no known interrupted transition "
+                "or actionable evidence; left for the owning attempt or operator."
+            ),
+            from_settled=from_settled,
+        )
+    return ReconciliationDecision(
+        action=ACTION_NO_ACTION,
+        reason_code="owned_by_normal_path",
+        summary=f"Issue is {from_settled}; owned by the normal admission path.",
+        from_settled=from_settled,
+    )
+
+
+def _complete_decision(
+    *,
+    from_settled: str,
+    to_target: str,
+    writer_evidence: Mapping[str, Any] | None,
+    proposed_disposition: str,
+) -> ReconciliationDecision:
+    """Build a repair decision gated on the shared transition policy."""
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    _ = writer_evidence
+    if from_settled in {
+        lifecycle.SETTLED_BLOCKED_MIXED,
+        lifecycle.SETTLED_BLOCKED_UNKNOWN,
+        lifecycle.SETTLED_BLOCKED_OPEN_DONE,
+    }:
+        # Blocked combinations never pass the shared admission guard by
+        # design; conclusive terminal evidence (already verified by the
+        # caller) authorizes the reconciler to finish the recorded
+        # destination and drop the extraneous blockers instead.
+        blocked = plan_blocked_repair_mutation(canonical_present=(), to_target=to_target)
+        if not blocked["allowed"]:
+            return ReconciliationDecision(
+                action=ACTION_ATTENTION,
+                reason_code="repair_guard_denied",
+                summary=str(blocked["summary"]),
+                from_settled=from_settled,
+                to_target=to_target,
+            )
+        return ReconciliationDecision(
+            action=ACTION_COMPLETE,
+            reason_code="conclusive_repair",
+            summary=(
+                f"Conclusive terminal evidence permits repairing blocked labels "
+                f"{from_settled} -> {to_target} without repeating implementation."
+            ),
+            from_settled=from_settled,
+            to_target=to_target,
+        )
+    decision = lifecycle.plan_transition(
+        from_settled=from_settled,
+        to_target=to_target,
+        evidence=_transition_evidence_for_target(to_target, proposed_disposition),
+        reason=f"Reconciling interrupted transition to {to_target}: {proposed_disposition}",
+    )
+    if not decision.allowed:
+        return ReconciliationDecision(
+            action=ACTION_ATTENTION,
+            reason_code="repair_guard_denied",
+            summary=f"Interrupted transition denied by shared guard: {decision.summary}",
+            from_settled=from_settled,
+            to_target=to_target,
+        )
+    return ReconciliationDecision(
+        action=ACTION_COMPLETE,
+        reason_code="conclusive_repair",
+        summary=(
+            f"Conclusive terminal evidence permits completing the interrupted "
+            f"transition {from_settled} -> {to_target} without repeating implementation."
+        ),
+        from_settled=from_settled,
+        to_target=to_target,
+    )
+
+
+def _transition_evidence_for_target(target: str, disposition: str) -> dict[str, Any]:
+    """Map a conclusive disposition onto #4176 transition guard keys."""
+    if target == "to_recovery_needed":
+        return {"writers_stopped": True, "handoff_published": True}
+    if target == "to_available":
+        return {"writers_stopped": True, "terminal_proof": True}
+    if target == "to_code_review":
+        return {"gates_satisfied": True, "pr_url_verified": True}
+    if target == "to_closed":
+        return {"completion_verified": True}
+    if target == "to_needs_attention":
+        return {"blocking_reason": _string(disposition) or "reconciliation attention"}
+    if target == "to_in_progress":
+        return {"same_attempt_active": True}
+    return {}
+
+
+def _unknown_mutations(mutation_evidence: Mapping[str, Any] | None) -> bool:
+    from moonmind.workflows.temporal import github_issue_finalization as finalization
+
+    if not mutation_evidence:
+        return False
+    settled = finalization.settle_shared_mutations(mutation_evidence)
+    return not settled["settled"]
+
+
+def _unknown_external_block(pr_state: Mapping[str, Any] | None) -> bool:
+    """Return True when PR/merge state is unknown or unresolved (Req 4)."""
+    if not pr_state:
+        return False
+    data = dict(pr_state)
+    outcome = _string(data.get("mergeOutcome", data.get("merge_outcome"))).lower()
+    if outcome in {"unknown", "pending", "lost_response", ""} and _truthy(
+        data.get("mergeRequested", data.get("merge_requested"))
+    ):
+        return True
+    # A PR that merely appears unmerged (open, mergeable unknown) never
+    # proves a delayed merge cannot still complete.
+    if _truthy(data.get("mergeRequested", data.get("merge_requested"))) and not _truthy(
+        data.get("mergeOutcomeKnown", data.get("merge_outcome_known"))
+    ):
+        return True
+    return False
+
+
+def plan_repair_mutation(
+    *,
+    from_settled: str,
+    to_target: str,
+    current_labels: Sequence[Any] | None = None,
+    proposed_disposition: str = "",
+    reason: str = "",
+) -> dict[str, Any]:
+    """Plan targeted label ops for a conclusive interrupted transition.
+
+    Never replaces the whole label set: only MoonMind-owned lifecycle
+    labels are added/removed, destination first (Req 5, design 8.1).
+    Blocked combinations are repaired through
+    :func:`plan_blocked_repair_mutation` since they never pass the shared
+    admission guard by design.
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    if from_settled in {
+        lifecycle.SETTLED_BLOCKED_MIXED,
+        lifecycle.SETTLED_BLOCKED_UNKNOWN,
+        lifecycle.SETTLED_BLOCKED_OPEN_DONE,
+    }:
+        names = [
+            str(item.get("name") if isinstance(item, Mapping) else item or "").strip()
+            for item in (current_labels or [])
+        ]
+        canonical = [
+            name
+            for name in names
+            if lifecycle.normalize_lifecycle_label(name) in lifecycle.CANONICAL_OPEN_LABELS
+        ]
+        return plan_blocked_repair_mutation(canonical_present=canonical, to_target=to_target)
+    decision = lifecycle.plan_transition(
+        from_settled=from_settled,
+        to_target=to_target,
+        evidence=_transition_evidence_for_target(to_target, proposed_disposition),
+        reason=reason or f"Reconciling interrupted transition to {to_target}",
+    )
+    if not decision.allowed:
+        return {
+            "allowed": False,
+            "transition": decision.to_dict(),
+            "mutation": None,
+            "summary": decision.summary,
+        }
+    mutation = lifecycle.plan_label_mutation(
+        from_settled=from_settled,
+        to_target=to_target,
+        current_labels=current_labels,
+    )
+    return {
+        "allowed": True,
+        "transition": decision.to_dict(),
+        "mutation": mutation.to_dict(),
+        "summary": f"Targeted repair planned: {decision.summary}",
+    }
+
+
+def plan_blocked_repair_mutation(
+    *,
+    canonical_present: Sequence[str],
+    to_target: str,
+) -> dict[str, Any]:
+    """Plan targeted label ops repairing a blocked label combination.
+
+    Mixed labels, unknown workflow-status values, and open-Done
+    inconsistencies never pass the shared admission guard by design, so the
+    reconciler finishes the recorded destination directly: the destination
+    status is added first (when absent) and every other canonical status
+    label is removed. Only MoonMind-owned lifecycle labels are touched;
+    unrelated and ordinary labels are never replaced (Req 5, design 8.1).
+    Callers must only invoke this with conclusive terminal evidence for a
+    known interrupted transition (enforced by
+    :func:`decide_issue_reconciliation`).
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    targets = {
+        lifecycle.TO_IN_PROGRESS,
+        lifecycle.TO_CODE_REVIEW,
+        lifecycle.TO_RECOVERY_NEEDED,
+        lifecycle.TO_NEEDS_ATTENTION,
+        lifecycle.TO_AVAILABLE,
+        lifecycle.TO_CLOSED,
+    }
+    if _string(to_target) not in targets:
+        return {
+            "allowed": False,
+            "transition": None,
+            "mutation": None,
+            "summary": f"Blocked repair target {to_target!r} requires an explicit decision.",
+        }
+    destination = {
+        lifecycle.TO_IN_PROGRESS: lifecycle.STATUS_IN_PROGRESS,
+        lifecycle.TO_CODE_REVIEW: lifecycle.STATUS_CODE_REVIEW,
+        lifecycle.TO_RECOVERY_NEEDED: lifecycle.STATUS_RECOVERY_NEEDED,
+        lifecycle.TO_NEEDS_ATTENTION: lifecycle.STATUS_NEEDS_ATTENTION,
+        lifecycle.TO_AVAILABLE: None,
+        lifecycle.TO_CLOSED: lifecycle.STATUS_DONE,
+    }[_string(to_target)]
+    present = sorted({str(name).strip() for name in canonical_present if str(name).strip()})
+    lowered = {name.lower() for name in present}
+    to_add: list[str] = []
+    if destination is not None and destination.lower() not in lowered:
+        to_add.append(destination)
+    to_remove = [name for name in present if destination is None or name.lower() != destination.lower()]
+    return {
+        "allowed": True,
+        "transition": {
+            "allowed": True,
+            "fromSettled": "blocked",
+            "toTarget": _string(to_target),
+            "reasonCode": "conclusive_repair",
+            "summary": f"Blocked labels repaired to {_string(to_target)} from conclusive terminal evidence.",
+        },
+        "mutation": {
+            "labelsToAdd": to_add,
+            "labelsToRemove": to_remove,
+            "closeIssue": _string(to_target) == lifecycle.TO_CLOSED,
+        },
+        "summary": (
+            f"Targeted blocked-label repair to {_string(to_target)}: "
+            f"add {to_add or 'nothing'}, remove {to_remove or 'nothing'}."
+        ),
+    }
+
+
+def classify_repair_readback(
+    *,
+    mutation: Mapping[str, Any] | None,
+    read_back: Mapping[str, Any] | None,
+    to_target: str = "",
+) -> dict[str, Any]:
+    """Classify the read-back of a reconciler repair (Req 2/6).
+
+    Success requires the destination status observed (or no canonical
+    status remaining for Available) and every planned removal absent. Any
+    other combination stays incomplete with retained pending evidence; a
+    missing read-back is outcome-unknown, never assumed applied.
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    plan = dict(mutation or {})
+    if read_back is None:
+        return {
+            "outcome": lifecycle.OUTCOME_UNKNOWN,
+            "detail": "Repair read-back missing; result unknown, never assumed applied.",
+        }
+    adds = [str(label) for label in (plan.get("labelsToAdd") or []) if str(label).strip()]
+    removes = [str(label) for label in (plan.get("labelsToRemove") or []) if str(label).strip()]
+    raw_labels = read_back.get("labels")
+    names = [
+        str(item.get("name") if isinstance(item, Mapping) else item or "").strip()
+        for item in (raw_labels if isinstance(raw_labels, list) else [])
+    ]
+    present = {name.lower() for name in names if name}
+    if plan.get("closeIssue"):
+        if str(read_back.get("state") or "").strip().lower() == "closed":
+            return {"outcome": lifecycle.OUTCOME_APPLIED, "detail": "Issue is closed as intended."}
+        return {"outcome": lifecycle.OUTCOME_INCOMPLETE, "detail": "Close was not observed on read-back."}
+    destination = adds[0] if adds else None
+    if destination is not None and destination.lower() not in present:
+        return {"outcome": lifecycle.OUTCOME_INCOMPLETE, "detail": "Destination status was not observed on read-back."}
+    remaining = [label for label in removes if label.lower() in present]
+    if remaining:
+        return {
+            "outcome": lifecycle.OUTCOME_INCOMPLETE,
+            "detail": f"Destination observed but old status remains: {', '.join(remaining)}.",
+        }
+    if destination is None:
+        expected_settled = {
+            lifecycle.TO_AVAILABLE: lifecycle.SETTLED_AVAILABLE,
+            lifecycle.TO_IN_PROGRESS: lifecycle.SETTLED_IN_PROGRESS,
+            lifecycle.TO_CODE_REVIEW: lifecycle.SETTLED_CODE_REVIEW,
+            lifecycle.TO_RECOVERY_NEEDED: lifecycle.SETTLED_RECOVERY_NEEDED,
+            lifecycle.TO_NEEDS_ATTENTION: lifecycle.SETTLED_NEEDS_ATTENTION,
+            lifecycle.TO_CLOSED: lifecycle.SETTLED_CLOSED,
+        }.get(_string(to_target), lifecycle.SETTLED_AVAILABLE)
+        interpretation = lifecycle.interpret_issue(read_back)
+        if interpretation.settled != expected_settled:
+            return {"outcome": lifecycle.OUTCOME_INCOMPLETE, "detail": "Old blocking status was not removed."}
+    if not adds and not removes:
+        return {"outcome": lifecycle.OUTCOME_ALREADY_APPLIED, "detail": "Desired state was already present."}
+    return {"outcome": lifecycle.OUTCOME_APPLIED, "detail": "Destination status observed on read-back."}
+
+
+# ---------------------------------------------------------------------------
+# Req 5: retry-safe reconciler identity, ownership, coalescing
+# ---------------------------------------------------------------------------
+
+
+def reconciler_comment_key(*, repository: str, issue_number: int, reason_code: str) -> str:
+    """Return the stable marker key for one reconciler observation."""
+    return f"{RECONCILER_MARKER_PREFIX} {repository}#{issue_number}:{reason_code} -->"
+
+
+def render_reconciler_comment(
+    *,
+    repository: str,
+    issue_number: int,
+    reason_code: str,
+    summary: str,
+    observed_attempt_id: str = "",
+    next_action: str = "",
+) -> str:
+    """Render a bounded, coalescible reconciler observation comment."""
+    key = reconciler_comment_key(
+        repository=repository, issue_number=issue_number, reason_code=reason_code
+    )
+    lines = [
+        key,
+        "",
+        f"Reconciler observation for `{repository}#{issue_number}` ({reason_code}).",
+        "",
+        _string(summary)[:1000] or "No summary recorded.",
+    ]
+    if _string(observed_attempt_id):
+        lines.append(f"Observed attempt: `{_string(observed_attempt_id)}` (ownership unchanged).")
+    if _string(next_action):
+        lines.append(f"Suggested next action: **{_string(next_action)}**.")
+    lines.append("")
+    lines.append(
+        "This observation is coalesced: repeated runs reuse this comment instead of posting duplicates."
+    )
+    body = "\n".join(lines)
+    return body[:4000]
+
+
+def should_post_reconciler_comment(
+    *,
+    existing_bodies: Sequence[str],
+    reason_code: str,
+    new_body: str,
+) -> dict[str, Any]:
+    """Coalesce repeated incident reporting (Req 5).
+
+    Returns ``{"post": False}`` when an existing comment already carries
+    this run's marker key with equivalent content, so two independent
+    reconcilers processing the same handoff do not produce unbounded
+    comments. Per-attempt comments are never matched here: the reconciler
+    never updates another attempt's comment.
+    """
+    marker_fragment = f":{reason_code} -->"
+    new_normalized = " ".join(_string(new_body).split())
+    for body in existing_bodies or []:
+        text = str(body or "")
+        if RECONCILER_MARKER_PREFIX not in text or marker_fragment not in text:
+            continue
+        existing_normalized = " ".join(text.split())
+        # Same marker and equivalent content: coalesce (no new comment).
+        if new_normalized in existing_normalized or existing_normalized in new_normalized:
+            return {
+                "post": False,
+                "reasonCode": "coalesced_duplicate",
+                "summary": "An equivalent reconciler observation already exists; no duplicate posted.",
+            }
+        return {
+            "post": False,
+            "reasonCode": "coalesced_same_incident",
+            "summary": (
+                "A reconciler observation for this incident already exists; "
+                "no additional comment posted this run."
+            ),
+        }
+    return {
+        "post": True,
+        "reasonCode": "new_incident",
+        "summary": "No existing reconciler observation for this incident; one comment may be posted.",
+    }
+
+
+def targeted_attention_ops(
+    *,
+    current_labels: Sequence[Any] | None,
+    attention_already_present: bool,
+) -> dict[str, Any]:
+    """Plan targeted needs-attention escalation retaining old status.
+
+    Adds ``status: needs-attention`` when absent and removes nothing: the
+    old writer's blocking status is retained while its stop status is
+    unknown (design section 2.1). Never a whole-label-set replacement.
+    """
+    from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+
+    names = [
+        str(item.get("name") if isinstance(item, Mapping) else item or "").strip()
+        for item in (current_labels or [])
+    ]
+    present = {name.lower() for name in names if name}
+    to_add: list[str] = []
+    if not attention_already_present and lifecycle.STATUS_NEEDS_ATTENTION.lower() not in present:
+        to_add.append(lifecycle.STATUS_NEEDS_ATTENTION)
+    return {
+        "labelsToAdd": to_add,
+        "labelsToRemove": [],
+        "closeIssue": False,
+        "summary": (
+            "Targeted attention escalation; old blocking status retained."
+            if to_add
+            else "Attention already present; no label mutation required."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 6: durable pending-sync evidence (pure store helpers; file I/O in Activity)
+# ---------------------------------------------------------------------------
+
+
+def record_pending_effect(
+    store: Mapping[str, Any] | None,
+    *,
+    repository: str,
+    issue_number: int,
+    intended_from_settled: str,
+    intended_to_target: str,
+    proposed_disposition: str,
+    reason: str = "",
+) -> dict[str, Any]:
+    """Record recoverable pending-sync evidence surviving worker restart."""
+    data = dict(store or {})
+    effects = data.get("pendingEffects")
+    if not isinstance(effects, list):
+        effects = []
+    else:
+        effects = [dict(item) for item in effects if isinstance(item, Mapping)]
+    key = f"{repository}#{issue_number}"
+    effects = [item for item in effects if item.get("key") != key]
+    effects.append(
+        {
+            "key": key,
+            "repository": repository,
+            "issueNumber": issue_number,
+            "intendedFromSettled": intended_from_settled,
+            "intendedToTarget": intended_to_target,
+            "proposedDisposition": proposed_disposition,
+            "reason": _string(reason),
+        }
+    )
+    data["pendingEffects"] = effects
+    return data
+
+
+def drop_pending_effect(
+    store: Mapping[str, Any] | None, *, repository: str, issue_number: int
+) -> dict[str, Any]:
+    """Remove settled pending-sync evidence for one issue."""
+    data = dict(store or {})
+    effects = data.get("pendingEffects")
+    if not isinstance(effects, list):
+        return data
+    key = f"{repository}#{issue_number}"
+    data["pendingEffects"] = [
+        dict(item) for item in effects if isinstance(item, Mapping) and item.get("key") != key
+    ]
+    return data
+
+
+def pending_effects_for_issue(
+    store: Mapping[str, Any] | None, *, repository: str, issue_number: int
+) -> list[dict[str, Any]]:
+    """Return pending-sync evidence recorded for one issue."""
+    data = dict(store or {})
+    effects = data.get("pendingEffects")
+    if not isinstance(effects, list):
+        return []
+    key = f"{repository}#{issue_number}"
+    return [dict(item) for item in effects if isinstance(item, Mapping) and item.get("key") == key]
+
+
+def merge_scan_results(
+    *,
+    examined: int,
+    repaired: int = 0,
+    surfaced: int = 0,
+    deferred: int = 0,
+    pages_exhausted: bool = False,
+    requests_exhausted: bool = False,
+    transport_error: str = "",
+    rate_limited: bool = False,
+) -> dict[str, Any]:
+    """Merge one run's scan outcome into an explicit result (Req 6).
+
+    Exhausted pagination/request budgets, rate limits, outages, and lost
+    acknowledgments produce explicit partial/unknown results, never a
+    clean-repository claim.
+    """
+    if transport_error or rate_limited:
+        return {
+            "status": SCAN_UNKNOWN,
+            "reasonCode": "github_connectivity_insufficient",
+            "summary": (
+                f"GitHub connectivity insufficient ({transport_error or 'rate limited'}): "
+                f"{examined} examined, {repaired} repaired, {surfaced} surfaced. "
+                "New admission and shared mutations must stop until connectivity returns."
+            ),
+            "admissionAllowed": False,
+            "examined": examined,
+            "repaired": repaired,
+            "surfaced": surfaced,
+            "deferred": deferred,
+        }
+    if pages_exhausted or requests_exhausted:
+        return {
+            "status": SCAN_PARTIAL,
+            "reasonCode": "budget_exhausted_partial",
+            "summary": (
+                f"Scan budget exhausted (pages={pages_exhausted}, requests={requests_exhausted}): "
+                f"{examined} examined, {repaired} repaired, {surfaced} surfaced, "
+                f"{deferred} deferred. Result is partial, not clean."
+            ),
+            "admissionAllowed": True,
+            "examined": examined,
+            "repaired": repaired,
+            "surfaced": surfaced,
+            "deferred": deferred,
+        }
+    return {
+        "status": SCAN_COMPLETE,
+        "reasonCode": "scan_complete",
+        "summary": (
+            f"Bounded scan examined {examined} issues: {repaired} repaired, "
+            f"{surfaced} surfaced, {deferred} deferred."
+        ),
+        "admissionAllowed": True,
+        "examined": examined,
+        "repaired": repaired,
+        "surfaced": surfaced,
+        "deferred": deferred,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 7: supported default maintenance path + actionable readiness
+# ---------------------------------------------------------------------------
+
+
+def default_reconciliation_schedule() -> dict[str, Any]:
+    """Return the supported default maintenance schedule descriptor.
+
+    Registered through the existing Temporal scheduling/readiness
+    mechanisms (the ``MoonMind.GitHubIssueReconcile`` workflow type and
+    the ``github_issue.reconcile_handoffs`` activity binding). Routine
+    correctness does not depend on a hidden enable flag: the descriptor
+    is enabled and unpaused by default, with explicit overlap/skip and
+    bounded catchup so duplicate observations stay bounded.
+    """
+    return {
+        "workflowType": "MoonMind.GitHubIssueReconcile",
+        "activityType": "github_issue.reconcile_handoffs",
+        "cron": DEFAULT_RECONCILIATION_CRON,
+        "timezone": DEFAULT_RECONCILIATION_TIMEZONE,
+        "overlapMode": DEFAULT_RECONCILIATION_OVERLAP_MODE,
+        "catchupMode": DEFAULT_RECONCILIATION_CATCHUP_MODE,
+        "enabled": True,
+        "paused": False,
+        "summary": (
+            "Default hourly bounded reconciliation through the existing "
+            "Temporal workflow/activity boundary; no hidden enable flag and "
+            "no permanently paused schedule."
+        ),
+    }
+
+
+def check_reconciliation_readiness(
+    *,
+    token_available: bool,
+    token_error: str = "",
+    permission_ok: bool = True,
+    permission_detail: str = "",
+    repository_authorized: bool = True,
+) -> dict[str, Any]:
+    """Check local readiness before any GitHub mutation (Req 7).
+
+    Missing credentials or permissions are actionable local readiness
+    failures: no fallback to another credential, no assumption that
+    GitHub was updated.
+    """
+    if not token_available:
+        return {
+            "ready": False,
+            "reasonCode": "github_credentials_missing",
+            "summary": (
+                "GitHub credentials are not configured for reconciliation: "
+                f"{_string(token_error) or 'no token resolved'}. "
+                "Configure GITHUB_TOKEN or the workflow secret reference; "
+                "no fallback credential is used and no GitHub update is assumed."
+            ),
+        }
+    if not permission_ok:
+        return {
+            "ready": False,
+            "reasonCode": "github_permissions_insufficient",
+            "summary": (
+                "GitHub permissions are insufficient for reconciliation: "
+                f"{_string(permission_detail) or 'permission probe failed'}. "
+                "Grant the required issue/label/comment permissions; no update is assumed."
+            ),
+        }
+    if not repository_authorized:
+        return {
+            "ready": False,
+            "reasonCode": "repository_not_authorized",
+            "summary": (
+                "Repository is not authorized for issue automation; "
+                "reconciliation performs no reads or writes there."
+            ),
+        }
+    return {
+        "ready": True,
+        "reasonCode": "ready",
+        "summary": "Reconciliation readiness satisfied: credentials, permissions, and scope.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Req 8: diagnostics and projections
+# ---------------------------------------------------------------------------
+
+
+def build_reconciliation_diagnostics(
+    *,
+    last_success_at: str = "",
+    pending_effects: Sequence[Mapping[str, Any]] | None = None,
+    ambiguous_owners: Sequence[Mapping[str, Any]] | None = None,
+    failures: Sequence[Mapping[str, Any]] | None = None,
+    scan: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Expose reconciliation state for existing diagnostics/projections.
+
+    Reports the last successful reconciliation, pending issue effects,
+    ambiguous owners, and actionable failures. Progress requires at least
+    one healthy authorized deployment; while all deployments are off or
+    GitHub is inaccessible, the result promises no updates.
+    """
+    pending = [dict(item) for item in (pending_effects or []) if isinstance(item, Mapping)]
+    ambiguous = [dict(item) for item in (ambiguous_owners or []) if isinstance(item, Mapping)]
+    failure_list = [dict(item) for item in (failures or []) if isinstance(item, Mapping)]
+    scan_summary = dict(scan or {})
+    healthy = bool(_string(last_success_at)) and not failure_list
+    return {
+        "lastSuccessfulReconciliation": _string(last_success_at),
+        "pendingIssueEffects": pending,
+        "ambiguousOwners": ambiguous,
+        "actionableFailures": failure_list,
+        "scan": scan_summary,
+        "progressPossible": healthy or bool(pending) is False and bool(_string(last_success_at)),
+        "summary": (
+            f"Last successful reconciliation: {_string(last_success_at) or 'never'}. "
+            f"{len(pending)} pending effects, {len(ambiguous)} ambiguous owners, "
+            f"{len(failure_list)} actionable failures."
+        ),
+    }
+
+
+__all__ = [
+    "MAX_SCAN_PAGES",
+    "MAX_SCAN_PER_PAGE",
+    "MAX_SCAN_ISSUES",
+    "MAX_SCAN_API_REQUESTS",
+    "MAX_COMMENTS_PER_ISSUE",
+    "MAX_RECONCILER_COMMENTS_PER_ISSUE",
+    "MAX_INCIDENTS_PER_ISSUE_PER_RUN",
+    "RETRY_BACKOFF_SECONDS",
+    "MAX_MUTATION_RETRIES_PER_ISSUE",
+    "DEFAULT_RECONCILIATION_CRON",
+    "DEFAULT_RECONCILIATION_TIMEZONE",
+    "DEFAULT_RECONCILIATION_OVERLAP_MODE",
+    "DEFAULT_RECONCILIATION_CATCHUP_MODE",
+    "RECONCILER_MARKER_PREFIX",
+    "ACTION_COMPLETE",
+    "ACTION_ATTENTION",
+    "ACTION_NO_ACTION",
+    "ACTION_DEFERRED_UNKNOWN",
+    "ACTION_ABANDONED",
+    "ACTIONS",
+    "SCAN_COMPLETE",
+    "SCAN_PARTIAL",
+    "SCAN_UNKNOWN",
+    "SCAN_IN_SCOPE_SETTLED",
+    "ReconciliationDecision",
+    "is_scan_in_scope",
+    "classify_issue_for_scan",
+    "classify_evidence_source",
+    "decide_issue_reconciliation",
+    "plan_repair_mutation",
+    "plan_blocked_repair_mutation",
+    "classify_repair_readback",
+    "reconciler_comment_key",
+    "render_reconciler_comment",
+    "should_post_reconciler_comment",
+    "targeted_attention_ops",
+    "record_pending_effect",
+    "drop_pending_effect",
+    "pending_effects_for_issue",
+    "merge_scan_results",
+    "default_reconciliation_schedule",
+    "check_reconciliation_readiness",
+    "build_reconciliation_diagnostics",
+]

--- a/moonmind/workflows/temporal/workflow_registry.py
+++ b/moonmind/workflows/temporal/workflow_registry.py
@@ -125,6 +125,11 @@ STATIC_WORKFLOW_REGISTRATIONS = (
         "MoonMindPublicationRecoveryWorkflow",
         "operator",
     ),
+    WorkflowRegistration(
+        "moonmind.workflows.temporal.workflows.github_issue_reconcile",
+        "MoonMindGitHubIssueReconcileWorkflow",
+        "operator",
+    ),
 )
 
 

--- a/moonmind/workflows/temporal/workflows/github_issue_reconcile.py
+++ b/moonmind/workflows/temporal/workflows/github_issue_reconcile.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from moonmind.workflows.temporal.activity_catalog import (
+        build_default_activity_catalog,
+    )
+
+DEFAULT_ACTIVITY_CATALOG = build_default_activity_catalog()
+
+
+@workflow.defn(name="MoonMind.GitHubIssueReconcile")
+class MoonMindGitHubIssueReconcileWorkflow:
+    """Bounded periodic reconciliation of interrupted issue handoffs (#4182).
+
+    Runs through the existing Temporal workflow/activity boundary (no new
+    always-on container): resolves the ``github_issue.reconcile_handoffs``
+    activity route from the canonical catalog and executes one bounded run
+    for the requested repository. Duplicate observations stay bounded via
+    the schedule's skip-on-overlap policy; the activity itself is
+    retry-safe across independent reconcilers.
+    """
+
+    @workflow.run
+    async def run(self, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        payload = dict(payload or {})
+        repository = str(payload.get("repository") or payload.get("repo") or "")
+        workflow.set_current_details(f"Reconciling interrupted issue handoffs for {repository or '<unscoped>'}")
+        workflow.upsert_search_attributes(
+            {
+                "SessionStatus": ["reconciling"],
+                "IsDegraded": [False],
+            }
+        )
+        route = DEFAULT_ACTIVITY_CATALOG.resolve_activity("github_issue.reconcile_handoffs")
+        try:
+            result = await workflow.execute_activity(
+                "github_issue.reconcile_handoffs",
+                payload,
+                task_queue=route.task_queue,
+                start_to_close_timeout=timedelta(seconds=route.timeouts.start_to_close_seconds),
+                schedule_to_close_timeout=timedelta(seconds=route.timeouts.schedule_to_close_seconds),
+                retry_policy=RetryPolicy(
+                    initial_interval=timedelta(seconds=5),
+                    backoff_coefficient=2.0,
+                    maximum_interval=timedelta(seconds=route.retries.max_interval_seconds),
+                    maximum_attempts=route.retries.max_attempts,
+                    non_retryable_error_types=list(route.retries.non_retryable_error_codes),
+                ),
+                summary="Reconcile interrupted GitHub issue handoffs",
+            )
+        except Exception:
+            workflow.set_current_details("GitHub issue reconcile failed")
+            workflow.upsert_search_attributes(
+                {
+                    "SessionStatus": ["failed"],
+                    "IsDegraded": [True],
+                }
+            )
+            raise
+        normalized = dict(result or {})
+        degraded = bool(normalized.get("diagnostics", {}).get("actionableFailures")) if isinstance(normalized.get("diagnostics"), dict) else False
+        workflow.set_current_details("GitHub issue reconcile complete")
+        workflow.upsert_search_attributes(
+            {
+                "SessionStatus": ["completed"],
+                "IsDegraded": [degraded],
+            }
+        )
+        return normalized

--- a/tests/unit/workflows/temporal/test_github_issue_reconciliation_4182.py
+++ b/tests/unit/workflows/temporal/test_github_issue_reconciliation_4182.py
@@ -1,0 +1,570 @@
+"""Interrupted-handoff reconciliation and unresponsive-owner surfacing (#4182).
+
+Covers MoonLadderStudios/MoonMind#4182 acceptance through the real
+policy/Activity call shapes: crash-between-comment-and-labels repair
+without reimplementation, mixed-label blocking with successor
+invalidation, unresponsive/manual-owner surfacing without age-based
+release, two-reconciler retry safety with coalesced reporting and
+targeted label ops, explicit uncertainty across rate limits/outages/
+lost acks/pagination/restart/unknown merges, default-deployment
+scheduling through the production boundary, and local-vs-remote evidence
+distinction preserving the source outcome.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from moonmind.workflows.temporal import github_issue_reconciliation as recon
+from moonmind.workflows.temporal import github_issue_lifecycle as lifecycle
+from moonmind.workflows.temporal.activities import github_issue_reconciliation_activities as acts
+from moonmind.workflows.temporal.github_issue_attempt import (
+    AttemptHandoff,
+    render_attempt_comment,
+)
+
+REPO = "o/r"
+ATTEMPT_ID = "att_" + "a" * 24
+
+
+def _conclusive_writer() -> dict[str, Any]:
+    return {
+        "writers_stopped": True,
+        "stop_method": "runtime_quiescence",
+        "stop_evidence": "runtime reports 0 writers; poll confirms stopped",
+    }
+
+
+def _settled_mutations() -> dict[str, Any]:
+    return {"push_outcome": "confirmed", "pr_outcome": "confirmed", "merge_outcome": "absent_na", "merge_outcome_absent": True}
+
+
+def _verified_preservation() -> dict[str, Any]:
+    return {
+        "save_method": "pr_head_verified",
+        "pr_url": "https://github.com/o/r/pull/7",
+        "pr_head_sha": "b" * 40,
+        "pr_base": "main",
+        "revision": "b" * 40,
+        "preservation_verified": True,
+    }
+
+
+def _handoff_body(**overrides: Any) -> str:
+    base: dict[str, Any] = {
+        "attempt_id": ATTEMPT_ID,
+        "deployment_id": "deploy-a",
+        "repository": REPO,
+        "issue_number": 11,
+        "workflow_id": "wf-1",
+        "run_id": "run-1",
+        "activity": "releasing",
+        "writers_stopped": True,
+        "stop_evidence": "runtime reports 0 writers",
+        "pending_disposition": "code_review",
+        "pr_url": "https://github.com/o/r/pull/7",
+        "pr_head_sha": "b" * 40,
+        "pr_base": "main",
+        "outcome": "completed",
+        "next_action": "continue-review",
+    }
+    base.update(overrides)
+    body, error = render_attempt_comment(AttemptHandoff(**base))
+    assert not error, error
+    return body
+
+
+class FakeGitHubService:
+    """Minimal trusted-boundary fake: targeted ops only, no whole-set writes."""
+
+    def __init__(self, issues: dict[int, dict[str, Any]] | None = None, comments: dict[int, list[str]] | None = None):
+        self.issues = dict(issues or {})
+        self.comments = {number: list(bodies) for number, bodies in (comments or {}).items()}
+        self.added: list[tuple[int, list[str]]] = []
+        self.removed: list[tuple[int, str]] = []
+        self.created: list[tuple[int, str]] = []
+        self.closed: list[int] = []
+        self.read_issue_result: dict[str, Any] | None = None
+
+    def _github_headers(self, token: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {token}"}
+
+    async def resolve_github_token(self, explicit_token=None, *, repo=None):
+        return "fake-token", None
+
+    async def get_issue(self, *, repo: str, issue_number: int) -> dict[str, Any]:
+        if self.read_issue_result is not None:
+            return dict(self.read_issue_result)
+        issue = self.issues.get(issue_number)
+        if issue is None:
+            return {"ok": False, "reasonCode": "denied", "summary": "Issue read denied with HTTP 404."}
+        return {"ok": True, "reasonCode": "read", "issue": dict(issue)}
+
+    async def list_issue_comments(self, *, repo: str, issue_number: int, github_token=None) -> dict[str, Any]:
+        bodies = self.comments.get(issue_number, [])
+        return {"ok": True, "reasonCode": "read", "comments": [{"id": index + 1, "body": body} for index, body in enumerate(bodies)], "incomplete": False}
+
+    async def add_issue_labels(self, *, repo: str, issue_number: int, labels: list[str], github_token=None) -> dict[str, Any]:
+        self.added.append((issue_number, list(labels)))
+        issue = self.issues.setdefault(issue_number, {"state": "open", "labels": []})
+        names = issue.setdefault("labels", [])
+        for label in labels:
+            if label.lower() not in {str(n).lower() for n in names}:
+                names.append(label)
+        return {"ok": True, "reasonCode": "added", "summary": f"Added {labels}."}
+
+    async def remove_issue_label(self, *, repo: str, issue_number: int, label: str, github_token=None) -> dict[str, Any]:
+        self.removed.append((issue_number, label))
+        issue = self.issues.setdefault(issue_number, {"state": "open", "labels": []})
+        issue["labels"] = [n for n in issue.get("labels", []) if str(n).lower() != label.lower()]
+        return {"ok": True, "reasonCode": "removed", "summary": f"Removed {label}."}
+
+    async def create_issue_comment(self, *, repo: str, issue_number: int, body: str, github_token=None) -> dict[str, Any]:
+        self.created.append((issue_number, body))
+        self.comments.setdefault(issue_number, []).append(body)
+        return {"ok": True, "reasonCode": "created", "summary": "Comment created.", "commentId": len(self.comments[issue_number])}
+
+    async def close_issue(self, *, repo: str, issue_number: int, github_token=None) -> dict[str, Any]:
+        self.closed.append(issue_number)
+        self.issues.setdefault(issue_number, {"state": "open", "labels": []})["state"] = "closed"
+        return {"ok": True, "reasonCode": "closed", "summary": "Closed."}
+
+
+def _issue(*labels: str, state: str = "open") -> dict[str, Any]:
+    return {"state": state, "labels": list(labels)}
+
+
+# -- Acceptance: crash between terminal comment and label writes -------------
+
+
+def test_crash_reconciled_from_conclusive_evidence_without_reimplementation() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        intended_from_settled="in_progress",
+        intended_to_target="to_code_review",
+        writer_evidence=_conclusive_writer(),
+        mutation_evidence=_settled_mutations(),
+        preservation_evidence=_verified_preservation(),
+        proposed_disposition="code_review",
+        trusted_handoff_present=True,
+        remote_handoff={"activity": "releasing", "attemptId": ATTEMPT_ID},
+        local_workflow_available=False,
+    )
+    assert decision.action == recon.ACTION_COMPLETE
+    assert decision.to_target == "to_code_review"
+    planned = recon.plan_repair_mutation(
+        from_settled="in_progress",
+        to_target="to_code_review",
+        current_labels=["status: in-progress"],
+        proposed_disposition="code_review",
+    )
+    assert planned["allowed"] is True
+    mutation = planned["mutation"]
+    # Targeted ops only: destination added first, old blocker removed, no
+    # whole-label-set replacement, no implementation repeated.
+    assert mutation["labelsToAdd"] == ["status: code-review"]
+    assert mutation["labelsToRemove"] == ["status: in-progress"]
+
+
+def test_inconclusive_crash_evidence_surfaced_not_repaired() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        intended_from_settled="in_progress",
+        intended_to_target="to_code_review",
+        writer_evidence={"writers_stopped": False},
+        mutation_evidence=_settled_mutations(),
+        preservation_evidence=_verified_preservation(),
+        proposed_disposition="code_review",
+        trusted_handoff_present=True,
+        remote_handoff={"activity": "active", "attemptId": ATTEMPT_ID},
+        local_workflow_available=False,
+    )
+    assert decision.action == recon.ACTION_ATTENTION
+    assert decision.to_target == ""
+
+
+# -- Acceptance: mixed labels block until repaired; successors invalidate ----
+
+
+def test_mixed_labels_block_until_repaired() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress", "status: needs-attention"),
+        trusted_handoff_present=True,
+        remote_handoff={"activity": "active", "attemptId": ATTEMPT_ID},
+    )
+    assert decision.action == recon.ACTION_ATTENTION
+    assert decision.reason_code == "mixed_labels_blocked"
+    assert set(decision.retain_labels) == {"status: in-progress", "status: needs-attention"}
+
+
+def test_mixed_labels_repaired_with_conclusive_evidence() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress", "status: needs-attention"),
+        intended_from_settled="blocked_mixed",
+        intended_to_target="to_needs_attention",
+        writer_evidence=_conclusive_writer(),
+        mutation_evidence=_settled_mutations(),
+        preservation_evidence=_verified_preservation(),
+        proposed_disposition="needs_attention",
+        trusted_handoff_present=True,
+        remote_handoff={"activity": "releasing", "attemptId": ATTEMPT_ID},
+    )
+    assert decision.action == recon.ACTION_COMPLETE
+
+
+@pytest.mark.parametrize("successor", ["needs_attention", "closed", "code_review", "available"])
+def test_newer_attempts_and_holds_invalidate_old_cleanup(successor: str) -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        intended_from_settled="in_progress",
+        intended_to_target="to_available",
+        writer_evidence=_conclusive_writer(),
+        mutation_evidence=_settled_mutations(),
+        preservation_evidence=_verified_preservation(),
+        proposed_disposition="available",
+        trusted_handoff_present=True,
+        successor_observed_settled=successor,
+    )
+    assert decision.action in {recon.ACTION_ABANDONED, recon.ACTION_ATTENTION}
+
+
+def test_operator_hold_abandons_repair() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        intended_from_settled="in_progress",
+        intended_to_target="to_available",
+        writer_evidence=_conclusive_writer(),
+        mutation_evidence=_settled_mutations(),
+        preservation_evidence=_verified_preservation(),
+        proposed_disposition="available",
+        trusted_handoff_present=True,
+        operator_hold=True,
+    )
+    assert decision.action in {recon.ACTION_ABANDONED, recon.ACTION_ATTENTION}
+    assert decision.to_target == ""
+
+
+# -- Acceptance: unresponsive owners and manual labels, no age-based release -
+
+
+def test_manual_in_progress_surfaced_without_age_clear() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        trusted_handoff_present=False,
+        manual_in_progress=True,
+    )
+    assert decision.action == recon.ACTION_ATTENTION
+    assert decision.reason_code == "manual_in_progress_surfaced"
+    assert "status: in-progress" in decision.retain_labels
+
+
+def test_silent_owner_surfaced_with_old_status_retained() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        trusted_handoff_present=True,
+        writer_evidence={"writers_stopped": False},
+        remote_handoff={"activity": "active", "attemptId": ATTEMPT_ID},
+        local_workflow_available=False,
+    )
+    assert decision.action == recon.ACTION_ATTENTION
+    assert decision.reason_code == "unresponsive_owner_uncertain"
+    assert "status: in-progress" in decision.retain_labels
+    ops = recon.targeted_attention_ops(current_labels=["status: in-progress"], attention_already_present=False)
+    assert ops["labelsToAdd"] == ["status: needs-attention"]
+    assert ops["labelsToRemove"] == []
+
+
+def test_unrecognized_status_never_silently_admitted() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: claiming"),
+        trusted_handoff_present=False,
+    )
+    assert decision.action == recon.ACTION_ATTENTION
+    assert decision.reason_code == "classification_required"
+
+
+# -- Acceptance: unknown outcomes require attention, not timed unlock --------
+
+
+def test_unknown_merge_outcome_blocks_takeover() -> None:
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        intended_from_settled="in_progress",
+        intended_to_target="to_available",
+        writer_evidence=_conclusive_writer(),
+        mutation_evidence=_settled_mutations(),
+        preservation_evidence=_verified_preservation(),
+        proposed_disposition="available",
+        trusted_handoff_present=True,
+        pr_state={"mergeRequested": True, "mergeOutcomeKnown": False},
+        remote_handoff={"activity": "releasing", "attemptId": ATTEMPT_ID},
+    )
+    assert decision.action == recon.ACTION_ATTENTION
+    assert decision.reason_code == "unknown_external_outcome"
+
+
+def test_unmerged_pr_never_proves_merge_cannot_complete() -> None:
+    assert recon._unknown_external_block({"mergeRequested": True, "mergeOutcomeKnown": False}) is True
+    assert recon._unknown_external_block({"mergeRequested": False}) is False
+    assert recon._unknown_external_block(None) is False
+
+
+# -- Acceptance: two reconcilers, no overwrite, bounded comments --------------
+
+
+def test_reconciler_never_rewrites_attempt_comments_and_coalesces() -> None:
+    existing = _handoff_body()
+    new_body = recon.render_reconciler_comment(
+        repository=REPO, issue_number=11, reason_code="unresponsive_owner_uncertain", summary="Owner uncertain."
+    )
+    assert "att_" + "a" * 24 not in new_body or "ownership unchanged" in new_body
+    # The reconciler marker never collides with the attempt marker.
+    assert "<!-- moonmind-github-attempt:" not in new_body
+    gate = recon.should_post_reconciler_comment(existing_bodies=[existing], reason_code="unresponsive_owner_uncertain", new_body=new_body)
+    assert gate["post"] is True  # unrelated attempt comment does not coalesce
+    gate2 = recon.should_post_reconciler_comment(existing_bodies=[new_body], reason_code="unresponsive_owner_uncertain", new_body=new_body)
+    assert gate2["post"] is False  # duplicate observation coalesced
+
+
+@pytest.mark.asyncio
+async def test_two_reconciler_runs_produce_one_observation(tmp_path) -> None:
+    service = FakeGitHubService(
+        issues={11: _issue("status: in-progress")},
+        comments={11: []},
+    )
+    kwargs: dict[str, Any] = {"repository": REPO, "issue_numbers": [11], "state_dir": str(tmp_path), "service": service}
+    first = await acts.reconcile_github_issue_handoffs(**kwargs)
+    second = await acts.reconcile_github_issue_handoffs(**kwargs)
+    assert first["results"][0]["action"] == recon.ACTION_ATTENTION
+    # Exactly one observation comment across both independent runs.
+    assert len(service.created) == 1
+    assert second["results"][0].get("commentCoalesced") is True
+    # Only targeted single-label ops; no whole-set replacement exists.
+    for _, labels in service.added:
+        assert len(labels) == 1
+
+
+# -- Acceptance: uncertainty preserved across failure modes --------------------
+
+
+def test_rate_limit_and_outage_return_unknown_and_stop_admission() -> None:
+    for transport in ("rate_limited", "outcome_unknown"):
+        scan = recon.merge_scan_results(examined=3, surfaced=1, transport_error=transport, rate_limited=(transport == "rate_limited"))
+        assert scan["status"] == recon.SCAN_UNKNOWN
+        assert scan["admissionAllowed"] is False
+
+
+def test_exhausted_budgets_return_partial_never_clean() -> None:
+    scan = recon.merge_scan_results(examined=100, repaired=2, pages_exhausted=True, requests_exhausted=True)
+    assert scan["status"] == recon.SCAN_PARTIAL
+    assert "not clean" in scan["summary"]
+
+
+@pytest.mark.asyncio
+async def test_worker_restart_preserves_pending_sync(tmp_path) -> None:
+    store = recon.record_pending_effect(
+        None, repository=REPO, issue_number=11,
+        intended_from_settled="in_progress", intended_to_target="to_code_review",
+        proposed_disposition="code_review", reason="crash before label writes",
+    )
+    assert recon.pending_effects_for_issue(store, repository=REPO, issue_number=11)
+    service = FakeGitHubService(issues={11: _issue("status: in-progress")}, comments={11: [_handoff_body()]})
+    (tmp_path / "pending_sync.json").write_text(json.dumps(store), encoding="utf-8")
+
+    async def _known_pr(*, service: Any, pr_url: str) -> dict[str, Any]:
+        return {"known": True, "state": "open", "merged": False, "headSha": "b" * 40, "reasonCode": "pr_read", "summary": "open"}
+
+    import moonmind.workflows.temporal.activities.github_issue_reconciliation_activities as activity_module
+
+    original = activity_module._fetch_pr_state
+    activity_module._fetch_pr_state = _known_pr  # type: ignore[assignment]
+    try:
+        result = await acts.reconcile_github_issue_handoffs(repository=REPO, issue_numbers=[11], state_dir=str(tmp_path), service=service)
+    finally:
+        activity_module._fetch_pr_state = original
+    item = result["results"][0]
+    assert item["action"] == recon.ACTION_COMPLETE
+    assert item["reasonCode"] == "repaired"
+    assert "status: code-review" in service.issues[11]["labels"]
+    assert "status: in-progress" not in service.issues[11]["labels"]
+
+
+@pytest.mark.asyncio
+async def test_lost_acknowledgment_retains_pending_evidence(tmp_path) -> None:
+    class LossyService(FakeGitHubService):
+        async def add_issue_labels(self, *, repo: str, issue_number: int, labels: list[str], github_token=None) -> dict[str, Any]:
+            self.added.append((issue_number, list(labels)))
+            return {"ok": False, "reasonCode": "outcome_unknown", "summary": "Response lost; result unknown."}
+
+    service = LossyService(issues={11: _issue("status: in-progress")}, comments={11: [_handoff_body()]})
+
+    async def _known_pr(*, service: Any, pr_url: str) -> dict[str, Any]:
+        return {"known": True, "state": "open", "merged": False, "headSha": "b" * 40, "reasonCode": "pr_read", "summary": "open"}
+
+    import moonmind.workflows.temporal.activities.github_issue_reconciliation_activities as activity_module
+
+    original = activity_module._fetch_pr_state
+    activity_module._fetch_pr_state = _known_pr  # type: ignore[assignment]
+    try:
+        store = recon.record_pending_effect(
+            None, repository=REPO, issue_number=11,
+            intended_from_settled="in_progress", intended_to_target="to_code_review",
+            proposed_disposition="code_review", reason="known interrupted transition",
+        )
+        (tmp_path / "pending_sync.json").write_text(json.dumps(store), encoding="utf-8")
+        result = await acts.reconcile_github_issue_handoffs(repository=REPO, issue_numbers=[11], state_dir=str(tmp_path), service=service)
+    finally:
+        activity_module._fetch_pr_state = original
+    item = result["results"][0]
+    assert item["action"] == recon.ACTION_DEFERRED_UNKNOWN
+    persisted = json.loads((tmp_path / "pending_sync.json").read_text(encoding="utf-8"))
+    assert recon.pending_effects_for_issue(persisted, repository=REPO, issue_number=11)
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_issue_read_defers_with_uncertainty(tmp_path) -> None:
+    service = FakeGitHubService(issues={11: _issue("status: in-progress")})
+    service.read_issue_result = {"ok": False, "reasonCode": "rate_limited", "summary": "Issue read rate limited (HTTP 429)."}
+    result = await acts.reconcile_github_issue_handoffs(repository=REPO, issue_numbers=[11], state_dir=str(tmp_path), service=service)
+    assert result["ok"] is False
+    assert result["scan"]["status"] == recon.SCAN_UNKNOWN
+    assert result["admissionAllowed"] is False
+
+
+# -- Acceptance: default deployment schedules bounded reconciliation ----------
+
+
+def test_default_maintenance_path_is_supported_not_hidden_or_paused() -> None:
+    schedule = recon.default_reconciliation_schedule()
+    assert schedule["workflowType"] == "MoonMind.GitHubIssueReconcile"
+    assert schedule["activityType"] == "github_issue.reconcile_handoffs"
+    assert schedule["enabled"] is True
+    assert schedule["paused"] is False
+    assert schedule["overlapMode"] == "skip"
+
+
+def test_production_boundary_wires_workflow_activity_and_registry() -> None:
+    from moonmind.workflows.temporal.activity_catalog import build_default_activity_catalog
+    from moonmind.workflows.temporal.activity_runtime import _ACTIVITY_HANDLER_ATTRS
+    from moonmind.workflows.temporal.workflow_registry import raw_workflow_registrations
+    from moonmind.workflows.temporal.workflows.github_issue_reconcile import MoonMindGitHubIssueReconcileWorkflow
+
+    catalog = build_default_activity_catalog()
+    route = catalog.resolve_activity("github_issue.reconcile_handoffs")
+    assert route.task_queue
+    assert route.fleet == "integrations"
+    assert _ACTIVITY_HANDLER_ATTRS["github_issue.reconcile_handoffs"] == ("integrations", "github_issue_reconcile_handoffs")
+    assert MoonMindGitHubIssueReconcileWorkflow is not None
+    by_type = {r.load_class().__name__: r for r in raw_workflow_registrations()}
+    assert "MoonMindGitHubIssueReconcileWorkflow" in by_type
+
+
+def test_missing_credentials_are_actionable_not_silent_fallback() -> None:
+    readiness = recon.check_reconciliation_readiness(token_available=False, token_error="no token resolved")
+    assert readiness["ready"] is False
+    assert readiness["reasonCode"] == "github_credentials_missing"
+    assert "no fallback" in readiness["summary"]
+
+
+@pytest.mark.asyncio
+async def test_activity_refuses_mutations_without_credentials(tmp_path) -> None:
+    class NoAuthService(FakeGitHubService):
+        async def resolve_github_token(self, explicit_token=None, *, repo=None):
+            return "", "no token configured"
+
+    result = await acts.reconcile_github_issue_handoffs(repository=REPO, issue_numbers=[11], state_dir=str(tmp_path), service=NoAuthService())
+    assert result["ok"] is False
+    assert result["admissionAllowed"] is False
+    assert result["results"] == []
+
+
+# -- Acceptance: local vs remote evidence distinction --------------------------
+
+
+def test_local_terminal_evidence_distinguished_from_remote_unresponsive() -> None:
+    local = recon.classify_evidence_source(
+        local_terminal_record={"terminal_recorded": True, "primaryOutcome": "failed"},
+        remote_handoff=None,
+        local_workflow_available=True,
+    )
+    assert local["locallyConfirmed"] is True
+    assert local["sourceOutcome"] == "failed"
+    assert local["sourceOutcomePreserved"] is True
+    remote = recon.classify_evidence_source(
+        local_terminal_record=None, remote_handoff={"activity": "active"}, local_workflow_available=False
+    )
+    assert remote["locallyConfirmed"] is False
+    assert remote["remoteUnresponsive"] is True
+
+
+def test_missing_local_record_is_not_remote_failure() -> None:
+    source = recon.classify_evidence_source(local_terminal_record=None, remote_handoff=None, local_workflow_available=False)
+    assert source["remoteUnresponsive"] is True
+    assert source["locallyConfirmed"] is False
+    # Uncertainty surfaces attention; it never fabricates a local failure.
+    decision = recon.decide_issue_reconciliation(
+        issue=_issue("status: in-progress"),
+        trusted_handoff_present=False,
+        manual_in_progress=True,
+    )
+    assert decision.action == recon.ACTION_ATTENTION
+
+
+def test_diagnostics_expose_last_run_pending_ambiguous_and_failures() -> None:
+    diagnostics = recon.build_reconciliation_diagnostics(
+        last_success_at="2026-09-11T00:00:00Z",
+        pending_effects=[{"key": "o/r#11"}],
+        ambiguous_owners=[{"issueNumber": 12, "reasonCode": "unresponsive_owner_uncertain"}],
+        failures=[{"reasonCode": "rate_limited", "summary": "slow down"}],
+        scan={"status": recon.SCAN_UNKNOWN},
+    )
+    assert diagnostics["lastSuccessfulReconciliation"] == "2026-09-11T00:00:00Z"
+    assert len(diagnostics["pendingIssueEffects"]) == 1
+    assert len(diagnostics["ambiguousOwners"]) == 1
+    assert len(diagnostics["actionableFailures"]) == 1
+
+
+def test_blocked_repair_plan_touches_only_lifecycle_labels() -> None:
+    planned = recon.plan_repair_mutation(
+        from_settled="blocked_mixed",
+        to_target="to_needs_attention",
+        current_labels=["status: in-progress", "status: needs-attention", "bug"],
+        proposed_disposition="needs_attention",
+    )
+    assert planned["allowed"] is True
+    assert planned["mutation"]["labelsToAdd"] == []
+    assert planned["mutation"]["labelsToRemove"] == ["status: in-progress"]
+    readback = recon.classify_repair_readback(
+        mutation=planned["mutation"],
+        read_back={"state": "open", "labels": ["status: needs-attention", "bug"]},
+        to_target="to_needs_attention",
+    )
+    assert readback["outcome"] == lifecycle.OUTCOME_APPLIED
+    stale = recon.classify_repair_readback(
+        mutation=planned["mutation"],
+        read_back={"state": "open", "labels": ["status: in-progress", "status: needs-attention"]},
+        to_target="to_needs_attention",
+    )
+    assert stale["outcome"] == lifecycle.OUTCOME_INCOMPLETE
+    unknown = recon.classify_repair_readback(mutation=planned["mutation"], read_back=None)
+    assert unknown["outcome"] == lifecycle.OUTCOME_UNKNOWN
+
+
+def test_scan_scope_independent_of_eligible_candidate_filter() -> None:
+    # Stranded in-progress/attention/review states are in scope even though
+    # Search and Implement would never select them as candidates.
+    for labels, expected in [
+        (["status: in-progress"], True),
+        (["status: needs-attention"], True),
+        (["status: code-review"], True),
+        (["status: in-progress", "status: needs-attention"], True),
+        ([], False),
+        (["status: recovery-needed"], False),
+    ]:
+        result = recon.classify_issue_for_scan({"state": "open", "labels": labels})
+        assert result["inScope"] is expected, labels
+        if expected:
+            assert lifecycle.interpret_issue({"state": "open", "labels": labels}).eligible_for_implement is False

--- a/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
+++ b/tests/unit/workflows/temporal/test_temporal_worker_runtime.py
@@ -4284,6 +4284,9 @@ async def test_main_async_workflow_fleet(
     from moonmind.workflows.temporal.workflows.omnigent_session import (
         MoonMindOmnigentSessionWorkflow,
     )
+    from moonmind.workflows.temporal.workflows.github_issue_reconcile import (
+        MoonMindGitHubIssueReconcileWorkflow,
+    )
 
     assert kwargs["workflows"] == (
         MoonMindUserWorkflow,
@@ -4301,6 +4304,7 @@ async def test_main_async_workflow_fleet(
         MoonMindMergeAutomationWorkflow,
         MoonMindPRResolverWorkflow,
         MoonMindPublicationRecoveryWorkflow,
+        MoonMindGitHubIssueReconcileWorkflow,
     )
     assert kwargs["activities"] == (
         resolve_adapter_metadata,

--- a/tests/unit/workflows/temporal/test_temporal_workers.py
+++ b/tests/unit/workflows/temporal/test_temporal_workers.py
@@ -144,6 +144,7 @@ def test_registered_workflow_types_exclude_retired_manifest_ingest():
         "MoonMind.MergeAutomation",
         "MoonMind.PRResolver",
         "MoonMind.PublicationRecoveryV1",
+        "MoonMind.GitHubIssueReconcile",
     )
 
 


### PR DESCRIPTION
## Summary

Implements bounded periodic repair and stale-work visibility for interrupted GitHub issue handoffs (MoonLadderStudios/MoonMind#4182).

- New deterministic policy module `moonmind/workflows/temporal/github_issue_reconciliation.py`: bounded GitHub-only scan independent of Search/Implement's eligible-candidate filter, conclusive-evidence repair reusing lifecycle/finalization semantics, uncertain-ownership surfacing (no age-clear, no takeover), unknown-outcome handling, retry-safe reconciler identity with coalesced observations and targeted label ops only.
- New durable Activity `moonmind/activities/github_issue_reconciliation_activities.py`: persisted pending-sync evidence across restarts/outages, bounded pages/requests/retries with backoff and rate-limit handling, explicit partial/unknown results, admission blocked during insufficient connectivity.
- Production boundary: `MoonMind.GitHubIssueReconcile` workflow + `github_issue.reconcile_handoffs` activity registered in workflow registry, activity catalog, and runtime; default maintenance schedule registered through existing scheduling/readiness mechanisms (enabled, not paused, no hidden flag). No new always-on container, leader service, or shared database.
- Diagnostics: last successful reconciliation, pending issue effects, ambiguous owners, and actionable failures exposed through existing diagnostics/projections.

## Verification outcome

Latest controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (confidence HIGH) at candidate 84f56b48. All 8 required-work items and 7 acceptance criteria verified against current-head code and test evidence. Initial assessment was NOT_IMPLEMENTED against pre-implementation base; this run produced the implementation.

## Tests run

- 30/30 new unit tests in `tests/unit/workflows/temporal/test_github_issue_reconciliation_4182.py` — PASS via managed container backend.
- 307/307 neighboring lifecycle/finalization-4179/attempts-4177/admission-4178/activity-catalog tests — PASS.
- Hermetic compose-backed integration suite: not run (no integration suite exists for this journey; unit tests exercise the real policy and Activity call shapes with fakes at the trusted service boundary).

## Remaining risks

- No hermetic end-to-end rehearsal against live GitHub/Temporal; first production reconciliation runs will exercise real pagination, rate-limit, and PR-state paths.
- Two independent reconcilers may emit duplicate observations under race (by design bounded to one coalesced comment per issue); prolonged GitHub outages surface explicit unknown results rather than progress.

Closes MoonLadderStudios/MoonMind#4182