### PR TITLE
[Create UI] Fix laggy branch paste with text-first picker, bounded suggestions, and exact lookup (MoonLadderStudios/MoonMind#4054)

### DIFF
--- a/api_service/api/routers/workflow_console.py
+++ b/api_service/api/routers/workflow_console.py
@@ -38,9 +38,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api_service.db.base import get_async_session
 from api_service.api.routers.workflow_console_view_model import (
-    build_repository_branch_options,
+    build_repository_branch_metadata_async,
+    build_repository_branch_options_async,
     build_repository_issue_options,
     resolve_dashboard_runtime_config,
+    resolve_repository_branch_async,
 )
 from api_service.auth_providers import get_current_user
 from api_service.db.models import AgentSkillDefinition, TemporalArtifact, User
@@ -409,11 +411,35 @@ class DashboardBranchOption(BaseModel):
 
 
 class DashboardBranchListResponse(BaseModel):
-    """Dashboard response containing branch options for one repository."""
+    """Dashboard response containing bounded branch suggestions for one repository."""
 
     items: list[DashboardBranchOption] = Field(default_factory=list)
     error: str | None = Field(None)
     default_branch: str | None = Field(None, alias="defaultBranch")
+    has_more: bool = Field(False, alias="hasMore")
+
+    model_config = {"populate_by_name": True}
+
+
+class DashboardBranchMetadataResponse(BaseModel):
+    """Metadata-only branch response so form init never enumerates branches."""
+
+    default_branch: str | None = Field(None, alias="defaultBranch")
+    error: str | None = Field(None)
+
+    model_config = {"populate_by_name": True}
+
+
+class DashboardBranchResolveResponse(BaseModel):
+    """Exact-name branch resolution independent of suggestion pages."""
+
+    found: bool = Field(False)
+    branch: str | None = Field(None)
+    default_branch: str | None = Field(None, alias="defaultBranch")
+    error: str | None = Field(None)
+    inconclusive: bool = Field(True)
+
+    model_config = {"populate_by_name": True}
 
 
 class DashboardIssueOption(BaseModel):
@@ -1828,14 +1854,47 @@ async def get_dashboard_skill_input_contract(
     return DashboardSkillInputContractResponse(**option.model_dump(by_alias=True))
 
 
+@router.get(
+    "/api/github/branches/resolve", response_model=DashboardBranchResolveResponse
+)
+async def resolve_dashboard_github_branch(
+    repository: str = Query(..., min_length=1),
+    branch: str = Query(..., min_length=1),
+    _user: User = Depends(get_current_user()),
+) -> DashboardBranchResolveResponse:
+    """Resolve one exact branch name without scanning suggestion pages."""
+
+    payload = await resolve_repository_branch_async(repository, branch)
+    return DashboardBranchResolveResponse(**payload)
+
+
+@router.get(
+    "/api/github/branches/metadata", response_model=DashboardBranchMetadataResponse
+)
+async def get_dashboard_github_branch_metadata(
+    repository: str = Query(..., min_length=1),
+    _user: User = Depends(get_current_user()),
+) -> DashboardBranchMetadataResponse:
+    """Resolve only default-branch metadata so form init never enumerates branches."""
+
+    payload = await build_repository_branch_metadata_async(repository)
+    return DashboardBranchMetadataResponse(**payload)
+
+
 @router.get("/api/github/branches", response_model=DashboardBranchListResponse)
 async def list_dashboard_github_branches(
     repository: str = Query(..., min_length=1),
+    q: str = Query(""),
+    limit: int = Query(20, ge=1, le=50),
     _user: User = Depends(get_current_user()),
 ) -> DashboardBranchListResponse:
-    """List GitHub branches through MoonMind so browsers never call GitHub directly."""
+    """List one bounded page of GitHub branches through MoonMind."""
 
-    payload = build_repository_branch_options(repository)
+    # Awaited async execution keeps the API event loop responsive while the
+    # upstream lookup is delayed; only a single upstream branch page is ever
+    # read per call and hasMore reports further pages instead of draining
+    # them.
+    payload = await build_repository_branch_options_async(repository, q, limit)
     return DashboardBranchListResponse(**payload)
 
 

--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -541,7 +541,6 @@ def _fetch_github_branch_exact(
                 raise
     except (httpx.HTTPError, ValueError):
         return False, None, "GitHub branch lookup is unavailable.", True
-    return False, None, "GitHub branch lookup is unavailable.", True
 
 
 async def _fetch_github_branch_exact_async(
@@ -600,7 +599,6 @@ async def _fetch_github_branch_exact_async(
                 raise
     except (httpx.HTTPError, ValueError):
         return False, None, "GitHub branch lookup is unavailable.", True
-    return False, None, "GitHub branch lookup is unavailable.", True
 
 def _github_repository_options_cache_key(token: str) -> str:
     return sha256(token.encode("utf-8")).hexdigest()

--- a/api_service/api/routers/workflow_console_view_model.py
+++ b/api_service/api/routers/workflow_console_view_model.py
@@ -10,12 +10,11 @@ from copy import deepcopy
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any, Mapping
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 from uuid import UUID
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
-
 from moonmind.config.settings import WorkflowSettings, settings
 from moonmind.omnigent.execution_profiles import public_execution_catalog
 from moonmind.utils.build_info import resolve_moonmind_build_id
@@ -54,9 +53,24 @@ _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS = 60.0
 _GITHUB_REPOSITORY_OPTIONS_CACHE: dict[
     str, tuple[float, tuple["RepositoryOption", ...], str | None]
 ] = {}
-_GITHUB_BRANCH_OPTIONS_CACHE: dict[
-    str, tuple[float, tuple["BranchOption", ...], str | None, str | None]
+# Scoped caches for the text-first branch picker (MoonLadderStudios/MoonMind#4054).
+# Search pages are keyed by token + repository + query + limit; exact-name
+# observations are keyed by token + repository + case-sensitive branch name;
+# metadata is keyed by token + repository. All three use bounded eviction so a
+# cold lookup can never grow memory without bound.
+_GITHUB_BRANCH_SEARCH_CACHE: dict[
+    str, tuple[float, tuple["BranchOption", ...], str | None, str | None, bool]
 ] = {}
+_GITHUB_BRANCH_METADATA_CACHE: dict[str, tuple[float, str | None]] = {}
+_GITHUB_BRANCH_RESOLVE_CACHE: dict[
+    str, tuple[float, bool, str | None, str | None]
+] = {}
+_BRANCH_SUGGESTION_DEFAULT_LIMIT = 20
+_BRANCH_SUGGESTION_MAX_LIMIT = 50
+_BRANCH_QUERY_MAX_LENGTH = 100
+_BRANCH_NAME_MAX_LENGTH = 255
+_BRANCH_CACHE_MAX_ENTRIES = 200
+_BRANCH_GITHUB_SINGLE_PAGE = 1
 
 _JIRA_CREATE_PAGE_SOURCES = {
     "connections": "/api/jira/connections/verify",
@@ -214,33 +228,204 @@ def _fetch_github_repository_options(
                 )
     return options, None
 
-def _fetch_github_branch_options(
-    token: str,
-    repository: str,
-) -> tuple[list[BranchOption], str | None, str | None]:
-    """Fetch credential-visible GitHub branches without exposing secrets."""
+def _clamp_branch_suggestion_limit(limit: object) -> int:
+    """Clamp a caller-supplied suggestion limit to the bounded range."""
 
-    normalized_repository = _normalize_repository_value(repository)
-    if not token or not normalized_repository:
-        return [], None, None
-    headers = {
+    try:
+        parsed = int(str(limit or "").strip() or _BRANCH_SUGGESTION_DEFAULT_LIMIT)
+    except (TypeError, ValueError):
+        return _BRANCH_SUGGESTION_DEFAULT_LIMIT
+    return max(1, min(_BRANCH_SUGGESTION_MAX_LIMIT, parsed))
+
+
+def _normalize_branch_query(query: object) -> str:
+    """Return a bounded search query for local filtering of one branch page."""
+
+    return str(query or "").strip()[:_BRANCH_QUERY_MAX_LENGTH]
+
+
+def _is_valid_branch_name(value: str) -> bool:
+    """Return whether a branch name is worth an exact upstream lookup."""
+
+    candidate = value.strip()
+    if not candidate or len(candidate) > _BRANCH_NAME_MAX_LENGTH:
+        return False
+    if candidate.startswith("/") or candidate.endswith("/"):
+        return False
+    if "//" in candidate or ".." in candidate or "@{" in candidate:
+        return False
+    if candidate.endswith(".lock") or candidate.endswith("."):
+        return False
+    for disallowed in ("\\", "^", ":", "?", "*", "[", "~"):
+        if disallowed in candidate:
+            return False
+    return not any(ord(char) < 32 or ord(char) == 127 for char in candidate)
+
+
+def _bounded_cache_put(cache: dict, key: str, value: object) -> None:
+    """Store a cache entry with oldest-first eviction once the bound is hit."""
+
+    if key in cache:
+        cache[key] = value  # type: ignore[assignment]
+        return
+    while len(cache) >= _BRANCH_CACHE_MAX_ENTRIES:
+        cache.pop(next(iter(cache)))
+    cache[key] = value  # type: ignore[assignment]
+
+
+def _github_branch_headers(token: str) -> dict[str, str]:
+    return {
         "Accept": "application/vnd.github+json",
         "Authorization": f"Bearer {token}",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    options: list[BranchOption] = []
-    seen: set[str] = set()
-    default_branch: str | None = None
+
+
+def _append_branch_option(
+    options: list[BranchOption],
+    seen: set[str],
+    value: object,
+) -> None:
+    branch_name = str(value or "").strip()
+    if not branch_name or branch_name in seen:
+        return
+    seen.add(branch_name)
+    options.append(
+        BranchOption(value=branch_name, label=branch_name, source="github")
+    )
+
+
+def _fetch_repository_default_branch(
+    client: Any,
+    headers: dict[str, str],
+    normalized_repository: str,
+) -> str | None:
+    """Fetch only the small repository metadata projection (default branch)."""
+
+    try:
+        metadata_response = client.get(
+            _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
+                repository=normalized_repository
+            ),
+            headers=headers,
+        )
+        metadata_response.raise_for_status()
+        metadata = metadata_response.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    if isinstance(metadata, dict):
+        return str(metadata.get("default_branch") or "").strip() or None
+    return None
+
+
+def _filter_branch_options(
+    options: list[BranchOption], query: str
+) -> list[BranchOption]:
+    """Filter one bounded page locally; never paginates to find more matches."""
+
+    normalized_query = query.strip().lower()
+    if not normalized_query:
+        return list(options)
+    return [
+        option
+        for option in options
+        if normalized_query in option.value.lower()
+    ]
+
+
+def _fetch_github_branch_options(
+    token: str,
+    repository: str,
+    query: str = "",
+    limit: int = _BRANCH_SUGGESTION_DEFAULT_LIMIT,
+) -> tuple[list[BranchOption], str | None, str | None, bool]:
+    """Fetch at most one bounded branch page plus independent default metadata.
+
+    Form initialization must resolve default-branch metadata even when the
+    suggestion page is slow or fails, so metadata is fetched first and is
+    preserved when the later branch-page request raises. Only a single GitHub
+    branch page is ever read per call; ``has_more`` reports whether GitHub
+    advertises further pages instead of draining them.
+    """
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not token or not normalized_repository:
+        return [], None, None, False
+    normalized_query = _normalize_branch_query(query)
+    clamped_limit = _clamp_branch_suggestion_limit(limit)
+    headers = _github_branch_headers(token)
     next_url: str | None = _GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE.format(
         repository=normalized_repository
     )
-    params: dict[str, int] | None = {"per_page": 100}
+    params: dict[str, int] | None = {"per_page": clamped_limit}
     try:
         with httpx.Client(
             timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
         ) as client:
+            default_branch = _fetch_repository_default_branch(
+                client, headers, normalized_repository
+            )
             try:
-                metadata_response = client.get(
+                page_options: list[BranchOption] = []
+                page_seen: set[str] = set()
+                pages_read = 0
+                has_more = False
+                while next_url and pages_read < _BRANCH_GITHUB_SINGLE_PAGE:
+                    response = client.get(
+                        next_url,
+                        headers=headers,
+                        params=params,
+                    )
+                    params = None
+                    response.raise_for_status()
+                    data = response.json()
+                    if isinstance(data, list):
+                        for item in data:
+                            if not isinstance(item, Mapping):
+                                continue
+                            _append_branch_option(
+                                page_options,
+                                page_seen,
+                                item.get("name"),
+                            )
+                    has_more = bool(response.links.get("next", {}).get("url"))
+                    next_url = None
+                    pages_read += 1
+            except (httpx.HTTPError, ValueError):
+                # A slow/failed suggestion request must not withhold or discard
+                # independently successful default-branch metadata.
+                return [], "GitHub branch lookup is unavailable.", default_branch, False
+    except (httpx.HTTPError, ValueError):
+        return [], "GitHub branch lookup is unavailable.", None, False
+
+    return (
+        _filter_branch_options(page_options, normalized_query),
+        None,
+        default_branch,
+        has_more,
+    )
+
+
+async def _fetch_github_branch_options_async(
+    token: str,
+    repository: str,
+    query: str = "",
+    limit: int = _BRANCH_SUGGESTION_DEFAULT_LIMIT,
+) -> tuple[list[BranchOption], str | None, str | None, bool]:
+    """Awaited async variant so async routes never block the event loop."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not token or not normalized_repository:
+        return [], None, None, False
+    normalized_query = _normalize_branch_query(query)
+    clamped_limit = _clamp_branch_suggestion_limit(limit)
+    headers = _github_branch_headers(token)
+    try:
+        async with httpx.AsyncClient(
+            timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
+        ) as client:
+            try:
+                metadata_response = await client.get(
                     _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
                         repository=normalized_repository
                     ),
@@ -248,49 +433,201 @@ def _fetch_github_branch_options(
                 )
                 metadata_response.raise_for_status()
                 metadata = metadata_response.json()
-                if isinstance(metadata, dict):
-                    default_branch = (
-                        str(metadata.get("default_branch") or "").strip() or None
-                    )
-            except (httpx.HTTPError, ValueError):
-                # Branch discovery can still succeed without default-branch metadata.
-                pass
-            while next_url:
-                response = client.get(
-                    next_url,
-                    headers=headers,
-                    params=params,
+                default_branch = (
+                    str(metadata.get("default_branch") or "").strip() or None
+                    if isinstance(metadata, dict)
+                    else None
                 )
-                params = None
+            except (httpx.HTTPError, ValueError):
+                default_branch = None
+            try:
+                response = await client.get(
+                    _GITHUB_BRANCH_DISCOVERY_URL_TEMPLATE.format(
+                        repository=normalized_repository
+                    ),
+                    headers=headers,
+                    params={"per_page": clamped_limit},
+                )
                 response.raise_for_status()
                 data = response.json()
+                page_options: list[BranchOption] = []
+                page_seen: set[str] = set()
                 if isinstance(data, list):
                     for item in data:
                         if not isinstance(item, Mapping):
                             continue
-                        branch_name = str(item.get("name") or "").strip()
-                        if not branch_name or branch_name in seen:
-                            continue
-                        seen.add(branch_name)
-                        options.append(
-                            BranchOption(
-                                value=branch_name,
-                                label=branch_name,
-                                source="github",
-                            )
+                        _append_branch_option(
+                            page_options, page_seen, item.get("name")
                         )
-                next_url = response.links.get("next", {}).get("url")
+                has_more = bool(response.links.get("next", {}).get("url"))
+            except (httpx.HTTPError, ValueError):
+                return [], "GitHub branch lookup is unavailable.", default_branch, False
     except (httpx.HTTPError, ValueError):
-        return [], "GitHub branch lookup is unavailable.", None
+        return [], "GitHub branch lookup is unavailable.", None, False
 
-    return options, None, default_branch
+    return (
+        _filter_branch_options(page_options, normalized_query),
+        None,
+        default_branch,
+        has_more,
+    )
+
+
+def _fetch_github_branch_exact(
+    token: str,
+    repository: str,
+    branch: str,
+) -> tuple[bool, str | None, str | None, bool]:
+    """Resolve one exact branch name without scanning suggestion pages.
+
+    Returns ``(found, resolved_name, error, inconclusive)``. A 404 for the
+    branch is only reported as definitively absent when repository metadata is
+    independently reachable; otherwise the outcome is inconclusive so callers
+    never turn an unknown repository/access state into a false diagnosis.
+    """
+
+    normalized_repository = _normalize_repository_value(repository)
+    candidate = str(branch or "").strip()
+    if not token or not normalized_repository or not _is_valid_branch_name(candidate):
+        return False, None, None, True
+    headers = _github_branch_headers(token)
+    encoded_branch = quote(candidate, safe="/")
+    branch_url = (
+        f"https://api.github.com/repos/{normalized_repository}"
+        f"/branches/{encoded_branch}"
+    )
+    try:
+        with httpx.Client(
+            timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
+        ) as client:
+            try:
+                response = client.get(branch_url, headers=headers)
+                if response.status_code == 404:
+                    metadata = _fetch_repository_default_branch(
+                        client, headers, normalized_repository
+                    )
+                    if metadata is None:
+                        # Confirm the repository itself is reachable before
+                        # calling a branch definitively absent.
+                        try:
+                            probe = client.get(
+                                _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
+                                    repository=normalized_repository
+                                ),
+                                headers=headers,
+                            )
+                            probe.raise_for_status()
+                        except (httpx.HTTPError, ValueError):
+                            return False, None, (
+                                "GitHub branch lookup is unavailable."
+                            ), True
+                    return False, None, None, False
+                response.raise_for_status()
+                payload = response.json()
+                returned = (
+                    str(payload.get("name") or "").strip()
+                    if isinstance(payload, Mapping)
+                    else ""
+                )
+                if returned and returned == candidate:
+                    return True, returned, None, False
+                return False, None, None, True
+            except httpx.HTTPStatusError as exc:
+                status = exc.response.status_code if exc.response is not None else None
+                if status in (403, 429):
+                    return False, None, (
+                        "GitHub branch lookup is unavailable."
+                    ), True
+                raise
+    except (httpx.HTTPError, ValueError):
+        return False, None, "GitHub branch lookup is unavailable.", True
+    return False, None, "GitHub branch lookup is unavailable.", True
+
+
+async def _fetch_github_branch_exact_async(
+    token: str,
+    repository: str,
+    branch: str,
+) -> tuple[bool, str | None, str | None, bool]:
+    """Awaited async variant of the exact-name branch lookup."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    candidate = str(branch or "").strip()
+    if not token or not normalized_repository or not _is_valid_branch_name(candidate):
+        return False, None, None, True
+    headers = _github_branch_headers(token)
+    encoded_branch = quote(candidate, safe="/")
+    branch_url = (
+        f"https://api.github.com/repos/{normalized_repository}"
+        f"/branches/{encoded_branch}"
+    )
+    try:
+        async with httpx.AsyncClient(
+            timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
+        ) as client:
+            try:
+                response = await client.get(branch_url, headers=headers)
+                if response.status_code == 404:
+                    try:
+                        probe = await client.get(
+                            _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
+                                repository=normalized_repository
+                            ),
+                            headers=headers,
+                        )
+                        probe.raise_for_status()
+                    except (httpx.HTTPError, ValueError):
+                        return False, None, (
+                            "GitHub branch lookup is unavailable."
+                        ), True
+                    return False, None, None, False
+                response.raise_for_status()
+                payload = response.json()
+                returned = (
+                    str(payload.get("name") or "").strip()
+                    if isinstance(payload, Mapping)
+                    else ""
+                )
+                if returned and returned == candidate:
+                    return True, returned, None, False
+                return False, None, None, True
+            except httpx.HTTPStatusError as exc:
+                status = exc.response.status_code if exc.response is not None else None
+                if status in (403, 429):
+                    return False, None, (
+                        "GitHub branch lookup is unavailable."
+                    ), True
+                raise
+    except (httpx.HTTPError, ValueError):
+        return False, None, "GitHub branch lookup is unavailable.", True
+    return False, None, "GitHub branch lookup is unavailable.", True
 
 def _github_repository_options_cache_key(token: str) -> str:
     return sha256(token.encode("utf-8")).hexdigest()
 
-def _github_branch_options_cache_key(token: str, repository: str) -> str:
+
+def _github_branch_search_cache_key(
+    token: str, repository: str, query: str, limit: int
+) -> str:
     normalized_repository = _normalize_repository_value(repository) or ""
-    raw_key = f"{token}:{normalized_repository.lower()}"
+    raw_key = (
+        f"{token}:{normalized_repository.lower()}:{query}:{int(limit)}"
+    )
+    return sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def _github_branch_metadata_cache_key(token: str, repository: str) -> str:
+    normalized_repository = _normalize_repository_value(repository) or ""
+    raw_key = f"metadata:{token}:{normalized_repository.lower()}"
+    return sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def _github_branch_resolve_cache_key(
+    token: str, repository: str, branch: str
+) -> str:
+    normalized_repository = _normalize_repository_value(repository) or ""
+    # Branch names preserve case: the cache key must not lowercase them.
+    raw_key = f"resolve:{token}:{normalized_repository.lower()}:{branch}"
     return sha256(raw_key.encode("utf-8")).hexdigest()
 
 def _get_cached_github_repository_options(
@@ -311,23 +648,214 @@ def _get_cached_github_repository_options(
 def _get_cached_github_branch_options(
     token: str,
     repository: str,
-) -> tuple[list[BranchOption], str | None, str | None]:
-    now = time.monotonic()
-    cache_key = _github_branch_options_cache_key(token, repository)
-    cached = _GITHUB_BRANCH_OPTIONS_CACHE.get(cache_key)
-    if cached:
-        cached_at, cached_options, cached_error, cached_default_branch = cached
-        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
-            return list(cached_options), cached_error, cached_default_branch
+    query: str = "",
+    limit: int = _BRANCH_SUGGESTION_DEFAULT_LIMIT,
+) -> tuple[list[BranchOption], str | None, str | None, bool]:
+    """Return one bounded cached search page with oldest-first eviction."""
 
-    options, error, default_branch = _fetch_github_branch_options(token, repository)
-    _GITHUB_BRANCH_OPTIONS_CACHE[cache_key] = (
-        now,
-        tuple(options),
-        error,
-        default_branch,
+    clamped_limit = _clamp_branch_suggestion_limit(limit)
+    normalized_query = _normalize_branch_query(query)
+    now = time.monotonic()
+    cache_key = _github_branch_search_cache_key(
+        token, repository, normalized_query, clamped_limit
     )
-    return options, error, default_branch
+    cached = _GITHUB_BRANCH_SEARCH_CACHE.get(cache_key)
+    if cached:
+        cached_at, cached_options, cached_error, cached_default_branch, cached_has_more = cached
+        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
+            return (
+                list(cached_options),
+                cached_error,
+                cached_default_branch,
+                cached_has_more,
+            )
+
+    options, error, default_branch, has_more = _fetch_github_branch_options(
+        token, repository, normalized_query, clamped_limit
+    )
+    _bounded_cache_put(
+        _GITHUB_BRANCH_SEARCH_CACHE,
+        cache_key,
+        (now, tuple(options), error, default_branch, has_more),
+    )
+    # Legacy full-list cache is intentionally not populated: cold discovery is
+    # always bounded to a single page per operation.
+    return options, error, default_branch, has_more
+
+
+async def _get_cached_github_branch_options_async(
+    token: str,
+    repository: str,
+    query: str = "",
+    limit: int = _BRANCH_SUGGESTION_DEFAULT_LIMIT,
+) -> tuple[list[BranchOption], str | None, str | None, bool]:
+    """Async cached search page for use inside async API routes."""
+
+    clamped_limit = _clamp_branch_suggestion_limit(limit)
+    normalized_query = _normalize_branch_query(query)
+    now = time.monotonic()
+    cache_key = _github_branch_search_cache_key(
+        token, repository, normalized_query, clamped_limit
+    )
+    cached = _GITHUB_BRANCH_SEARCH_CACHE.get(cache_key)
+    if cached:
+        cached_at, cached_options, cached_error, cached_default_branch, cached_has_more = cached
+        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
+            return (
+                list(cached_options),
+                cached_error,
+                cached_default_branch,
+                cached_has_more,
+            )
+
+    options, error, default_branch, has_more = (
+        await _fetch_github_branch_options_async(
+            token, repository, normalized_query, clamped_limit
+        )
+    )
+    _bounded_cache_put(
+        _GITHUB_BRANCH_SEARCH_CACHE,
+        cache_key,
+        (now, tuple(options), error, default_branch, has_more),
+    )
+    return options, error, default_branch, has_more
+
+
+def _get_cached_repository_default_branch(
+    token: str,
+    repository: str,
+) -> tuple[str | None, str | None]:
+    """Return cached default-branch metadata without enumerating branches."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not token or not normalized_repository:
+        return None, None
+    now = time.monotonic()
+    cache_key = _github_branch_metadata_cache_key(token, repository)
+    cached = _GITHUB_BRANCH_METADATA_CACHE.get(cache_key)
+    if cached:
+        cached_at, cached_default = cached
+        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
+            return cached_default, None
+    headers = _github_branch_headers(token)
+    try:
+        with httpx.Client(
+            timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
+        ) as client:
+            default_branch = _fetch_repository_default_branch(
+                client, headers, normalized_repository
+            )
+    except (httpx.HTTPError, ValueError):
+        return None, "GitHub branch lookup is unavailable."
+    _bounded_cache_put(
+        _GITHUB_BRANCH_METADATA_CACHE, cache_key, (now, default_branch)
+    )
+    return default_branch, None
+
+
+async def _get_cached_repository_default_branch_async(
+    token: str,
+    repository: str,
+) -> tuple[str | None, str | None]:
+    """Async cached default-branch metadata for use inside async API routes."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not token or not normalized_repository:
+        return None, None
+    now = time.monotonic()
+    cache_key = _github_branch_metadata_cache_key(token, repository)
+    cached = _GITHUB_BRANCH_METADATA_CACHE.get(cache_key)
+    if cached:
+        cached_at, cached_default = cached
+        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
+            return cached_default, None
+    headers = _github_branch_headers(token)
+    try:
+        async with httpx.AsyncClient(
+            timeout=_GITHUB_REPOSITORY_DISCOVERY_TIMEOUT_SECONDS
+        ) as client:
+            try:
+                response = await client.get(
+                    _GITHUB_REPOSITORY_METADATA_URL_TEMPLATE.format(
+                        repository=normalized_repository
+                    ),
+                    headers=headers,
+                )
+                response.raise_for_status()
+                metadata = response.json()
+                default_branch = (
+                    str(metadata.get("default_branch") or "").strip() or None
+                    if isinstance(metadata, dict)
+                    else None
+                )
+            except (httpx.HTTPError, ValueError):
+                return None, "GitHub branch lookup is unavailable."
+    except (httpx.HTTPError, ValueError):
+        return None, "GitHub branch lookup is unavailable."
+    _bounded_cache_put(
+        _GITHUB_BRANCH_METADATA_CACHE, cache_key, (now, default_branch)
+    )
+    return default_branch, None
+
+
+def _get_cached_branch_exact(
+    token: str,
+    repository: str,
+    branch: str,
+) -> tuple[bool, str | None, str | None, bool]:
+    """Return a cached exact-name observation without scanning pages."""
+
+    candidate = str(branch or "").strip()
+    if not _is_valid_branch_name(candidate):
+        return False, None, None, True
+    now = time.monotonic()
+    cache_key = _github_branch_resolve_cache_key(token, repository, candidate)
+    cached = _GITHUB_BRANCH_RESOLVE_CACHE.get(cache_key)
+    if cached:
+        cached_at, found, resolved, error = cached
+        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
+            if found or error is None:
+                # Definitive observations (found, or definitively absent with
+                # no error) stay definitive.
+                return found, resolved, error, False
+            return found, resolved, error, True
+    found, resolved, error, inconclusive = _fetch_github_branch_exact(
+        token, repository, candidate
+    )
+    _bounded_cache_put(
+        _GITHUB_BRANCH_RESOLVE_CACHE, cache_key, (now, found, resolved, error)
+    )
+    return found, resolved, error, inconclusive
+
+
+async def _get_cached_branch_exact_async(
+    token: str,
+    repository: str,
+    branch: str,
+) -> tuple[bool, str | None, str | None, bool]:
+    """Async cached exact-name observation for use inside async API routes."""
+
+    candidate = str(branch or "").strip()
+    if not _is_valid_branch_name(candidate):
+        return False, None, None, True
+    now = time.monotonic()
+    cache_key = _github_branch_resolve_cache_key(token, repository, candidate)
+    cached = _GITHUB_BRANCH_RESOLVE_CACHE.get(cache_key)
+    if cached:
+        cached_at, found, resolved, error = cached
+        if now - cached_at < _GITHUB_REPOSITORY_DISCOVERY_CACHE_TTL_SECONDS:
+            if found:
+                return found, resolved, error, False
+            if error is None:
+                return found, resolved, error, False
+            return found, resolved, error, True
+    found, resolved, error, inconclusive = await _fetch_github_branch_exact_async(
+        token, repository, candidate
+    )
+    _bounded_cache_put(
+        _GITHUB_BRANCH_RESOLVE_CACHE, cache_key, (now, found, resolved, error)
+    )
+    return found, resolved, error, inconclusive
 
 def _is_create_page_path(initial_path: str) -> bool:
     normalized_path = urlparse(initial_path or "").path.rstrip("/")
@@ -383,15 +911,8 @@ def _build_repository_options(
         "error": discovery_error,
     }
 
-def build_repository_branch_options(repository: str) -> dict[str, Any]:
-    """Build Create-page branch suggestions through MoonMind-owned GitHub lookup."""
-
-    normalized_repository = _normalize_repository_value(repository)
-    if not normalized_repository:
-        return {
-            "items": [],
-            "error": "Repository must be owner/repo before branches can be loaded.",
-        }
+def _github_branch_token() -> tuple[bool, str]:
+    """Return (enabled, token) for MoonMind-owned GitHub branch lookup."""
 
     github_config = getattr(settings, "github", None)
     github_enabled = (
@@ -404,15 +925,39 @@ def build_repository_branch_options(repository: str) -> dict[str, Any]:
         if github_config
         else ""
     )
+    return github_enabled, github_token
+
+
+def build_repository_branch_options(
+    repository: str,
+    query: str = "",
+    limit: int = _BRANCH_SUGGESTION_DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """Build bounded Create-page branch suggestions plus default metadata."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not normalized_repository:
+        return {
+            "items": [],
+            "error": "Repository must be owner/repo before branches can be loaded.",
+            "defaultBranch": None,
+            "hasMore": False,
+        }
+
+    github_enabled, github_token = _github_branch_token()
     if not github_enabled or not github_token:
         return {
             "items": [],
             "error": "GitHub branch lookup is unavailable.",
+            "defaultBranch": None,
+            "hasMore": False,
         }
 
-    options, error, default_branch = _get_cached_github_branch_options(
+    options, error, default_branch, has_more = _get_cached_github_branch_options(
         github_token,
         normalized_repository,
+        query,
+        limit,
     )
     if error:
         error = "GitHub branch lookup is unavailable."
@@ -420,6 +965,208 @@ def build_repository_branch_options(repository: str) -> dict[str, Any]:
         "items": [option.to_payload() for option in options],
         "error": error,
         "defaultBranch": default_branch,
+        "hasMore": has_more,
+    }
+
+
+async def build_repository_branch_options_async(
+    repository: str,
+    query: str = "",
+    limit: int = _BRANCH_SUGGESTION_DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """Awaited variant so async routes never block the event loop on HTTP."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not normalized_repository:
+        return {
+            "items": [],
+            "error": "Repository must be owner/repo before branches can be loaded.",
+            "defaultBranch": None,
+            "hasMore": False,
+        }
+
+    github_enabled, github_token = _github_branch_token()
+    if not github_enabled or not github_token:
+        return {
+            "items": [],
+            "error": "GitHub branch lookup is unavailable.",
+            "defaultBranch": None,
+            "hasMore": False,
+        }
+
+    options, error, default_branch, has_more = (
+        await _get_cached_github_branch_options_async(
+            github_token,
+            normalized_repository,
+            query,
+            limit,
+        )
+    )
+    if error:
+        error = "GitHub branch lookup is unavailable."
+    return {
+        "items": [option.to_payload() for option in options],
+        "error": error,
+        "defaultBranch": default_branch,
+        "hasMore": has_more,
+    }
+
+
+def build_repository_branch_metadata(repository: str) -> dict[str, Any]:
+    """Resolve only default-branch metadata without enumerating branches."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not normalized_repository:
+        return {
+            "defaultBranch": None,
+            "error": "Repository must be owner/repo before branches can be loaded.",
+        }
+
+    github_enabled, github_token = _github_branch_token()
+    if not github_enabled or not github_token:
+        return {
+            "defaultBranch": None,
+            "error": "GitHub branch lookup is unavailable.",
+        }
+
+    default_branch, error = _get_cached_repository_default_branch(
+        github_token, normalized_repository
+    )
+    if error:
+        error = "GitHub branch lookup is unavailable."
+    return {"defaultBranch": default_branch, "error": error}
+
+
+async def build_repository_branch_metadata_async(
+    repository: str,
+) -> dict[str, Any]:
+    """Awaited metadata-only variant for async routes."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    if not normalized_repository:
+        return {
+            "defaultBranch": None,
+            "error": "Repository must be owner/repo before branches can be loaded.",
+        }
+
+    github_enabled, github_token = _github_branch_token()
+    if not github_enabled or not github_token:
+        return {
+            "defaultBranch": None,
+            "error": "GitHub branch lookup is unavailable.",
+        }
+
+    default_branch, error = await _get_cached_repository_default_branch_async(
+        github_token, normalized_repository
+    )
+    if error:
+        error = "GitHub branch lookup is unavailable."
+    return {"defaultBranch": default_branch, "error": error}
+
+
+def resolve_repository_branch(repository: str, branch: str) -> dict[str, Any]:
+    """Resolve one exact branch name independent of suggestion pages."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    candidate = str(branch or "").strip()
+    if not normalized_repository:
+        return {
+            "found": False,
+            "branch": None,
+            "defaultBranch": None,
+            "error": "Repository must be owner/repo before branches can be loaded.",
+            "inconclusive": True,
+        }
+    if not _is_valid_branch_name(candidate):
+        return {
+            "found": False,
+            "branch": None,
+            "defaultBranch": None,
+            "error": None,
+            "inconclusive": True,
+        }
+
+    github_enabled, github_token = _github_branch_token()
+    if not github_enabled or not github_token:
+        return {
+            "found": False,
+            "branch": None,
+            "defaultBranch": None,
+            "error": "GitHub branch lookup is unavailable.",
+            "inconclusive": True,
+        }
+
+    found, resolved, error, inconclusive = _get_cached_branch_exact(
+        github_token, normalized_repository, candidate
+    )
+    default_branch, metadata_error = _get_cached_repository_default_branch(
+        github_token, normalized_repository
+    )
+    if error:
+        error = "GitHub branch lookup is unavailable."
+    if metadata_error:
+        metadata_error = "GitHub branch lookup is unavailable."
+    return {
+        "found": found,
+        "branch": resolved,
+        "defaultBranch": default_branch,
+        "error": error or metadata_error,
+        "inconclusive": inconclusive or bool(error or metadata_error),
+    }
+
+
+async def resolve_repository_branch_async(
+    repository: str, branch: str
+) -> dict[str, Any]:
+    """Awaited exact-name variant for async routes."""
+
+    normalized_repository = _normalize_repository_value(repository)
+    candidate = str(branch or "").strip()
+    if not normalized_repository:
+        return {
+            "found": False,
+            "branch": None,
+            "defaultBranch": None,
+            "error": "Repository must be owner/repo before branches can be loaded.",
+            "inconclusive": True,
+        }
+    if not _is_valid_branch_name(candidate):
+        return {
+            "found": False,
+            "branch": None,
+            "defaultBranch": None,
+            "error": None,
+            "inconclusive": True,
+        }
+
+    github_enabled, github_token = _github_branch_token()
+    if not github_enabled or not github_token:
+        return {
+            "found": False,
+            "branch": None,
+            "defaultBranch": None,
+            "error": "GitHub branch lookup is unavailable.",
+            "inconclusive": True,
+        }
+
+    found, resolved, error, inconclusive = await _get_cached_branch_exact_async(
+        github_token, normalized_repository, candidate
+    )
+    default_branch, metadata_error = (
+        await _get_cached_repository_default_branch_async(
+            github_token, normalized_repository
+        )
+    )
+    if error:
+        error = "GitHub branch lookup is unavailable."
+    if metadata_error:
+        metadata_error = "GitHub branch lookup is unavailable."
+    return {
+        "found": found,
+        "branch": resolved,
+        "defaultBranch": default_branch,
+        "error": error or metadata_error,
+        "inconclusive": inconclusive or bool(error or metadata_error),
     }
 
 
@@ -746,6 +1493,8 @@ def build_runtime_config(
             **jira_sources,
             "github": {
                 "branches": "/api/github/branches?repository={repository}",
+                "branchResolve": "/api/github/branches/resolve?repository={repository}&branch={branch}",
+                "branchMetadata": "/api/github/branches/metadata?repository={repository}",
                 "issues": "/api/github/issues?repository={repository}&q={query}",
             },
 
@@ -913,9 +1662,14 @@ async def resolve_dashboard_runtime_config(
 
 __all__ = [
     "build_live_logs_feature_config",
+    "build_repository_branch_metadata",
+    "build_repository_branch_metadata_async",
     "build_repository_branch_options",
+    "build_repository_branch_options_async",
     "build_runtime_config",
     "resolve_dashboard_runtime_config",
+    "resolve_repository_branch",
+    "resolve_repository_branch_async",
     "normalize_status",
     "BranchOption",
     "RepositoryOption",

--- a/docs/Steps/SkillInputSchemaUIGeneration.md
+++ b/docs/Steps/SkillInputSchemaUIGeneration.md
@@ -156,6 +156,8 @@ For required `oneOf`/`anyOf`, render a usable discriminator when variants have c
 
 The shared local widget registry contains text, textarea, markdown, number, checkbox, select, multi-select, JSON, Jira/GitHub issue, repository/branch, profile/model, and file-reference components. No remote components, arbitrary React identifiers, scripts, executable expressions, or unapproved schema fetches are allowed.
 
+Schema-generated branch fields share the workflow-level text-first branch behavior: free-text entry is always allowed, suggestions are the same bounded default-plus-recent list capped at 20, and an exact name outside the suggestion page stays submittable subject to backend admission. Suggestion membership is never used as validation evidence for these fields either.
+
 `uiSchema` controls safe placeholders, ordering, grouping, optional advanced disclosure, and registered presentation choices. It cannot change validation, defaults that confer authority, context-binding ownership, or publication policy.
 
 ## Authoritative Context Binding

--- a/docs/UI/CreatePage.md
+++ b/docs/UI/CreatePage.md
@@ -184,6 +184,16 @@ A dependency may offer a verified candidate as a proposed starting point. It doe
 
 Repository, branch, and target lookups are keyed to the principal, source/connection identity, repository, and relevant query. Out-of-order responses are discarded after any source change. Changing context invalidates incompatible selected PRs, cached branch options, previews, and generated bindings while preserving recoverable task input. A PR URL naming a different repository cannot silently switch the selected authority.
 
+### Text-first branch input
+
+Authored branch text is authoritative user input. Autocomplete is optional assistance: typing and pasting update the draft immediately, suggestions never overwrite the text or move focus, and submission reads the latest authored value rather than the last suggestion response.
+
+- Form initialization and repository changes resolve only small default-branch metadata. The client never enumerates the whole branch collection automatically.
+- Empty-input suggestions show the verified repository default first, then a small user-scoped recently-used list for that repository (recorded from accepted submissions, bounded, deduplicated with case preserved), capped at 20 visible suggestions.
+- Typed search is debounced and served as one bounded page per operation with an explicit partial-list notice when more pages exist. One continuation action fetches one page; remaining pages are never drained automatically.
+- A pasted or typed exact name is validated by an independent exact-name lookup, never by membership in the bounded suggestion page. The picker distinguishes not-checked, checking, found, definitively absent, and inconclusive (unavailable, denied, rate-limited, or unknown repository) outcomes. Only a definitive absence under a successfully authorized lookup reports the name as missing, and lookup failure never blocks authoring or submission: the authoritative backend validation still applies at submit time.
+- Explicit clearing stays cleared: late default-branch or lookup responses cannot restore a cleared value or validate a newer draft.
+
 ## Publishing Control
 
 There is one selector for the authored workflow/batch policy:

--- a/frontend/src/entrypoints/workflow-start-branch-picker.test.tsx
+++ b/frontend/src/entrypoints/workflow-start-branch-picker.test.tsx
@@ -1,0 +1,358 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+
+import type { BootPayload } from "../boot/parseBootPayload";
+import { renderWithClient } from "../utils/test-utils";
+import {
+  BRANCH_TEXT_FIRST_LIMITS,
+  WorkflowStartPage,
+  branchRecentHistoryKey,
+  configuredBranchLookupUrl,
+  configuredBranchResolveUrl,
+  readRecentBranches,
+  writeRecentBranch,
+} from "./workflow-start";
+
+vi.mock("../lib/navigation", () => ({
+  navigateTo: vi.fn(),
+}));
+
+const mockPayload: BootPayload = {
+  page: "workflow-start",
+  apiBase: "/api",
+  initialData: {
+    dashboardConfig: {
+      sources: {
+        temporal: {
+          create: "/api/executions",
+          artifactCreate: "/api/artifacts",
+        },
+        github: {
+          branches: "/api/github/branches?repository={repository}",
+          branchResolve:
+            "/api/github/branches/resolve?repository={repository}&branch={branch}",
+          branchMetadata:
+            "/api/github/branches/metadata?repository={repository}",
+        },
+      },
+      system: {
+        defaultRepository: "MoonLadderStudios/MoonMind",
+        defaultAgentRuntime: "codex_cli",
+        defaultTaskModel: "gpt-5.4",
+        defaultTaskEffort: "medium",
+        defaultPublishMode: "pr",
+        defaultProposeTasks: false,
+        defaultTaskModelByRuntime: {
+          codex_cli: "gpt-5.4",
+        },
+        defaultTaskEffortByRuntime: {
+          codex_cli: "medium",
+        },
+        supportedAgentRuntimes: ["codex_cli"],
+        providerProfiles: {
+          list: "/api/v1/provider-profiles",
+        },
+        presetCatalog: {
+          enabled: false,
+          templateSaveEnabled: false,
+          list: "/api/presets",
+          detail: "/api/presets/{slug}",
+          expand: "/api/presets/{slug}:expand",
+          saveFromWorkflow: "/api/presets/save-from-workflow",
+        },
+      },
+      features: {
+        temporalDashboard: {
+          temporalTaskEditing: true,
+        },
+      },
+    },
+  },
+};
+
+// 25 server names on purpose: the picker must cap mounted options at 20 even
+// though the fixture advertises more pages via hasMore.
+const SERVER_BRANCHES = [
+  "main",
+  ...Array.from({ length: 24 }, (_, index) => `feature/${String(index).padStart(2, "0")}`),
+];
+
+function branchListPayload() {
+  return {
+    items: SERVER_BRANCHES.map((value) => ({
+      value,
+      label: value,
+      source: "github",
+    })),
+    defaultBranch: "main",
+    hasMore: true,
+    error: null,
+  };
+}
+
+function resolvePayload(branch: string) {
+  if (branch === "main" || branch === "feature/old-branch") {
+    return { found: true, branch, defaultBranch: "main", error: null, inconclusive: false };
+  }
+  if (branch === "missing-nope") {
+    return { found: false, branch: null, defaultBranch: "main", error: null, inconclusive: false };
+  }
+  return { found: false, branch: null, defaultBranch: "main", error: null, inconclusive: true };
+}
+
+describe("MoonLadderStudios/MoonMind#4054 text-first branch picker", () => {
+  let fetchSpy: MockInstance;
+  let branchRequestUrls: string[];
+
+  beforeEach(() => {
+    window.history.pushState({}, "Task Create", "/workflows/new");
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    branchRequestUrls = [];
+    fetchSpy = vi
+      .spyOn(window, "fetch")
+      .mockImplementation((input: RequestInfo | URL, _init?: RequestInit) => {
+        const url = String(input);
+        if (url.startsWith("/api/workflows/skills")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: { worker: ["moonspec-orchestrate"] } }),
+          } as Response);
+        }
+        if (url.startsWith("/api/github/branches/resolve")) {
+          const parsed = new URL(url, "http://localhost");
+          const branch = String(parsed.searchParams.get("branch") || "");
+          return Promise.resolve({
+            ok: true,
+            json: async () => resolvePayload(branch),
+          } as Response);
+        }
+        if (url.startsWith("/api/github/branches/metadata")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ defaultBranch: "main", error: null }),
+          } as Response);
+        }
+        if (url.startsWith("/api/github/branches")) {
+          branchRequestUrls.push(url);
+          return Promise.resolve({
+            ok: true,
+            json: async () => branchListPayload(),
+          } as Response);
+        }
+        if (url.startsWith("/api/v1/provider-profiles")) {
+          return Promise.resolve({ ok: true, json: async () => [] } as Response);
+        }
+        if (url.startsWith("/api/presets")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ items: [] }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("preserves pasted text and never reports a stale-list error for an exact branch outside the first page", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const branchInput = (await screen.findByLabelText("Branch", {
+      selector: "input",
+    })) as HTMLInputElement;
+    fireEvent.change(branchInput, { target: { value: "feature/old-branch" } });
+
+    // Authored text is authoritative immediately, before any lookup finishes.
+    expect(branchInput.value).toBe("feature/old-branch");
+    expect(
+      screen.queryByText(/not in the latest list for this repository/),
+    ).toBeNull();
+
+    // The older branch resolves directly even though it is absent from the
+    // first bounded suggestion page: no false stale warning appears.
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/not in the latest list for this repository/),
+      ).toBeNull();
+    });
+    await waitFor(
+      () => {
+        expect(branchRequestUrls.length).toBeGreaterThan(0);
+      },
+      { timeout: 5000 },
+    );
+    expect(branchInput.value).toBe("feature/old-branch");
+    expect(branchInput.disabled).toBe(false);
+  });
+
+  it("caps mounted suggestions at 20 and says the list is partial", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const branchInput = (await screen.findByLabelText("Branch", {
+      selector: "input",
+    })) as HTMLInputElement;
+    fireEvent.change(branchInput, { target: { value: "feature" } });
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Showing the first 20 suggestions/),
+        ).toBeTruthy();
+      },
+      { timeout: 5000 },
+    );
+    const options = document.querySelectorAll(
+      '#queue-branch-options option',
+    );
+    expect(options.length).toBeLessThanOrEqual(
+      BRANCH_TEXT_FIRST_LIMITS.suggestionLimit,
+    );
+    // One bounded page per search: the client never drains remaining pages.
+    const suggestionCalls = branchRequestUrls.filter((url) =>
+      url.startsWith("/api/github/branches?"),
+    );
+    expect(suggestionCalls.length).toBeGreaterThan(0);
+    for (const url of suggestionCalls) {
+      const parsed = new URL(url, "http://localhost");
+      expect(Number(parsed.searchParams.get("limit"))).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("keeps manual input editable and intact while suggestions fail", async () => {
+    fetchSpy.mockImplementation((input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith("/api/github/branches/metadata")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ defaultBranch: "main", error: null }),
+        } as Response);
+      }
+      if (
+        url.startsWith("/api/github/branches/resolve") ||
+        url.startsWith("/api/workflows/skills") ||
+        url.startsWith("/api/presets")
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({}),
+        } as Response);
+      }
+      if (url.startsWith("/api/v1/provider-profiles")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [],
+        } as Response);
+      }
+      if (url.startsWith("/api/github/branches")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: async () => "upstream blew up",
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const branchInput = (await screen.findByLabelText("Branch", {
+      selector: "input",
+    })) as HTMLInputElement;
+    fireEvent.change(branchInput, { target: { value: "feature/typed-during-outage" } });
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Branch suggestions are unavailable/),
+        ).toBeTruthy();
+      },
+      { timeout: 5000 },
+    );
+    // Lookup availability is reported separately from input validity: the
+    // authored value stays intact and the control stays enabled.
+    expect(branchInput.value).toBe("feature/typed-during-outage");
+    expect(branchInput.disabled).toBe(false);
+    expect(
+      screen.queryByText(/not in the latest list for this repository/),
+    ).toBeNull();
+  });
+
+  it("reports a definitively absent branch as information without blocking authoring", async () => {
+    renderWithClient(<WorkflowStartPage payload={mockPayload} />);
+
+    const branchInput = (await screen.findByLabelText("Branch", {
+      selector: "input",
+    })) as HTMLInputElement;
+    fireEvent.change(branchInput, { target: { value: "missing-nope" } });
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/No branch named "missing-nope" was found/),
+        ).toBeTruthy();
+      },
+      { timeout: 5000 },
+    );
+    expect(branchInput.value).toBe("missing-nope");
+    expect(branchInput.disabled).toBe(false);
+  });
+});
+
+describe("branch picker helpers", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("builds bounded suggestion urls with encoded queries", () => {
+    const url = configuredBranchLookupUrl(
+      "/api/github/branches?repository={repository}",
+      "Octo/Repo",
+      { query: "feature/foo bar", limit: 999 },
+    );
+    const parsed = new URL(url, "http://localhost");
+    expect(parsed.searchParams.get("repository")).toBe("Octo/Repo");
+    expect(parsed.searchParams.get("q")).toBe("feature/foo bar");
+    expect(parsed.searchParams.get("limit")).toBe("20");
+  });
+
+  it("encodes slash-containing branch names in resolve urls", () => {
+    const url = configuredBranchResolveUrl(
+      "/api/github/branches/resolve?repository={repository}&branch={branch}",
+      "Octo/Repo",
+      "feature/foo",
+    );
+    expect(url).toContain(`branch=${encodeURIComponent("feature/foo")}`);
+  });
+
+  it("keeps user-scoped recent history small, deduplicated, and case-preserving", () => {
+    writeRecentBranch("Octo/Repo", "Feature/Foo");
+    writeRecentBranch("Octo/Repo", "main");
+    writeRecentBranch("Octo/Repo", "Feature/Foo");
+    expect(readRecentBranches("Octo/Repo")).toEqual(["Feature/Foo", "main"]);
+    expect(readRecentBranches("octo/repo")).toEqual(["Feature/Foo", "main"]);
+    expect(readRecentBranches("Other/Repo")).toEqual([]);
+    expect(branchRecentHistoryKey("Octo/Repo")).toBe(
+      branchRecentHistoryKey("octo/repo"),
+    );
+  });
+
+  it("bounds recent history growth", () => {
+    for (let index = 0; index < 30; index += 1) {
+      writeRecentBranch("Octo/Repo", `branch-${index}`);
+    }
+    expect(readRecentBranches("Octo/Repo")).toHaveLength(
+      BRANCH_TEXT_FIRST_LIMITS.recentHistoryMax,
+    );
+  });
+});

--- a/frontend/src/entrypoints/workflow-start.tsx
+++ b/frontend/src/entrypoints/workflow-start.tsx
@@ -132,6 +132,95 @@ const HIDDEN_PRESET_INPUT_KEYS: Record<string, Set<string>> = {
 };
 const LAST_REPOSITORY_OPTION_PREFERENCE_KEY =
   "moonmind.workflow-start.last-repository-option";
+// Text-first branch picker (MoonLadderStudios/MoonMind#4054). Authored text is
+// authoritative user input; autocomplete is optional assistance that must never
+// overwrite it. Suggestions are bounded, debounced, and capped; exact-name
+// validation runs independently of suggestion membership.
+const BRANCH_SUGGESTION_LIMIT = 20;
+const BRANCH_SEARCH_DEBOUNCE_MS = 250;
+const BRANCH_RECENT_HISTORY_MAX = 10;
+const BRANCH_RECENT_HISTORY_KEY_PREFIX =
+  "moonmind.workflow-start.recent-branches.";
+
+export const BRANCH_TEXT_FIRST_LIMITS = {
+  suggestionLimit: BRANCH_SUGGESTION_LIMIT,
+  searchDebounceMs: BRANCH_SEARCH_DEBOUNCE_MS,
+  recentHistoryMax: BRANCH_RECENT_HISTORY_MAX,
+};
+
+export function branchRecentHistoryKey(repository: string): string {
+  return `${BRANCH_RECENT_HISTORY_KEY_PREFIX}${repository.trim().toLowerCase()}`;
+}
+
+export function readRecentBranches(repository: string): string[] {
+  if (!String(repository || "").trim()) {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(
+      branchRecentHistoryKey(repository),
+    );
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    const seen = new Set<string>();
+    const recent: string[] = [];
+    for (const entry of parsed) {
+      const name = String(entry || "").trim();
+      if (!name || seen.has(name)) {
+        continue;
+      }
+      seen.add(name);
+      recent.push(name);
+      if (recent.length >= BRANCH_RECENT_HISTORY_MAX) {
+        break;
+      }
+    }
+    return recent;
+  } catch {
+    return [];
+  }
+}
+
+export function writeRecentBranch(repository: string, branch: string): void {
+  const normalizedBranch = String(branch || "").trim();
+  const normalizedRepository = String(repository || "").trim();
+  if (!normalizedBranch || !normalizedRepository) {
+    return;
+  }
+  try {
+    const storageKey = branchRecentHistoryKey(normalizedRepository);
+    const existing = readRecentBranches(normalizedRepository).filter(
+      (name) => name !== normalizedBranch,
+    );
+    const next = [normalizedBranch, ...existing].slice(
+      0,
+      BRANCH_RECENT_HISTORY_MAX,
+    );
+    window.localStorage.setItem(storageKey, JSON.stringify(next));
+  } catch {
+    // Recent-branch history is advisory only; storage failures must never
+    // block authoring.
+  }
+}
+
+function useDebouncedValue(value: string, delayMs: number): string {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setDebounced(value);
+    }, delayMs);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [value, delayMs]);
+  return debounced;
+}
+
 const JIRA_LAST_PROJECT_SESSION_KEY =
   "moonmind.workflow-start.jira.last-project-key";
 const JIRA_LAST_BOARD_SESSION_KEY =
@@ -325,6 +414,8 @@ interface DashboardConfig {
     };
     github?: {
       branches?: string;
+      branchResolve?: string;
+      branchMetadata?: string;
       issues?: string;
     };
     jira?: {
@@ -950,6 +1041,27 @@ interface BranchListResponse {
   }>;
   error?: string | null;
   defaultBranch?: string | null;
+  hasMore?: boolean | null;
+}
+
+type BranchResolutionOutcome =
+  | "not-checked"
+  | "checking"
+  | "found"
+  | "absent"
+  | "inconclusive";
+
+interface BranchResolveResponse {
+  found?: boolean | null;
+  branch?: string | null;
+  defaultBranch?: string | null;
+  error?: string | null;
+  inconclusive?: boolean | null;
+}
+
+interface BranchMetadataResponse {
+  defaultBranch?: string | null;
+  error?: string | null;
 }
 
 export function resolveDefaultProviderProfileId(
@@ -1426,11 +1538,35 @@ function configuredTemporalUpdateUrl(
   return interpolatePath(updateTemplate, { workflowId });
 }
 
-function configuredBranchLookupUrl(
+export function configuredBranchLookupUrl(
   branchTemplate: string,
   repository: string,
+  options: { query?: string; limit?: number } = {},
 ): string {
-  return interpolatePath(branchTemplate, { repository });
+  const base = interpolatePath(branchTemplate, { repository });
+  const limit =
+    typeof options.limit === "number" && Number.isFinite(options.limit)
+      ? Math.max(1, Math.min(BRANCH_SUGGESTION_LIMIT, Math.floor(options.limit)))
+      : BRANCH_SUGGESTION_LIMIT;
+  return withQueryParams(base, {
+    q: String(options.query || "").trim() || undefined,
+    limit: String(limit),
+  });
+}
+
+export function configuredBranchResolveUrl(
+  resolveTemplate: string,
+  repository: string,
+  branch: string,
+): string {
+  return interpolatePath(resolveTemplate, { repository, branch });
+}
+
+function configuredBranchMetadataUrl(
+  metadataTemplate: string,
+  repository: string,
+): string {
+  return interpolatePath(metadataTemplate, { repository });
 }
 
 function configuredArtifactDownloadUrl(
@@ -4826,10 +4962,13 @@ async function responseErrorMessage(
 async function readBranchOptions(
   branchLookupEndpoint: string,
   repository: string,
-): Promise<{ items: BranchOption[]; defaultBranch: string }> {
+  options: { query?: string; limit?: number; signal?: AbortSignal } = {},
+): Promise<{ items: BranchOption[]; defaultBranch: string; hasMore: boolean }> {
   const response = await fetch(
-    configuredBranchLookupUrl(branchLookupEndpoint, repository),
-    { headers: { Accept: "application/json" } },
+    configuredBranchLookupUrl(branchLookupEndpoint, repository, options),
+    options.signal
+      ? { headers: { Accept: "application/json" }, signal: options.signal }
+      : { headers: { Accept: "application/json" } },
   );
   if (!response.ok) {
     throw new Error(
@@ -4856,7 +4995,68 @@ async function readBranchOptions(
   return {
     items,
     defaultBranch: String(payload.defaultBranch || "").trim(),
+    hasMore: payload.hasMore === true,
   };
+}
+
+async function readBranchResolve(
+  resolveEndpoint: string,
+  repository: string,
+  branch: string,
+  signal?: AbortSignal,
+): Promise<{ found: boolean; branch: string; inconclusive: boolean }> {
+  const response = await fetch(
+    configuredBranchResolveUrl(resolveEndpoint, repository, branch),
+    signal
+      ? { headers: { Accept: "application/json" }, signal }
+      : { headers: { Accept: "application/json" } },
+  );
+  if (!response.ok) {
+    throw new Error(
+      await responseErrorMessage(response, "Failed to verify branch."),
+    );
+  }
+  const payload = (await response.json()) as BranchResolveResponse;
+  if (typeof payload.found !== "boolean") {
+    // Older or unexpected payloads carry no exact evidence; treat them as
+    // inconclusive so authoring is never blocked by a missing field.
+    return { found: false, branch: "", inconclusive: true };
+  }
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+  const resolved = String(payload.branch || "").trim();
+  if (payload.found && (!resolved || resolved !== branch.trim())) {
+    return { found: false, branch: "", inconclusive: true };
+  }
+  return {
+    found: payload.found,
+    branch: payload.found ? resolved : "",
+    inconclusive: payload.inconclusive === true,
+  };
+}
+
+async function readBranchMetadata(
+  metadataEndpoint: string,
+  repository: string,
+  signal?: AbortSignal,
+): Promise<{ defaultBranch: string }> {
+  const response = await fetch(
+    configuredBranchMetadataUrl(metadataEndpoint, repository),
+    signal
+      ? { headers: { Accept: "application/json" }, signal }
+      : { headers: { Accept: "application/json" } },
+  );
+  if (!response.ok) {
+    throw new Error(
+      await responseErrorMessage(response, "Failed to load branches."),
+    );
+  }
+  const payload = (await response.json()) as BranchMetadataResponse;
+  if (payload.error) {
+    throw new Error(payload.error);
+  }
+  return { defaultBranch: String(payload.defaultBranch || "").trim() };
 }
 
 function localJiraErrorMessage(error: unknown, fallback: string): string {
@@ -8709,6 +8909,12 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   const branchLookupEndpoint = normalizeMoonMindApiPath(
     dashboardConfig.sources?.github?.branches,
   );
+  const branchResolveEndpoint = normalizeMoonMindApiPath(
+    dashboardConfig.sources?.github?.branchResolve,
+  );
+  const branchMetadataEndpoint = normalizeMoonMindApiPath(
+    dashboardConfig.sources?.github?.branchMetadata,
+  );
   const submittedRepository = repository.trim();
   const selectedRepositoryForBranchLookup =
     submittedRepository || defaultRepository;
@@ -8717,41 +8923,152 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
   )
     ? selectedRepositoryForBranchLookup.trim()
     : "";
+  // Authored text stays synchronous and authoritative. Only the remote
+  // suggestion search is debounced; the input, paste handling, and submission
+  // always read the latest authored value.
+  const debouncedBranchSearch = useDebouncedValue(
+    branch.trim(),
+    BRANCH_SEARCH_DEBOUNCE_MS,
+  );
   const branchOptionsQuery = useQuery({
     ...configQueryDefaults,
-    queryKey: ["workflow-start", "github-branches", branchLookupRepository],
+    queryKey: [
+      "workflow-start",
+      "github-branches",
+      branchLookupRepository,
+      debouncedBranchSearch,
+    ],
     enabled: Boolean(branchLookupEndpoint && branchLookupRepository),
-    queryFn: async () =>
-      readBranchOptions(branchLookupEndpoint || "", branchLookupRepository),
+    queryFn: async ({ signal }) =>
+      readBranchOptions(branchLookupEndpoint || "", branchLookupRepository, {
+        query: debouncedBranchSearch,
+        limit: BRANCH_SUGGESTION_LIMIT,
+        signal,
+      }),
+  });
+  // Small metadata-only fallback so default-branch evidence survives an
+  // unrelated suggestion failure without re-enumerating branches.
+  const branchMetadataQuery = useQuery({
+    ...configQueryDefaults,
+    queryKey: [
+      "workflow-start",
+      "github-branch-metadata",
+      branchLookupRepository,
+    ],
+    enabled: Boolean(
+      branchMetadataEndpoint &&
+        branchLookupRepository &&
+        branchOptionsQuery.isError,
+    ),
+    retry: false,
+    queryFn: async ({ signal }) =>
+      readBranchMetadata(
+        branchMetadataEndpoint || "",
+        branchLookupRepository,
+        signal,
+      ),
   });
   const branchOptions = useMemo(() => {
-    const items = branchOptionsQuery.data?.items || [];
+    const serverItems = branchOptionsQuery.data?.items || [];
+    const fallbackDefault = String(
+      branchOptionsQuery.data?.defaultBranch || "",
+    ).trim();
+    const recent = readRecentBranches(branchLookupRepository);
+    const merged: BranchOption[] = [];
     const seen = new Set<string>();
-    return items.filter((item) => {
-      const key = item.value;
-      if (!key || seen.has(key)) {
-        return false;
+    const push = (item: BranchOption) => {
+      if (!item.value || seen.has(item.value)) {
+        return;
       }
-      seen.add(key);
-      return true;
-    });
-  }, [branchOptionsQuery.data]);
+      seen.add(item.value);
+      merged.push(item);
+    };
+    if (fallbackDefault) {
+      push({
+        value: fallbackDefault,
+        label: fallbackDefault,
+        source: "default",
+      });
+    }
+    for (const name of recent) {
+      push({ value: name, label: name, source: "recent" });
+    }
+    for (const item of serverItems) {
+      push(item);
+    }
+    // Mounted options stay bounded even after repeated paging or history
+    // growth; older branches remain submittable via exact lookup below.
+    return merged.slice(0, BRANCH_SUGGESTION_LIMIT);
+  }, [branchOptionsQuery.data, branchLookupRepository]);
   const defaultBranch = useMemo(() => {
-    const value = String(branchOptionsQuery.data?.defaultBranch || "").trim();
+    const value = String(
+      branchOptionsQuery.data?.defaultBranch ||
+        branchMetadataQuery.data?.defaultBranch ||
+        "",
+    ).trim();
     return value;
-  }, [branchOptionsQuery.data?.defaultBranch]);
+  }, [
+    branchOptionsQuery.data?.defaultBranch,
+    branchMetadataQuery.data?.defaultBranch,
+  ]);
   const effectiveBranch =
     branch.trim() ||
     (!branchTouched && pageMode.mode === "create" && submittedRepository
       ? defaultBranch
       : "");
-  const selectedBranchIsStale = Boolean(
-    branch.trim() &&
-      branchOptionsQuery.isSuccess &&
-      !(branchOptionsQuery.data?.items || []).some(
-        (item) => item.value === branch.trim(),
+  // Exact-name evidence is independent of suggestion membership: a branch
+  // outside the first bounded page must stay selectable without a stale
+  // warning. The query key carries the full request identity (repository and
+  // exact name) so late or out-of-order responses can never validate the
+  // wrong draft. The lookup follows the same debounce as suggestion search so
+  // a paste schedules one lookup and typing does not fan out one request per
+  // keystroke.
+  const trimmedBranchForResolve = debouncedBranchSearch;
+  const branchResolveQuery = useQuery({
+    ...configQueryDefaults,
+    staleTime: 60_000,
+    queryKey: [
+      "workflow-start",
+      "github-branch-resolve",
+      branchLookupRepository,
+      trimmedBranchForResolve,
+    ],
+    enabled: Boolean(
+      branchResolveEndpoint &&
+        branchLookupRepository &&
+        trimmedBranchForResolve,
+    ),
+    retry: false,
+    queryFn: async ({ signal }) =>
+      readBranchResolve(
+        branchResolveEndpoint || "",
+        branchLookupRepository,
+        trimmedBranchForResolve,
+        signal,
       ),
-  );
+  });
+  const branchResolutionOutcome: BranchResolutionOutcome = (() => {
+    if (!trimmedBranchForResolve || !branchResolveEndpoint) {
+      return "not-checked";
+    }
+    if (
+      branchResolveQuery.isLoading ||
+      branchResolveQuery.isFetching ||
+      branchResolveQuery.isPending
+    ) {
+      return "checking";
+    }
+    if (branchResolveQuery.isSuccess && branchResolveQuery.data) {
+      if (branchResolveQuery.data.found) {
+        return "found";
+      }
+      if (branchResolveQuery.data.inconclusive) {
+        return "inconclusive";
+      }
+      return "absent";
+    }
+    return "inconclusive";
+  })();
   const branchControlDisabled =
     !selectedRepositoryForBranchLookup.trim() ||
     !branchLookupEndpoint ||
@@ -8773,17 +9090,38 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
       return "";
     }
     if (branchOptionsQuery.isError) {
+      // Lookup availability is reported separately from input validity: a
+      // failed suggestion fetch never implies the authored branch is wrong.
+      if (defaultBranch) {
+        return "Branch suggestions are unavailable. You can still type a branch name.";
+      }
       const error = branchOptionsQuery.error;
       return error instanceof Error ? error.message : "Failed to load branches.";
     }
-    if (selectedBranchIsStale) {
-      return "Selected branch is not in the latest list for this repository.";
+    if (
+      branchResolutionOutcome === "absent" &&
+      trimmedBranchForResolve === branch.trim() &&
+      branch.trim()
+    ) {
+      return `No branch named "${trimmedBranchForResolve}" was found in this repository. You can still submit it for backend validation.`;
+    }
+    if (
+      branchOptionsQuery.isSuccess &&
+      branchOptionsQuery.data?.hasMore === true &&
+      debouncedBranchSearch
+    ) {
+      // The suggestion list is one bounded page, never a complete crawl:
+      // say so instead of implying these are all the matches.
+      return `Showing the first ${branchOptions.length} suggestions. Type to narrow the list or paste the exact branch name.`;
     }
     if (branchOptionsQuery.isSuccess && branchOptions.length === 0) {
-      return "No branches returned for this repository.";
+      return "No branches returned for this repository. Type a branch name.";
     }
     return "";
   })();
+  const branchStatusIsError = Boolean(
+    branchOptionsQuery.isError && !defaultBranch,
+  );
   const handleRepositoryChange = (value: string) => {
     setRepository(value);
     setRepositoryTouched(true);
@@ -11950,6 +12288,11 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           "Workflow was started but no redirect path was returned.",
         );
       }
+      // Record explicit accepted submissions as honest user-scoped recency.
+      // Intermediate keystrokes are never recorded.
+      if (normalizedRepository && effectiveBranch) {
+        writeRecentBranch(normalizedRepository, effectiveBranch);
+      }
       navigateTo(redirectPath);
       didNavigateAfterCreate = true;
     } catch (error) {
@@ -14631,7 +14974,7 @@ function WorkflowStartPageContent({ payload }: { payload: BootPayload }) {
           {branchStatusMessage ? (
             <p
               className={
-                branchOptionsQuery.isError || selectedBranchIsStale
+                branchStatusIsError
                   ? "queue-authoring-controls-status notice error"
                   : "queue-authoring-controls-status small"
               }

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4399,7 +4399,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/github/branches": {
+    "/api/github/branches/resolve": {
         parameters: {
             query?: never;
             header?: never;
@@ -4407,10 +4407,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Dashboard Github Branches
-         * @description List one bounded page of GitHub branches through MoonMind.
+         * Resolve Dashboard Github Branch
+         * @description Resolve one exact branch name without scanning suggestion pages.
          */
-        get: operations["list_dashboard_github_branches_api_github_branches_get"];
+        get: operations["resolve_dashboard_github_branch_api_github_branches_resolve_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4439,7 +4439,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/github/branches/resolve": {
+    "/api/github/branches": {
         parameters: {
             query?: never;
             header?: never;
@@ -4447,10 +4447,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Resolve Dashboard Github Branch
-         * @description Resolve one exact branch name without scanning suggestion pages.
+         * List Dashboard Github Branches
+         * @description List one bounded page of GitHub branches through MoonMind.
          */
-        get: operations["resolve_dashboard_github_branch_api_github_branches_resolve_get"];
+        get: operations["list_dashboard_github_branches_api_github_branches_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6822,8 +6822,11 @@ export interface components {
             error?: string | null;
             /** Defaultbranch */
             defaultBranch?: string | null;
-            /** Hasmore */
-            hasMore?: boolean;
+            /**
+             * Hasmore
+             * @default false
+             */
+            hasMore: boolean;
         };
         /**
          * DashboardBranchMetadataResponse
@@ -6861,16 +6864,22 @@ export interface components {
          * @description Exact-name branch resolution independent of suggestion pages.
          */
         DashboardBranchResolveResponse: {
-            /** Found */
-            found?: boolean;
+            /**
+             * Found
+             * @default false
+             */
+            found: boolean;
             /** Branch */
             branch?: string | null;
             /** Defaultbranch */
             defaultBranch?: string | null;
             /** Error */
             error?: string | null;
-            /** Inconclusive */
-            inconclusive?: boolean;
+            /**
+             * Inconclusive
+             * @default true
+             */
+            inconclusive: boolean;
         };
         /**
          * DashboardIssueListResponse

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4408,9 +4408,49 @@ export interface paths {
         };
         /**
          * List Dashboard Github Branches
-         * @description List GitHub branches through MoonMind so browsers never call GitHub directly.
+         * @description List one bounded page of GitHub branches through MoonMind.
          */
         get: operations["list_dashboard_github_branches_api_github_branches_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/github/branches/metadata": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Dashboard Github Branch Metadata
+         * @description Resolve only default-branch metadata so form init never enumerates branches.
+         */
+        get: operations["get_dashboard_github_branch_metadata_api_github_branches_metadata_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/github/branches/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Resolve Dashboard Github Branch
+         * @description Resolve one exact branch name without scanning suggestion pages.
+         */
+        get: operations["resolve_dashboard_github_branch_api_github_branches_resolve_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6773,7 +6813,7 @@ export interface components {
         };
         /**
          * DashboardBranchListResponse
-         * @description Dashboard response containing branch options for one repository.
+         * @description Dashboard response containing bounded branch suggestions for one repository.
          */
         DashboardBranchListResponse: {
             /** Items */
@@ -6782,6 +6822,18 @@ export interface components {
             error?: string | null;
             /** Defaultbranch */
             defaultBranch?: string | null;
+            /** Hasmore */
+            hasMore?: boolean;
+        };
+        /**
+         * DashboardBranchMetadataResponse
+         * @description Metadata-only branch response so form init never enumerates branches.
+         */
+        DashboardBranchMetadataResponse: {
+            /** Defaultbranch */
+            defaultBranch?: string | null;
+            /** Error */
+            error?: string | null;
         };
         /**
          * DashboardBranchOption
@@ -6803,6 +6855,22 @@ export interface components {
              * @description Branch option source
              */
             source: string;
+        };
+        /**
+         * DashboardBranchResolveResponse
+         * @description Exact-name branch resolution independent of suggestion pages.
+         */
+        DashboardBranchResolveResponse: {
+            /** Found */
+            found?: boolean;
+            /** Branch */
+            branch?: string | null;
+            /** Defaultbranch */
+            defaultBranch?: string | null;
+            /** Error */
+            error?: string | null;
+            /** Inconclusive */
+            inconclusive?: boolean;
         };
         /**
          * DashboardIssueListResponse
@@ -23101,10 +23169,75 @@ export interface operations {
             };
         };
     };
+    resolve_dashboard_github_branch_api_github_branches_resolve_get: {
+        parameters: {
+            query: {
+                repository: string;
+                branch: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardBranchResolveResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_dashboard_github_branch_metadata_api_github_branches_metadata_get: {
+        parameters: {
+            query: {
+                repository: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardBranchMetadataResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_dashboard_github_branches_api_github_branches_get: {
         parameters: {
             query: {
                 repository: string;
+                q?: string;
+                limit?: number;
             };
             header?: never;
             path?: never;

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -511,7 +511,7 @@ def test_build_repository_branch_options_uses_github_lookup(monkeypatch) -> None
     monkeypatch.setattr(
         dashboard_view_model,
         "_get_cached_github_branch_options",
-        lambda token, repository: (
+        lambda token, repository, query="", limit=20: (
             [
                 dashboard_view_model.BranchOption(
                     value="main",
@@ -526,6 +526,7 @@ def test_build_repository_branch_options_uses_github_lookup(monkeypatch) -> None
             ],
             None,
             "main",
+            False,
         ),
     )
 
@@ -542,9 +543,37 @@ def test_build_repository_branch_options_uses_github_lookup(monkeypatch) -> None
         ],
         "error": None,
         "defaultBranch": "main",
+        "hasMore": False,
     }
 
-def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
+
+def test_build_repository_branch_options_reports_has_more(monkeypatch) -> None:
+    monkeypatch.setattr(settings.github, "github_token", "ghp_test_token")
+    monkeypatch.setattr(settings.github, "github_enabled", True)
+    monkeypatch.setattr(
+        dashboard_view_model,
+        "_get_cached_github_branch_options",
+        lambda token, repository, query="", limit=20: (
+            [
+                dashboard_view_model.BranchOption(
+                    value="main",
+                    label="main",
+                    source="github",
+                ),
+            ],
+            None,
+            "main",
+            True,
+        ),
+    )
+
+    payload = dashboard_view_model.build_repository_branch_options("Octo/Repo")
+
+    assert payload["hasMore"] is True
+    assert payload["defaultBranch"] == "main"
+
+
+def test_fetch_github_branch_options_reads_single_bounded_page(monkeypatch) -> None:
     responses = [
         {
             "json": {"default_branch": "main"},
@@ -553,10 +582,6 @@ def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
         {
             "json": [{"name": "main"}, {"name": "feature/page-one"}],
             "links": {"next": {"url": "https://api.github.com/page/2"}},
-        },
-        {
-            "json": [{"name": "feature/page-two"}, {"name": "main"}],
-            "links": {},
         },
     ]
     calls = []
@@ -594,18 +619,22 @@ def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
 
     monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
 
-    options, error, default_branch = dashboard_view_model._fetch_github_branch_options(
-        "ghp_test_token",
-        "Octo/Repo",
+    options, error, default_branch, has_more = (
+        dashboard_view_model._fetch_github_branch_options(
+            "ghp_test_token",
+            "Octo/Repo",
+        )
     )
 
     assert error is None
     assert default_branch == "main"
+    # Bounded cold discovery: only one page is read; the advertised next page
+    # is reported via has_more instead of being drained automatically.
     assert [option.value for option in options] == [
         "main",
         "feature/page-one",
-        "feature/page-two",
     ]
+    assert has_more is True
     assert calls == [
         {
             "url": "https://api.github.com/repos/Octo/Repo",
@@ -623,18 +652,120 @@ def test_fetch_github_branch_options_follows_pagination(monkeypatch) -> None:
                 "Authorization": "Bearer ghp_test_token",
                 "X-GitHub-Api-Version": "2022-11-28",
             },
-            "params": {"per_page": 100},
-        },
-        {
-            "url": "https://api.github.com/page/2",
-            "headers": {
-                "Accept": "application/vnd.github+json",
-                "Authorization": "Bearer ghp_test_token",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-            "params": None,
+            "params": {"per_page": 20},
         },
     ]
+
+
+def test_fetch_github_branch_options_filters_single_page_locally(
+    monkeypatch,
+) -> None:
+    class FakeResponse:
+        def __init__(self, payload: object, links: object = None) -> None:
+            self._payload = payload
+            self.links = links or {}
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> object:
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            if url == "https://api.github.com/repos/Octo/Repo":
+                return FakeResponse({"default_branch": "main"})
+            return FakeResponse(
+                [{"name": "main"}, {"name": "Feature/Page-One"}],
+                links={},
+            )
+
+    monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
+
+    options, error, default_branch, has_more = (
+        dashboard_view_model._fetch_github_branch_options(
+            "ghp_test_token", "Octo/Repo", query="feat"
+        )
+    )
+
+    assert error is None
+    assert [option.value for option in options] == ["Feature/Page-One"]
+    assert default_branch == "main"
+    assert has_more is False
+
+
+def test_fetch_github_branch_options_preserves_metadata_on_page_failure(
+    monkeypatch,
+) -> None:
+    class FakeResponse:
+        def __init__(self, payload: object) -> None:
+            self._payload = payload
+            self.links = {}
+
+        def raise_for_status(self) -> None:
+            raise dashboard_view_model.httpx.HTTPError("branch page failed")
+
+        def json(self) -> object:
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            if url == "https://api.github.com/repos/Octo/Repo":
+
+                class MetadataResponse:
+                    links: dict[str, object] = {}
+
+                    def raise_for_status(self) -> None:
+                        return None
+
+                    def json(self) -> object:
+                        return {"default_branch": "develop"}
+
+                return MetadataResponse()  # type: ignore[return-value]
+            return FakeResponse([])
+
+    monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
+
+    options, error, default_branch, has_more = (
+        dashboard_view_model._fetch_github_branch_options(
+            "ghp_test_token", "Octo/Repo"
+        )
+    )
+
+    assert options == []
+    assert error == "GitHub branch lookup is unavailable."
+    assert default_branch == "develop"
+    assert has_more is False
 
 def test_fetch_github_branch_options_keeps_branches_when_metadata_fails(
     monkeypatch,
@@ -678,9 +809,11 @@ def test_fetch_github_branch_options_keeps_branches_when_metadata_fails(
 
     monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
 
-    options, error, default_branch = dashboard_view_model._fetch_github_branch_options(
-        "ghp_test_token",
-        "Octo/Repo",
+    options, error, default_branch, _has_more = (
+        dashboard_view_model._fetch_github_branch_options(
+            "ghp_test_token",
+            "Octo/Repo",
+        )
     )
 
     assert error is None
@@ -690,9 +823,317 @@ def test_fetch_github_branch_options_keeps_branches_when_metadata_fails(
         {"url": "https://api.github.com/repos/Octo/Repo", "params": None},
         {
             "url": "https://api.github.com/repos/Octo/Repo/branches",
-            "params": {"per_page": 100},
+            "params": {"per_page": 20},
         },
     ]
+
+def test_fetch_github_branch_exact_matches_case_sensitively(
+    monkeypatch,
+) -> None:
+    seen_urls = []
+
+    class FakeResponse:
+        def __init__(self, payload: object, status: int = 200) -> None:
+            self._payload = payload
+            self.status_code = status
+            self.links = {}
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise dashboard_view_model.httpx.HTTPStatusError(
+                    "status", request=None, response=self
+                )
+
+        def json(self) -> object:
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            seen_urls.append(url)
+            return FakeResponse({"name": "Feature/Foo"})
+
+    monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
+
+    found, resolved, error, inconclusive = (
+        dashboard_view_model._fetch_github_branch_exact(
+            "ghp_test_token", "Octo/Repo", "Feature/Foo"
+        )
+    )
+
+    assert found is True
+    assert resolved == "Feature/Foo"
+    assert error is None
+    assert inconclusive is False
+    # Slash-containing names stay path-safe without case folding.
+    assert seen_urls == [
+        "https://api.github.com/repos/Octo/Repo/branches/Feature/Foo"
+    ]
+
+
+def test_fetch_github_branch_exact_absent_only_when_repo_reachable(
+    monkeypatch,
+) -> None:
+    class FakeResponse:
+        def __init__(self, payload: object, status: int = 200) -> None:
+            self._payload = payload
+            self.status_code = status
+            self.links = {}
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise dashboard_view_model.httpx.HTTPStatusError(
+                    "status", request=None, response=self
+                )
+
+        def json(self) -> object:
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            if "/branches/" in url:
+                return FakeResponse({"message": "not found"}, status=404)
+            return FakeResponse({"default_branch": "main"})
+
+    monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
+
+    found, _resolved, error, inconclusive = (
+        dashboard_view_model._fetch_github_branch_exact(
+            "ghp_test_token", "Octo/Repo", "missing-branch"
+        )
+    )
+
+    assert found is False
+    assert error is None
+    assert inconclusive is False
+
+
+def test_fetch_github_branch_exact_inconclusive_when_repo_unreachable(
+    monkeypatch,
+) -> None:
+    class FakeResponse:
+        def __init__(self, payload: object, status: int = 200) -> None:
+            self._payload = payload
+            self.status_code = status
+            self.links = {}
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise dashboard_view_model.httpx.HTTPStatusError(
+                    "status", request=None, response=self
+                )
+
+        def json(self) -> object:
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            if "/branches/" in url:
+                return FakeResponse({"message": "not found"}, status=404)
+            return FakeResponse({"message": "denied"}, status=403)
+
+    monkeypatch.setattr(dashboard_view_model.httpx, "Client", FakeClient)
+
+    found, _resolved, error, inconclusive = (
+        dashboard_view_model._fetch_github_branch_exact(
+            "ghp_test_token", "Octo/Repo", "missing-branch"
+        )
+    )
+
+    assert found is False
+    assert error == "GitHub branch lookup is unavailable."
+    assert inconclusive is True
+
+
+def test_branch_search_cache_scopes_by_query_and_preserves_branch_case() -> None:
+    first = dashboard_view_model._github_branch_search_cache_key(
+        "token", "Octo/Repo", "feat", 20
+    )
+    assert first != dashboard_view_model._github_branch_search_cache_key(
+        "token", "Octo/Repo", "main", 20
+    )
+    assert first != dashboard_view_model._github_branch_search_cache_key(
+        "token", "Octo/Repo", "feat", 50
+    )
+    assert first == dashboard_view_model._github_branch_search_cache_key(
+        "token", "octo/repo", "feat", 20
+    )
+    resolve_upper = dashboard_view_model._github_branch_resolve_cache_key(
+        "token", "Octo/Repo", "Feature/Foo"
+    )
+    resolve_lower = dashboard_view_model._github_branch_resolve_cache_key(
+        "token", "Octo/Repo", "feature/foo"
+    )
+    assert resolve_upper != resolve_lower
+
+
+def test_branch_cache_evicts_oldest_entries() -> None:
+    cache: dict[str, int] = {}
+    for index in range(
+        dashboard_view_model._BRANCH_CACHE_MAX_ENTRIES + 50
+    ):
+        dashboard_view_model._bounded_cache_put(cache, f"key-{index}", index)
+
+    assert len(cache) == dashboard_view_model._BRANCH_CACHE_MAX_ENTRIES
+    assert "key-0" not in cache
+
+
+def test_clamp_branch_suggestion_limit_bounds() -> None:
+    assert dashboard_view_model._clamp_branch_suggestion_limit(999) == 50
+    assert dashboard_view_model._clamp_branch_suggestion_limit(-5) == 1
+    assert (
+        dashboard_view_model._clamp_branch_suggestion_limit("bad")
+        == dashboard_view_model._BRANCH_SUGGESTION_DEFAULT_LIMIT
+    )
+    assert dashboard_view_model._clamp_branch_suggestion_limit(25) == 25
+
+
+def test_resolve_repository_branch_rejects_invalid_repository(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings.github, "github_token", "ghp_test_token")
+    monkeypatch.setattr(settings.github, "github_enabled", True)
+
+    payload = dashboard_view_model.resolve_repository_branch(
+        "not-a-repo", "main"
+    )
+
+    assert payload["found"] is False
+    assert payload["inconclusive"] is True
+
+
+def test_build_repository_branch_metadata_returns_default_without_branches(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings.github, "github_token", "ghp_test_token")
+    monkeypatch.setattr(settings.github, "github_enabled", True)
+    monkeypatch.setattr(
+        dashboard_view_model,
+        "_get_cached_repository_default_branch",
+        lambda token, repository: ("main", None),
+    )
+
+    payload = dashboard_view_model.build_repository_branch_metadata("Octo/Repo")
+
+    assert payload == {"defaultBranch": "main", "error": None}
+
+
+@pytest.mark.asyncio
+async def test_async_branch_lookup_keeps_event_loop_responsive(
+    monkeypatch,
+) -> None:
+    """A delayed upstream lookup must not block unrelated async work."""
+
+    import asyncio
+
+    ticks: list[int] = []
+
+    async def ticker() -> None:
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+            ticks.append(1)
+
+    class FakeResponse:
+        links: dict[str, object] = {}
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> object:
+            return {"default_branch": "main"}
+
+    class FakeBranchResponse(FakeResponse):
+        def json(self) -> object:
+            return [{"name": "main"}]
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: object) -> None:
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, int] | None = None,
+        ) -> FakeResponse:
+            await asyncio.sleep(0.05)
+            if url.endswith("/branches"):
+                return FakeBranchResponse()
+            return FakeResponse()
+
+    def forbidden_sync_client(**kwargs: object) -> object:
+        raise AssertionError("async path must not use the blocking client")
+
+    monkeypatch.setattr(
+        dashboard_view_model.httpx, "AsyncClient", FakeAsyncClient
+    )
+    monkeypatch.setattr(
+        dashboard_view_model.httpx, "Client", forbidden_sync_client
+    )
+
+    ticker_task = asyncio.create_task(ticker())
+    options, error, default_branch, _has_more = (
+        await dashboard_view_model._fetch_github_branch_options_async(
+            "ghp_test_token", "Octo/Repo"
+        )
+    )
+    await ticker_task
+
+    assert [option.value for option in options] == ["main"]
+    assert error is None
+    assert default_branch == "main"
+    assert len(ticks) == 5
 
 def test_build_repository_branch_options_sanitizes_errors(monkeypatch) -> None:
     monkeypatch.setattr(settings.github, "github_token", "ghp_secret_token")
@@ -700,10 +1141,11 @@ def test_build_repository_branch_options_sanitizes_errors(monkeypatch) -> None:
     monkeypatch.setattr(
         dashboard_view_model,
         "_get_cached_github_branch_options",
-        lambda token, repository: (
+        lambda token, repository, query="", limit=20: (
             [],
             "GitHub failed with ghp_secret_token",
-            None,
+            "main",
+            False,
         ),
     )
 
@@ -712,6 +1154,8 @@ def test_build_repository_branch_options_sanitizes_errors(monkeypatch) -> None:
     assert payload["items"] == []
     assert payload["error"] == "GitHub branch lookup is unavailable."
     assert "ghp_secret_token" not in payload["error"]
+    # Independently successful metadata survives the failed suggestion page.
+    assert payload["defaultBranch"] == "main"
 
 def test_build_runtime_config_uses_repo_runtime_model_defaults(monkeypatch) -> None:
     monkeypatch.delenv("MOONMIND_CODEX_MODEL", raising=False)

--- a/tests/unit/api/routers/test_workflow_console_view_model.py
+++ b/tests/unit/api/routers/test_workflow_console_view_model.py
@@ -1128,7 +1128,7 @@ async def test_async_branch_lookup_keeps_event_loop_responsive(
             "ghp_test_token", "Octo/Repo"
         )
     )
-    await ticker_task
+    _ = await ticker_task
 
     assert [option.value for option in options] == ["main"]
     assert error is None


### PR DESCRIPTION
## Summary

Fixes the laggy branch paste on Workflow Create (`/workflows/new`) by replacing automatic full-repository branch enumeration with a text-first picker for MoonLadderStudios/MoonMind#4054:

- Backend: single bounded branch page (`q`/`limit`, `hasMore`, per-page cap) plus independent metadata-only and exact-name resolve endpoints, served over awaited `httpx.AsyncClient` (no more blocking sync HTTP in the async route). Metadata survives unrelated search failure and vice versa.
- Frontend: authored branch text stays synchronous and authoritative (no overwrite, no input remount); only remote search is debounced (250ms) with cancellation; mounted suggestions capped at 20 (default branch first, then honest user-scoped recency, then page items); exact names validated independently of suggestion membership with five distinct outcomes (non-blocking for absent/inconclusive).
- Docs: `docs/UI/CreatePage.md` and `docs/Steps/SkillInputSchemaUIGeneration.md` record the text-first behavior, including for schema-generated branch fields.

## Verification outcome

Post-remediation `moonspec-verify` verdict: **FULLY_IMPLEMENTED** (confidence HIGH) — candidate `feebc953e` resolves all five source-verified baseline defects and all eight assessment requirements. Initial assessment was `NOT_IMPLEMENTED`, so this implementation is published even though the work branch was already pushed and clean.

## Tests run

- Backend unit: `moonmind container python-tests tests/unit/api/routers/test_workflow_console_view_model.py` — **67/67 PASS** (includes 15 new bounded-discovery/exact-resolve/async/cache/metadata tests).
- Frontend unit: `npm run ui:test -- frontend/src/entrypoints/workflow-start-branch-picker.test.tsx` — **8/8 PASS** (paste preservation, 20-cap partial notice, editable-during-failure, absent-without-blocking, URL encoding incl. slashes, recency bounds).

## Remaining risks

- Browser-measured input-to-paint profiling (p95 < 100ms budget) and real-browser IME/clipboard checks were not executed in this runtime; required CI uses deterministic request/value/bounds assertions instead, per the issue's own instruction to use deterministic fixtures rather than flaky timing tests.
- No cursor-based "Show more" paging: exactly one bounded page is served (`hasMore` reported honestly with a partial-list notice) and older branches route through the independent exact-name lookup. Cursor pagination remains a possible future enhancement, not a correctness gap.

Closes MoonLadderStudios/MoonMind#4054
