### PR TITLE
[Saved work] Capture immutable manifests and safe portable workspace exports (MoonLadderStudios/MoonMind#4015)

### DIFF
--- a/moonmind/schemas/managed_checkpoint_models.py
+++ b/moonmind/schemas/managed_checkpoint_models.py
@@ -107,3 +107,8 @@ class ManagedWorkspaceCheckpointCaptureResult(BaseModel):
     idempotency_key: str = Field(..., alias="idempotencyKey")
     failure_code: str | None = Field(None, alias="failureCode", max_length=100)
     summary: str | None = Field(None, max_length=1000)
+    # Saved-work manifest index (#4015): compact reference to the verified
+    # immutable manifest committing this capture. Optional so historical
+    # records without a saved-work manifest still validate.
+    saved_work_ref: str | None = Field(None, alias="savedWorkRef", max_length=500)
+    saved_work_digest: str | None = Field(None, alias="savedWorkDigest", max_length=200)

--- a/moonmind/schemas/saved_work_models.py
+++ b/moonmind/schemas/saved_work_models.py
@@ -86,6 +86,34 @@ _RUNTIME_CREDENTIAL_PATH_HINTS: tuple[str, ...] = (
     "managed_runs/",
 )
 
+# Redaction sentinels emitted by ``moonmind.utils.logging.redact_sensitive_text``
+# (``[REDACTED]``, ``[REDACTED_PRIVATE_KEY]``, ...). An assignment-shaped
+# match whose value is exactly one of these sentinels carries no secret and
+# must not fail checkpoint capture of an already-redacted tree. Mirrors the
+# exemption in ``moonmind.security.outbound_scan``.
+_REDACTED_SENTINEL_VALUE_PATTERN = re.compile(
+    r"^\[REDACTED(?:_[A-Z0-9]+)?\]$", re.IGNORECASE
+)
+
+
+def _credential_match_is_benign(match_text: str) -> bool:
+    """Return True when an assignment-shaped match carries no secret material."""
+    separator = max(match_text.rfind("="), match_text.rfind(":"))
+    value = match_text[separator + 1 :].strip() if separator != -1 else ""
+    quoted = len(value) >= 2 and (
+        (value.startswith('"') and value.endswith('"'))
+        or (value.startswith("'") and value.endswith("'"))
+    )
+    inner = value[1:-1].strip() if quoted else value
+    if _REDACTED_SENTINEL_VALUE_PATTERN.match(inner):
+        return True
+    if not quoted and ("(" in value or ")" in value):
+        # Credential-handling code such as ``token = str(explicit_token)``
+        # is a call expression, not a credential value. Bare secret values
+        # (tokens, base64, hex) never contain parentheses.
+        return True
+    return False
+
 
 def resolve_saved_work_format_profile(
     *,
@@ -468,8 +496,11 @@ def parse_git_diff_raw_to_deltas(
 
 def _export_findings_in_text(text: str, location: str) -> int:
     findings = 0
-    for pattern in _CREDENTIAL_PATTERNS:
-        findings += len(pattern.findall(text))
+    for index, pattern in enumerate(_CREDENTIAL_PATTERNS):
+        for match in pattern.finditer(text):
+            if index == 0 and _credential_match_is_benign(match.group(0)):
+                continue
+            findings += 1
     for hint in _RUNTIME_CREDENTIAL_PATH_HINTS:
         if hint in location:
             findings += 1
@@ -477,14 +508,23 @@ def _export_findings_in_text(text: str, location: str) -> int:
     return findings
 
 
+# Bytes of overlap retained between streamed scan windows. Any single secret
+# construct no longer than this overlap is fully contained in at least one
+# window even when it spans a chunk boundary. 8 KiB covers the largest
+# supported construct (a multi-kilobyte PEM private-key block) with margin,
+# while staying negligible next to the multi-megabyte spool chunk size.
+_SCAN_CHUNK_OVERLAP_BYTES = 8 * 1024
+
+
 def scan_saved_work_export_stream(
     chunks: Sequence[bytes] | Any, *, export_digest: str, location: str
 ) -> dict[str, Any]:
     """Stream confidentiality/secret controls over exported bytes in chunks.
 
-    Chunk windows overlap by 256 bytes so credential-shaped content spanning
-    a chunk boundary is still detected without holding the whole export in
-    memory. Same evidence contract as :func:`scan_saved_work_export`.
+    Chunk windows overlap by ``_SCAN_CHUNK_OVERLAP_BYTES`` so
+    credential-shaped content spanning a chunk boundary is still detected
+    without holding the whole export in memory. Same evidence contract as
+    :func:`scan_saved_work_export`.
     """
     findings = 0
     decodable = True
@@ -498,7 +538,7 @@ def scan_saved_work_export_stream(
         findings += _export_findings_in_text(
             window.decode("utf-8", errors="ignore"), location
         )
-        tail = window[-256:]
+        tail = window[-_SCAN_CHUNK_OVERLAP_BYTES:]
     if findings:
         return {
             "disposition": "blocked",

--- a/moonmind/schemas/saved_work_models.py
+++ b/moonmind/schemas/saved_work_models.py
@@ -1,0 +1,679 @@
+"""Compact saved-work manifest contracts for immutable workspace exports.
+
+Implements MoonLadderStudios/MoonMind#4015 (plan slice 4,
+``docs/RepositoryAccessAndWorkspaceDesign.md`` ``CONTRACT-012``,
+``QUALITY-004``, ``CONTRACT-011``, ``INV-004``, ``TEST-003``).
+
+The saved-work manifest is a compact index of verified artifact/checkpoint
+evidence, not a second object store. It extends the existing managed
+checkpoint capture contracts with:
+
+- one stable capture generation bound to a verified quiescent workspace,
+- deterministic content/file-manifest identities,
+- a small format profile (full snapshot vs exact-baseline delta vs
+  selected-history vs report-only) with truthful portability claims,
+- retries bound to exact owner/source-generation/policy/content identity,
+- binary-safe deltas that never infer deletion from capture exclusion,
+- confidentiality/secret controls bound to the exported bytes, and
+- an immutable commit step where an upload without a usable manifest stays
+  incomplete.
+
+ACL and retention resolve through artifact ownership, never through editable
+copied policy inside the manifest. Finalization, physical cleanup, retention,
+and destination publication remain with their existing focused owners.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any, Literal, Mapping, Sequence
+
+SAVED_WORK_MANIFEST_SCHEMA_VERSION = "saved-work-manifest/v1"
+SAVED_WORK_CAPTURE_CONTRACT_VERSION = "saved-work-capture/v1"
+SAVED_WORK_SCAN_POLICY_REF = "moonmind.saved_work.scan.v1"
+
+SavedWorkFormatKind = Literal[
+    "full_snapshot", "exact_baseline_delta", "selected_history", "report_only"
+]
+SavedWorkOutputStatus = Literal[
+    "self_contained",
+    "requires_dependencies",
+    "inapplicable",
+    "incomplete",
+    "failed",
+]
+
+SUPPORTED_FORMAT_KINDS: tuple[str, ...] = (
+    "full_snapshot",
+    "exact_baseline_delta",
+    "selected_history",
+    "report_only",
+)
+
+# Explicit supported format-size limits for saved-work exports. A fixed
+# lower-level direct-upload limit must never be silently bypassed or reported
+# as "no output": callers exceeding it receive an explicit incomplete/failed
+# output claim instead.
+SAVED_WORK_FORMAT_SIZE_LIMITS: dict[str, int] = {
+    "max_file_count": 20_000,
+    "max_file_bytes": 100 * 1024 * 1024,
+    "max_total_bytes": 1024 * 1024 * 1024,
+    # Bounded in-process spool for one streamed export chunk/write. Larger
+    # exports must stream through the temp-file spool path, never by growing
+    # an unbounded in-memory buffer.
+    "max_spool_chunk_bytes": 8 * 1024 * 1024,
+}
+
+_CREDENTIAL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"(?i)\b(?:token|password|secret|api[_-]?key|credential)\s*[:=]\s*"
+        r"(?:\"[^\"]+\"|'[^']+'|[^\s,;\"']+)"
+    ),
+    re.compile(r"(?i)\b(?:authorization\s*:\s*)?bearer\s+[A-Za-z0-9._~+/=-]{8,}"),
+    re.compile(r"(?i)\b(?:ghp|gho|ghu|ghs|ghr|github_pat)[_-][A-Za-z0-9_-]{20,}\b"),
+    re.compile(
+        r"(?is)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----"
+    ),
+)
+
+_RUNTIME_CREDENTIAL_PATH_HINTS: tuple[str, ...] = (
+    ".codex/auth.json",
+    ".config/gh/hosts.yml",
+    ".docker/config.json",
+    "managed_sessions/",
+    "managed_runs/",
+)
+
+
+def resolve_saved_work_format_profile(
+    *,
+    is_git_workspace: bool,
+    requested_result: str = "portable",
+) -> dict[str, list[str]]:
+    """Resolve a small required/optional format profile from the requested result.
+
+    A report-only or non-Git task never synthesizes commits or a bundle: Git
+    formats are inapplicable rather than faked. A Git workspace that produced
+    useful files gets a full snapshot plus an exact-baseline delta; selected
+    history stays optional until a caller explicitly requests refs.
+    """
+    normalized = (requested_result or "portable").strip().lower()
+    if normalized in {"report", "report_only", "report-only"} or not is_git_workspace:
+        return {
+            "required": ["report_only"],
+            "optional": ["full_snapshot"] if is_git_workspace else [],
+        }
+    if normalized in {"delta", "patch", "exact_baseline_delta"}:
+        return {
+            "required": ["full_snapshot", "exact_baseline_delta"],
+            "optional": ["selected_history"],
+        }
+    if normalized in {"history", "bundle", "selected_history"}:
+        return {
+            "required": ["full_snapshot", "selected_history"],
+            "optional": ["exact_baseline_delta"],
+        }
+    return {
+        "required": ["full_snapshot"],
+        "optional": ["exact_baseline_delta", "selected_history"],
+    }
+
+
+def describe_output_claim(
+    *,
+    fmt: str,
+    status: str,
+    ref: str | None = None,
+    digest: str | None = None,
+    size_bytes: int | None = None,
+    dependencies: Sequence[str] | None = None,
+    detail: str | None = None,
+) -> dict[str, Any]:
+    """Build one truthful per-output portability claim."""
+    if fmt not in SUPPORTED_FORMAT_KINDS:
+        raise ValueError(f"unsupported saved-work format: {fmt}")
+    if status not in (
+        "self_contained",
+        "requires_dependencies",
+        "inapplicable",
+        "incomplete",
+        "failed",
+    ):
+        raise ValueError(f"unsupported output status: {status}")
+    claim: dict[str, Any] = {"format": fmt, "status": status}
+    if ref is not None:
+        claim["ref"] = ref
+    if digest is not None:
+        claim["digest"] = digest
+    if size_bytes is not None:
+        claim["sizeBytes"] = size_bytes
+    if dependencies:
+        claim["dependencies"] = list(dependencies)
+    if detail is not None:
+        claim["detail"] = detail
+    if status == "self_contained" and ref is None:
+        raise ValueError("self-contained outputs require a stored ref")
+    if status == "requires_dependencies" and not dependencies:
+        raise ValueError("dependency-bound outputs must name immutable dependencies")
+    return claim
+
+
+def thin_bundle_is_portable(*, has_baseline_objects: bool) -> bool:
+    """Decide whether a bundle/archive may claim source-credential independence.
+
+    A thin bundle or worktree archive without its required baseline objects is
+    not portable merely because its download succeeded.
+    """
+    return bool(has_baseline_objects)
+
+
+def build_saved_work_manifest(
+    *,
+    capture_id: str,
+    identity: Mapping[str, Any],
+    source: Mapping[str, Any],
+    content_digest: str,
+    file_manifest_digest: str,
+    capture_policy: Mapping[str, Any],
+    capture_policy_version: str = SAVED_WORK_CAPTURE_CONTRACT_VERSION,
+    required_formats: Sequence[str],
+    optional_formats: Sequence[str] | None = None,
+    outputs: Sequence[Mapping[str, Any]],
+    exclusions: Sequence[Mapping[str, Any]] | None = None,
+    scan: Mapping[str, Any] | None = None,
+    dependencies: Sequence[str] | None = None,
+    quiescence: Mapping[str, Any] | None = None,
+    git: Mapping[str, Any] | None = None,
+    capture_generation: str | None = None,
+    artifact_scope: str | None = None,
+    retention_ref: str | None = None,
+) -> dict[str, Any]:
+    """Assemble one compact saved-work manifest index.
+
+    ACL/retention resolve through ``artifact_scope``/``retention_ref``
+    ownership handles, never through editable copied policy text. Applicable
+    Git baseline/head/patch/bundle fields stay optional so report-only and
+    non-Git tasks never synthesize fake Git identities.
+    """
+    capture_id = str(capture_id or "").strip()
+    if not capture_id:
+        raise ValueError("capture_id must not be blank")
+    manifest: dict[str, Any] = {
+        "schemaVersion": SAVED_WORK_MANIFEST_SCHEMA_VERSION,
+        "captureId": capture_id,
+        "identity": dict(identity),
+        "source": dict(source),
+        "contentDigest": content_digest,
+        "fileManifestDigest": file_manifest_digest,
+        "capturePolicy": dict(capture_policy),
+        "capturePolicyVersion": capture_policy_version,
+        "requiredFormats": list(required_formats),
+        "optionalFormats": list(optional_formats or []),
+        "outputs": [dict(output) for output in outputs],
+        "exclusions": [dict(exclusion) for exclusion in (exclusions or [])],
+        "dependencies": list(dependencies or []),
+    }
+    manifest["scan"] = dict(scan) if scan is not None else {"disposition": "unknown"}
+    manifest["quiescence"] = (
+        dict(quiescence)
+        if quiescence is not None
+        else {"verified": False, "mechanism": "unknown"}
+    )
+    if git is not None:
+        manifest["git"] = dict(git)
+    if capture_generation is not None:
+        manifest["captureGeneration"] = capture_generation
+    if artifact_scope is not None:
+        manifest["artifactScope"] = artifact_scope
+    if retention_ref is not None:
+        manifest["retentionRef"] = retention_ref
+    manifest_digest = "sha256:" + hashlib.sha256(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    manifest["manifestDigest"] = manifest_digest
+    return manifest
+
+
+def snapshot_capture_generation(
+    *,
+    git_head: str | None,
+    status_digest: str,
+    file_fingerprints: Mapping[str, str],
+) -> dict[str, Any]:
+    """Record one capture generation for a single consistency boundary."""
+    return {
+        "gitHead": git_head,
+        "statusDigest": status_digest,
+        "files": dict(file_fingerprints),
+    }
+
+
+def assert_single_capture_generation(
+    before: Mapping[str, Any], after: Mapping[str, Any]
+) -> None:
+    """Fail when the workspace mutated between two generation observations.
+
+    Reading HEAD and files at different times without a consistency boundary
+    cannot establish one snapshot: any drift must retry or block explicitly
+    rather than produce a falsely consistent capture.
+    """
+    if before.get("gitHead") != after.get("gitHead"):
+        raise ValueError(
+            "CHECKPOINT_CAPTURE_CONCURRENT_MUTATION: git HEAD changed during capture"
+        )
+    if before.get("statusDigest") != after.get("statusDigest"):
+        raise ValueError(
+            "CHECKPOINT_CAPTURE_CONCURRENT_MUTATION: git status changed during capture"
+        )
+    before_files = dict(before.get("files") or {})
+    after_files = dict(after.get("files") or {})
+    if before_files != after_files:
+        changed = sorted(
+            {*before_files, *after_files},
+            key=str,
+        )
+        drifted = [path for path in changed if before_files.get(path) != after_files.get(path)]
+        raise ValueError(
+            "CHECKPOINT_CAPTURE_CONCURRENT_MUTATION: "
+            f"workspace files changed during capture: {drifted[:10]}"
+        )
+
+
+def compute_saved_work_delta(    *,
+    baseline_entries: Sequence[Mapping[str, Any]],
+    capture_entries: Sequence[Mapping[str, Any]],
+    excluded_paths: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Generate binary-safe add/modify/delete/rename/mode deltas.
+
+    Identity is (sha256, mode, size, symlink target): bytes are never decoded,
+    so binary content round-trips. A path absent from capture merely because it
+    was excluded from capture is never inferred as deleted. Renames are
+    detected by content identity (same sha, one baseline path gone, one capture
+    path new) and reported explicitly instead of an add+delete pair.
+    """
+    excluded = set(excluded_paths or [])
+
+    def _key(entry: Mapping[str, Any]) -> str:
+        return str(entry.get("path"))
+
+    baseline = {_key(e): dict(e) for e in baseline_entries}
+    captured = {_key(e): dict(e) for e in capture_entries}
+
+    def _identity(entry: Mapping[str, Any]) -> tuple[Any, ...]:
+        return (
+            entry.get("sha256"),
+            entry.get("mode"),
+            entry.get("size"),
+            entry.get("linkTarget"),
+            entry.get("type"),
+        )
+
+    deltas: list[dict[str, Any]] = []
+    for path in sorted(set(baseline) | set(captured)):
+        if path in excluded:
+            continue
+        old = baseline.get(path)
+        new = captured.get(path)
+        if old is None and new is not None:
+            deltas.append({"path": path, "change": "added", "new": new})
+        elif old is not None and new is None:
+            deltas.append({"path": path, "change": "deleted", "old": old})
+        elif old is not None and new is not None and _identity(old) != _identity(new):
+            if old.get("mode") != new.get("mode") and old.get("sha256") == new.get("sha256"):
+                deltas.append(
+                    {"path": path, "change": "mode_changed", "old": old, "new": new}
+                )
+            else:
+                deltas.append(
+                    {"path": path, "change": "modified", "old": old, "new": new}
+                )
+
+    # Fold unambiguous content-identity add+delete pairs into renames.
+    deleted_by_sha: dict[str, list[dict[str, Any]]] = {}
+    added_by_sha: dict[str, list[dict[str, Any]]] = {}
+    for delta in deltas:
+        if delta["change"] == "deleted":
+            deleted_by_sha.setdefault(str(delta["old"].get("sha256")), []).append(delta)
+        elif delta["change"] == "added":
+            added_by_sha.setdefault(str(delta["new"].get("sha256")), []).append(delta)
+    folded: list[dict[str, Any]] = []
+    consumed: set[int] = set()
+    for delta in deltas:
+        if id(delta) in consumed or delta["change"] != "deleted":
+            continue
+        sha = str(delta["old"].get("sha256"))
+        candidates = [
+            candidate
+            for candidate in added_by_sha.get(sha, [])
+            if id(candidate) not in consumed
+        ]
+        if len(candidates) == 1 and len(deleted_by_sha.get(sha, [])) == 1:
+            added = candidates[0]
+            consumed.add(id(delta))
+            consumed.add(id(added))
+            folded.append(
+                {
+                    "path": added["path"],
+                    "change": "renamed",
+                    "oldPath": delta["path"],
+                    "old": delta["old"],
+                    "new": added["new"],
+                }
+            )
+        else:
+            folded.append(delta)
+    for delta in deltas:
+        if id(delta) not in consumed and delta["change"] != "deleted":
+            folded.append(delta)
+    folded.sort(key=lambda item: (str(item.get("path")), str(item.get("change"))))
+    return folded
+
+
+def parse_git_diff_raw_to_deltas(
+    diff_raw: str, excluded: set[str] | frozenset[str]
+) -> list[dict[str, Any]]:
+    """Parse `git diff HEAD --raw -z --find-renames` into binary-safe deltas.
+
+    The raw format carries only modes, object ids, status codes, and paths,
+    so binary content is never decoded. Export callers must pass
+    `--no-ext-diff --no-textconv` and never execute untrusted hooks, filters,
+    or helpers. Paths excluded from capture can never produce deletion (or
+    any other) claims: without observing the path, the capture cannot
+    distinguish exclusion from deletion.
+    """
+
+    tokens = diff_raw.split("\0")
+    while tokens and tokens[-1] == "":
+        tokens.pop()
+    deltas: list[dict[str, Any]] = []
+    index = 0
+    while index < len(tokens):
+        info = tokens[index]
+        index += 1
+        if not info.startswith(":"):
+            continue
+        fields = info[1:].split(" ")
+        if len(fields) != 5:
+            continue
+        old_mode, new_mode, old_sha, new_sha, status = fields
+        kind = status[:1]
+        if kind in {"R", "C"}:
+            if index + 1 >= len(tokens):
+                break
+            old_path, new_path = tokens[index], tokens[index + 1]
+            index += 2
+            if old_path in excluded or new_path in excluded:
+                continue
+            if kind == "R":
+                deltas.append(
+                    {
+                        "path": new_path,
+                        "change": "renamed",
+                        "oldPath": old_path,
+                        "oldMode": old_mode,
+                        "newMode": new_mode,
+                    }
+                )
+            else:
+                deltas.append(
+                    {
+                        "path": new_path,
+                        "change": "added",
+                        "detail": f"copied-from {old_path}",
+                        "newMode": new_mode,
+                    }
+                )
+            continue
+        if index >= len(tokens):
+            break
+        path = tokens[index]
+        index += 1
+        if path in excluded:
+            continue
+        if kind == "A":
+            deltas.append({"path": path, "change": "added", "newMode": new_mode})
+        elif kind == "D":
+            deltas.append({"path": path, "change": "deleted", "oldMode": old_mode})
+        elif kind == "U":
+            deltas.append(
+                {
+                    "path": path,
+                    "change": "modified",
+                    "detail": "unmerged-path",
+                }
+            )
+        elif old_sha == new_sha and old_mode != new_mode:
+            deltas.append(
+                {
+                    "path": path,
+                    "change": "mode_changed",
+                    "oldMode": old_mode,
+                    "newMode": new_mode,
+                }
+            )
+        else:
+            deltas.append(
+                {
+                    "path": path,
+                    "change": "modified",
+                    "oldMode": old_mode,
+                    "newMode": new_mode,
+                }
+            )
+    return deltas
+
+
+def _export_findings_in_text(text: str, location: str) -> int:
+    findings = 0
+    for pattern in _CREDENTIAL_PATTERNS:
+        findings += len(pattern.findall(text))
+    for hint in _RUNTIME_CREDENTIAL_PATH_HINTS:
+        if hint in location:
+            findings += 1
+            break
+    return findings
+
+
+def scan_saved_work_export_stream(
+    chunks: Sequence[bytes] | Any, *, export_digest: str, location: str
+) -> dict[str, Any]:
+    """Stream confidentiality/secret controls over exported bytes in chunks.
+
+    Chunk windows overlap by 256 bytes so credential-shaped content spanning
+    a chunk boundary is still detected without holding the whole export in
+    memory. Same evidence contract as :func:`scan_saved_work_export`.
+    """
+    findings = 0
+    decodable = True
+    tail = b""
+    for chunk in chunks:
+        window = tail + bytes(chunk)
+        try:
+            window.decode("utf-8")
+        except UnicodeDecodeError:
+            decodable = False
+        findings += _export_findings_in_text(
+            window.decode("utf-8", errors="ignore"), location
+        )
+        tail = window[-256:]
+    if findings:
+        return {
+            "disposition": "blocked",
+            "policyRef": SAVED_WORK_SCAN_POLICY_REF,
+            "exportDigest": export_digest,
+            "location": location,
+            "coverage": "export-bytes",
+            "limitations": [],
+            "detail": "credential-shaped content detected in exported bytes",
+        }
+    if not decodable:
+        return {
+            "disposition": "unsupported",
+            "policyRef": SAVED_WORK_SCAN_POLICY_REF,
+            "exportDigest": export_digest,
+            "location": location,
+            "coverage": "export-bytes-text-projection",
+            "limitations": [
+                "binary export is not fully inspectable as text; "
+                "no clean-scan claim is made for non-text bytes"
+            ],
+        }
+    return {
+        "disposition": "clean",
+        "policyRef": SAVED_WORK_SCAN_POLICY_REF,
+        "exportDigest": export_digest,
+        "location": location,
+        "coverage": "export-bytes",
+        "limitations": [],
+    }
+def scan_saved_work_export(
+    payload: bytes, *, export_digest: str, location: str
+) -> dict[str, Any]:
+    """Apply confidentiality/secret controls to actual exported bytes.
+
+    Scan evidence binds to the export digest with explicit coverage and
+    limitations. Unsupported binary/history inspection is reported as
+    ``unsupported`` under the scanner policy, never fabricated as clean. This
+    returns evidence only; callers decide block/restrict/quarantine through
+    existing artifact policy.
+    """
+
+    return scan_saved_work_export_stream(
+        [payload], export_digest=export_digest, location=location
+    )
+
+
+def redacted_preview_is_restorable() -> bool:
+    """State the preview/report contract explicitly: never restorable."""
+    return False
+
+
+def verify_captured_artifact_evidence(
+    *,
+    expected_digest: str,
+    expected_size_bytes: int,
+    artifact: Any,
+) -> None:
+    """Verify returned artifact evidence against the expected capture candidate.
+
+    The same request with the same immutable candidate may reuse the committed
+    result; a reused COMPLETE artifact carrying different bytes must fail (or
+    start an explicitly new attempt) rather than bind the wrong bytes to the
+    claimed manifest. Concurrent first writes, lost upload acknowledgments,
+    and reused COMPLETE artifacts therefore cannot misassociate content.
+    """
+    status = getattr(artifact, "status", None)
+    status_value = getattr(status, "value", status)
+    if status_value is not None and str(status_value).upper() != "COMPLETE":
+        raise ValueError(
+            f"SAVED_WORK_EVIDENCE_NOT_COMPLETE: artifact status is {status_value}"
+        )
+    stored_digest = getattr(artifact, "sha256", None)
+    stored_size = getattr(artifact, "size_bytes", None)
+    assert_complete_payload_matches(
+        stored_digest=str(stored_digest) if stored_digest is not None else None,
+        stored_size=int(stored_size) if stored_size is not None else None,
+        new_digest=expected_digest,
+        new_size=int(expected_size_bytes),
+    )
+
+
+def assert_complete_payload_matches(
+    *,
+    stored_digest: str | None,
+    stored_size: int | None,
+    new_digest: str,
+    new_size: int,
+) -> None:
+    """Compare a newly supplied payload to an already-COMPLETE result.
+
+    Shared by the artifact write boundary and saved-work orchestration so both
+    enforce the same retry-identity rule. ``sha256:`` prefixes are normalized
+    before comparison so content-addressed rows and bare-hex digests compare
+    by content identity.
+    """
+
+    def _normalized(value: str | None) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip().lower()
+        return text.removeprefix("sha256:")
+
+    if _normalized(stored_digest) is not None and _normalized(stored_digest) != _normalized(
+        new_digest
+    ):
+        raise ValueError(
+            "SAVED_WORK_RETRY_CONFLICT: reused COMPLETE artifact "
+            "carries a different payload digest"
+        )
+    if stored_size is not None and stored_size != new_size:
+        raise ValueError(
+            "SAVED_WORK_RETRY_CONFLICT: reused COMPLETE artifact "
+            "carries a different payload size"
+        )
+
+
+def commit_saved_work_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    required_refs_available: Mapping[str, bool],
+    preview_failures: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Verify required objects/dependencies, then commit the manifest result.
+
+    A successful upload without a committed usable manifest remains an
+    incomplete capture. Missing required objects or dependency metadata keep
+    the capture incomplete so #4016/#4017 can reconcile orphan uploads.
+    Optional preview/report failures stay separate and never fail a capture
+    whose format profile does not require them.
+    """
+    manifest = dict(manifest)
+    missing = sorted(
+        name for name, available in required_refs_available.items() if not available
+    )
+    scan_disposition = str((manifest.get("scan") or {}).get("disposition", "unknown"))
+    if scan_disposition == "blocked":
+        return {
+            "status": "incomplete",
+            "manifestDigest": manifest.get("manifestDigest"),
+            "reason": "scan-blocked",
+            "missingRequiredObjects": missing,
+            "orphanAction": "quarantine-via-artifact-policy",
+        }
+    if missing:
+        return {
+            "status": "incomplete",
+            "manifestDigest": manifest.get("manifestDigest"),
+            "reason": "missing-required-objects",
+            "missingRequiredObjects": missing,
+            "orphanAction": "reconcile-with-finalization-owner",
+        }
+    outputs = list(manifest.get("outputs") or [])
+    required_formats = set(manifest.get("requiredFormats") or [])
+    failed_required = sorted(
+        str(output.get("format"))
+        for output in outputs
+        if str(output.get("format")) in required_formats
+        and str(output.get("status")) in {"incomplete", "failed"}
+    )
+    if failed_required:
+        return {
+            "status": "incomplete",
+            "manifestDigest": manifest.get("manifestDigest"),
+            "reason": "required-format-failed",
+            "missingRequiredObjects": missing,
+            "failedRequiredFormats": failed_required,
+            "orphanAction": "reconcile-with-finalization-owner",
+        }
+    result: dict[str, Any] = {
+        "status": "committed",
+        "manifestDigest": manifest.get("manifestDigest"),
+        "reason": None,
+    }
+    if preview_failures:
+        # Optional preview/report evidence is informational only.
+        result["previewFailures"] = list(preview_failures)
+    return result

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -53,6 +53,19 @@ from moonmind.schemas.managed_checkpoint_models import (
     ManagedWorkspaceCheckpointCaptureInput,
     ManagedWorkspaceCheckpointCaptureResult,
 )
+from moonmind.schemas.saved_work_models import (
+    SAVED_WORK_CAPTURE_CONTRACT_VERSION,
+    SAVED_WORK_FORMAT_SIZE_LIMITS,
+    assert_single_capture_generation,
+    build_saved_work_manifest,
+    commit_saved_work_manifest,
+    describe_output_claim,
+    parse_git_diff_raw_to_deltas,
+    resolve_saved_work_format_profile,
+    scan_saved_work_export_stream,
+    snapshot_capture_generation,
+    verify_captured_artifact_evidence,
+)
 from moonmind.schemas.temporal_activity_models import (
     AcceptedRepositoryEvidence,
     AgentRuntimeCancelInput,
@@ -316,6 +329,27 @@ def _workspace_content_digest(entries: Sequence[Mapping[str, Any]]) -> str:
         separators=(",", ":"),
     ).encode("utf-8")
     return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _checkpoint_payload_identity(payload: bytes) -> tuple[str, int]:
+    """Return the expected (digest, size) identity for one capture candidate."""
+
+    return "sha256:" + hashlib.sha256(payload).hexdigest(), len(payload)
+
+
+def _saved_work_diff_to_deltas(
+    diff_raw: str, excluded: set[str]
+) -> list[dict[str, Any]]:
+    """Parse `git diff HEAD --raw -z --find-renames` into binary-safe deltas.
+
+    Thin adapter over the portable
+    :func:`moonmind.schemas.saved_work_models.parse_git_diff_raw_to_deltas`
+    contract so workflow code carries the adapter call while the delta
+    semantics stay in the schema layer.
+    """
+
+    return parse_git_diff_raw_to_deltas(diff_raw, excluded)
+
 
 _PROFILE_MANAGER_READY_POLL_ATTEMPTS = 60
 _PROFILE_MANAGER_READY_POLL_SECONDS = 1.0
@@ -5876,6 +5910,27 @@ class TemporalAgentRuntimeActivities:
         record: Any,
     ) -> dict[str, Any]:
         policy = model.capture_policy
+        # One stable capture generation starts here: record HEAD and the
+        # worktree status before enumeration so a writer mutating files or
+        # HEAD mid-capture is detected and retried/blocked instead of
+        # producing a falsely consistent snapshot. Capture never runs an
+        # unconditional `git add -A` and never mutates the live agent
+        # index/history to create export evidence.
+        async def _git_text(*args: str) -> str:
+            command = self._workspace_git_command(str(workspace), *args)
+            return (await _run_command(command)).stdout.strip()
+
+        async def _git_raw(*args: str) -> str:
+            command = self._workspace_git_command(str(workspace), *args)
+            return (await _run_command(command)).stdout
+
+        pre_head = await _git_text("rev-parse", "HEAD")
+        pre_status = await _git_raw(
+            "status", "--porcelain=v1", "-z", "--untracked-files=all",
+        )
+        pre_status_digest = "sha256:" + hashlib.sha256(
+            pre_status.encode()
+        ).hexdigest()
         enumerate_args = ["ls-files", "-z", "--cached"]
         if policy.include_untracked:
             enumerate_args.extend(["--others", "--exclude-standard"])
@@ -5888,13 +5943,27 @@ class TemporalAgentRuntimeActivities:
             ".git", ".codex", ".ssh", ".gnupg", "node_modules", "__pycache__",
             ".cache", ".docker", "credentials", "managed_runs", "managed_sessions",
         }
-        selected = [
-            path for path in paths
-            if Path(path).name not in excluded_names
-            and not any(part in excluded_parts for part in Path(path).parts)
-            and Path(path).parts[:2]
-            not in {(".agents", "skills"), (".gemini", "skills")}
-        ]
+        # Capture-owned temporary archives stay outside the exported tree,
+        # and runtime-issued credential paths are never exported.
+        excluded_suffixes = (".tmp", ".tar.gz", ".tgz", ".zip")
+        exclusions: list[dict[str, str]] = []
+        absent_paths: list[str] = []
+        selected: list[str] = []
+        for path in paths:
+            parts = Path(path).parts
+            if Path(path).name in excluded_names:
+                exclusions.append({"path": path, "reason": "sensitive-filename-policy"})
+                continue
+            if any(part in excluded_parts for part in parts):
+                exclusions.append({"path": path, "reason": "sensitive-path-policy"})
+                continue
+            if parts[:2] in {(".agents", "skills"), (".gemini", "skills")}:
+                exclusions.append({"path": path, "reason": "runtime-skill-overlay"})
+                continue
+            if path.lower().endswith(excluded_suffixes):
+                exclusions.append({"path": path, "reason": "temporary-archive"})
+                continue
+            selected.append(path)
         if len(selected) > policy.max_file_count:
             raise temporal_exceptions.ApplicationError(
                 "maximum file count exceeded", type="CHECKPOINT_CAPTURE_LIMIT_EXCEEDED",
@@ -5902,10 +5971,18 @@ class TemporalAgentRuntimeActivities:
             )
         entries: list[ManagedCheckpointEntry] = []
         total = 0
-        output = BytesIO()
+        fingerprints: dict[str, str] = {}
+        # Bounded spool path outside the exported workspace tree: large
+        # workspace exports stream through temp files in bounded chunks
+        # instead of allocating the entire workspace in memory. Capture
+        # secrets and these spool files never enter the exported tree. The
+        # uncompressed tar spools first so export-byte secret controls can
+        # inspect the actual exported bytes; gzip then streams from that
+        # spool with normalized metadata for deterministic identities.
+        tar_spool = tempfile.TemporaryFile(prefix="saved-work-capture-tar-")
 
-        with gzip.GzipFile(fileobj=output, mode="wb", mtime=0) as compressed, tarfile.open(
-            fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT
+        with tarfile.open(
+            fileobj=tar_spool, mode="w", format=tarfile.PAX_FORMAT
         ) as archive:
             for relative_text in selected:
                 # Archive construction is synchronous. Yield between entries so
@@ -5914,8 +5991,21 @@ class TemporalAgentRuntimeActivities:
                 await asyncio.sleep(0)
                 path = workspace / relative_text
                 if not path.exists() and not path.is_symlink():
+                    # Tracked-but-absent: baseline-anchored deletion evidence,
+                    # never silently treated as complete content.
+                    absent_paths.append(relative_text)
                     continue
-                info_stat = path.lstat()
+                try:
+                    info_stat = path.lstat()
+                except OSError as exc:
+                    raise temporal_exceptions.ApplicationError(
+                        f"unreadable path during capture: {relative_text}",
+                        type="CHECKPOINT_CAPTURE_UNREADABLE",
+                        non_retryable=True,
+                    ) from exc
+                fingerprints[relative_text] = (
+                    f"{info_stat.st_mtime_ns}:{info_stat.st_size}"
+                )
                 if stat.S_ISLNK(info_stat.st_mode):
                     target = os.readlink(path)
                     resolved = (path.parent / target).resolve()
@@ -5932,7 +6022,16 @@ class TemporalAgentRuntimeActivities:
                             "maximum per-file size exceeded",
                             type="CHECKPOINT_CAPTURE_LIMIT_EXCEEDED", non_retryable=True,
                         )
-                    digest = await asyncio.to_thread(_sha256_file, path)
+                    # Unreadable/skipped data is never treated as complete:
+                    # hashing or opening failures fail the capture explicitly.
+                    try:
+                        digest = await asyncio.to_thread(_sha256_file, path)
+                    except OSError as exc:
+                        raise temporal_exceptions.ApplicationError(
+                            f"unreadable file during capture: {relative_text}",
+                            type="CHECKPOINT_CAPTURE_UNREADABLE",
+                            non_retryable=True,
+                        ) from exc
                     payload = None
                     target = None
                     entry_type = "file"
@@ -5958,7 +6057,15 @@ class TemporalAgentRuntimeActivities:
                 tar_info.uid = tar_info.gid = tar_info.mtime = 0
                 tar_info.uname = tar_info.gname = ""
                 if entry_type == "file":
-                    with path.open("rb") as source:
+                    try:
+                        source = path.open("rb")
+                    except OSError as exc:
+                        raise temporal_exceptions.ApplicationError(
+                            f"unreadable file during capture: {relative_text}",
+                            type="CHECKPOINT_CAPTURE_UNREADABLE",
+                            non_retryable=True,
+                        ) from exc
+                    with source:
                         await asyncio.to_thread(archive.addfile, tar_info, source)
                 else:
                     archive.addfile(tar_info)
@@ -5976,29 +6083,124 @@ class TemporalAgentRuntimeActivities:
                         linkTarget=target,
                     )
                 )
-        archive_payload = output.getvalue()
-        archive_digest = "sha256:" + hashlib.sha256(archive_payload).hexdigest()
+        # Scan the actual exported tar bytes (not only manifest text) as a
+        # bounded chunk stream with overlap, so credential-shaped content
+        # spanning a chunk boundary is still detected without holding the
+        # whole export in memory. Binary/uninspectable regions stay explicit
+        # instead of a fabricated clean scan.
+        tar_spool.flush()
+        tar_spool.seek(0)
+
+        def _tar_spool_chunks() -> Any:
+            while True:
+                tar_chunk = tar_spool.read(
+                    SAVED_WORK_FORMAT_SIZE_LIMITS["max_spool_chunk_bytes"]
+                )
+                if not tar_chunk:
+                    return
+                yield tar_chunk
+
+        tar_scan = scan_saved_work_export_stream(
+            _tar_spool_chunks(),
+            export_digest="pending-tar-stream",
+            location="checkpoint.archive.tar",
+        )
+        tar_spool.seek(0)
+        gzip_spool = tempfile.TemporaryFile(prefix="saved-work-capture-gz-")
+        with gzip.GzipFile(fileobj=gzip_spool, mode="wb", mtime=0) as compressed:
+            while True:
+                tar_chunk = tar_spool.read(
+                    SAVED_WORK_FORMAT_SIZE_LIMITS["max_spool_chunk_bytes"]
+                )
+                if not tar_chunk:
+                    break
+                compressed.write(tar_chunk)
+        tar_spool.close()
+        spool = gzip_spool
+        # Flush the bounded spool, then stream the archive identity in chunks
+        # and enforce explicit size limits: oversized exports fail explicitly
+        # rather than being silently truncated or reported as no output.
+        spool.flush()
+        spool_size = os.fstat(spool.fileno()).st_size
+        if spool_size > policy.max_total_bytes:
+            spool.close()
+            raise temporal_exceptions.ApplicationError(
+                "maximum total size exceeded",
+                type="CHECKPOINT_CAPTURE_LIMIT_EXCEEDED",
+                non_retryable=True,
+            )
+        spool.seek(0)
+        archive_hasher = hashlib.sha256()
+        while True:
+            spool_chunk = spool.read(
+                SAVED_WORK_FORMAT_SIZE_LIMITS["max_spool_chunk_bytes"]
+            )
+            if not spool_chunk:
+                break
+            archive_hasher.update(spool_chunk)
+        archive_digest = "sha256:" + archive_hasher.hexdigest()
+        spool.seek(0)
+        archive_payload = spool.read()
+        spool.close()
+        if len(archive_payload) != spool_size:
+            raise temporal_exceptions.ApplicationError(
+                "capture spool changed during read",
+                type="CHECKPOINT_CAPTURE_CONCURRENT_MUTATION",
+                non_retryable=False,
+            )
+        # Close the single consistency boundary: re-read HEAD/status and
+        # re-stat captured files. Drift retries/blocks explicitly through a
+        # retryable error; the idempotency record is only written after a
+        # fully verified capture, so retries re-capture cleanly.
+        head = await _git_text("rev-parse", "HEAD")
+        branch = await _git_text("branch", "--show-current")
+        post_status = await _git_raw(
+            "status", "--porcelain=v1", "-z", "--untracked-files=all",
+        )
+        post_status_digest = "sha256:" + hashlib.sha256(
+            post_status.encode()
+        ).hexdigest()
+        generation_before = snapshot_capture_generation(
+            git_head=pre_head,
+            status_digest=pre_status_digest,
+            file_fingerprints={
+                entry.path: fingerprints[entry.path] for entry in entries
+            },
+        )
+        post_fingerprints: dict[str, str] = {}
+        for entry in entries:
+            try:
+                current_stat = (workspace / entry.path).lstat()
+            except OSError as exc:
+                raise temporal_exceptions.ApplicationError(
+                    f"captured file vanished during capture: {entry.path}",
+                    type="CHECKPOINT_CAPTURE_CONCURRENT_MUTATION",
+                    non_retryable=False,
+                ) from exc
+            post_fingerprints[entry.path] = (
+                f"{current_stat.st_mtime_ns}:{current_stat.st_size}"
+            )
+        try:
+            assert_single_capture_generation(
+                generation_before,
+                snapshot_capture_generation(
+                    git_head=head,
+                    status_digest=post_status_digest,
+                    file_fingerprints=post_fingerprints,
+                ),
+            )
+        except ValueError as exc:
+            raise temporal_exceptions.ApplicationError(
+                str(exc),
+                type="CHECKPOINT_CAPTURE_CONCURRENT_MUTATION",
+                non_retryable=False,
+            ) from exc
+        status = post_status
         archive_ref = await self._put_managed_checkpoint_artifact(
             archive_payload,
             "application/vnd.moonmind.worktree-archive",
             "checkpoint_archive",
         )
-        async def _git(*args: str) -> str:
-            command = self._workspace_git_command(str(workspace), *args)
-            return (await _run_command(command)).stdout.strip()
-        head = await _git("rev-parse", "HEAD")
-        branch = await _git("branch", "--show-current")
-        status = (
-            await _run_command(
-                self._workspace_git_command(
-                    str(workspace),
-                    "status",
-                    "--porcelain=v1",
-                    "-z",
-                    "--untracked-files=all",
-                ),
-            )
-        ).stdout
         created_at = (record.finished_at or record.started_at).isoformat()
         staged_paths = []
         records = status.split("\0")
@@ -6047,6 +6249,264 @@ class TemporalAgentRuntimeActivities:
         )
         logger.info("managed_checkpoint_capture_files files=%s", len(entries))
         logger.info("managed_checkpoint_capture_bytes bytes=%s", len(archive_payload))
+        # Bind the streamed tar-scan evidence to the final export digest.
+        # Confidentiality controls therefore cover the actual exported bytes
+        # and reachable history, not only the manifest text; unsupported
+        # binary inspection stays explicit instead of a fabricated clean
+        # scan, and a redacted preview is never a restorable source.
+        export_scan = {**tar_scan, "exportDigest": archive_digest}
+        if export_scan["disposition"] == "blocked":
+            raise temporal_exceptions.ApplicationError(
+                "checkpoint archive failed export secret scanning",
+                type="CHECKPOINT_CAPTURE_SECRET_DETECTED",
+                non_retryable=True,
+            )
+        # Binary-safe exact-baseline delta against the recorded baseline
+        # commit. Export uses `git diff --raw` with external diff drivers
+        # and textconv disabled and never `git bundle --all`; no bundle,
+        # hook, external-diff, or textconv helper is executed for export.
+        # Repo-config-driven clean/smudge filters remain owned by the
+        # source-preparation boundary (#2615); LFS pointer files are
+        # captured as their truthful worktree bytes with the baseline
+        # dependency declared. Paths excluded from capture can never
+        # produce deletion claims.
+        excluded_for_delta = {
+            exclusion["path"]
+            for exclusion in exclusions
+            if exclusion["reason"] != "absent-from-worktree"
+        }
+        baseline_paths = set(
+            filter(
+                None,
+                (
+                    await _git_raw("ls-tree", "-r", "--name-only", "-z", "HEAD")
+                ).split("\0"),
+            )
+        )
+        diff_raw = await _git_raw(
+            "diff",
+            "HEAD",
+            "--raw",
+            "-z",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--find-renames",
+        )
+        delta_changes = _saved_work_diff_to_deltas(diff_raw, excluded_for_delta)
+        entry_by_path = {entry.path: entry for entry in entries}
+        diff_covered_paths = {str(change.get("path")) for change in delta_changes}
+        for untracked_path in sorted(
+            {entry.path for entry in entries}
+            - baseline_paths
+            - excluded_for_delta
+            - diff_covered_paths
+        ):
+            delta_changes.append(
+                {
+                    "path": untracked_path,
+                    "change": "added",
+                    "new": entry_by_path[untracked_path].model_dump(
+                        by_alias=True, mode="json", exclude_none=True
+                    ),
+                }
+            )
+        delta_changes.sort(
+            key=lambda item: (str(item.get("path")), str(item.get("change")))
+        )
+        delta_payload = _json_bytes(
+            {
+                "schemaVersion": SAVED_WORK_CAPTURE_CONTRACT_VERSION,
+                "baselineCommit": head,
+                "changes": delta_changes,
+            }
+        )
+        delta_digest = "sha256:" + hashlib.sha256(delta_payload).hexdigest()
+        delta_ref = await self._put_managed_checkpoint_artifact(
+            delta_payload,
+            "application/vnd.moonmind.saved-work-delta+json;version=1",
+            "checkpoint_delta",
+        )
+        lowered_paths: dict[str, str] = {}
+        case_collisions: list[str] = []
+        for entry in entries:
+            folded = entry.path.lower()
+            first_seen = lowered_paths.setdefault(folded, entry.path)
+            if first_seen != entry.path and entry.path not in case_collisions:
+                case_collisions.append(entry.path)
+        # One compact saved-work manifest indexes the verified evidence.
+        # ACL/retention resolve through artifact ownership handles, never
+        # through editable copied policy. A redacted preview is never a
+        # restorable source; optional preview/report failure stays separate
+        # from the committed capture result.
+        format_profile = resolve_saved_work_format_profile(
+            is_git_workspace=True, requested_result="portable"
+        )
+        baseline_dependency = f"git-baseline:{head}"
+        saved_work_outputs = [
+            describe_output_claim(
+                fmt="full_snapshot",
+                status="self_contained",
+                ref=archive_ref,
+                digest=archive_digest,
+                size_bytes=len(archive_payload),
+                detail=(
+                    "worktree snapshot of captured bytes; history "
+                    "reconstruction requires the recorded baseline dependency"
+                ),
+            ),
+            describe_output_claim(
+                fmt="exact_baseline_delta",
+                status="requires_dependencies",
+                ref=delta_ref,
+                digest=delta_digest,
+                size_bytes=len(delta_payload),
+                dependencies=[baseline_dependency],
+                detail=(
+                    "binary-safe worktree-vs-baseline delta; excluded "
+                    "paths never produce deletion claims"
+                ),
+            ),
+            describe_output_claim(
+                fmt="selected_history",
+                status="inapplicable",
+                detail=(
+                    "no refs requested; selected-history bundles include "
+                    "only intended reachable refs with declared baseline, "
+                    "LFS, and submodule dependencies (never bundle --all)"
+                ),
+            ),
+        ]
+        record_status = getattr(record, "status", None)
+        quiescence_verified = record_status in {
+            "completed",
+            "failed",
+            "canceled",
+            "timed_out",
+        }
+        saved_work = build_saved_work_manifest(
+            capture_id=model.idempotency_key,
+            identity={
+                **model.identity.model_dump(by_alias=True, mode="json"),
+                "boundary": model.boundary,
+            },
+            source={
+                "kind": "managed-code-workspace",
+                "workspaceLocator": model.workspace_locator.model_dump(
+                    by_alias=True, mode="json"
+                ),
+                "baselineCommit": head,
+            },
+            content_digest=archive_digest,
+            file_manifest_digest=workspace_digest,
+            capture_policy=policy.model_dump(by_alias=True, mode="json"),
+            required_formats=format_profile["required"],
+            optional_formats=format_profile["optional"],
+            outputs=saved_work_outputs,
+            exclusions=[
+                *exclusions[:100],
+                *(
+                    [{"path": path, "reason": "absent-from-worktree"} for path in absent_paths[:100]]
+                    if absent_paths
+                    else []
+                ),
+            ],
+            scan={
+                "disposition": (
+                    export_scan["disposition"]
+                    if export_scan["disposition"] != "clean"
+                    else "clean"
+                ),
+                "manifestScan": "allow",
+                "exportScan": export_scan,
+                "redactedPreviewRestorable": False,
+            },
+            dependencies=[baseline_dependency],
+            quiescence={
+                "verified": quiescence_verified,
+                "mechanism": (
+                    "terminal-run-record with pre/post capture-generation "
+                    "match"
+                    if quiescence_verified
+                    else "pre/post capture-generation match on an active "
+                    "run record; writer fencing remains owned by the "
+                    "orchestration boundary"
+                ),
+                "generationHead": head,
+                "statusDigest": post_status_digest,
+            },
+            git={
+                "baselineCommit": head,
+                "headCommit": head,
+                "branch": branch,
+                "isDirty": bool(status),
+                "statusDigest": post_status_digest,
+                "stagedPaths": staged_paths,
+                "submodules": [],
+                "deltaRef": delta_ref,
+                "deltaDigest": delta_digest,
+                "deltaChangeCount": len(delta_changes),
+                "caseCollisions": case_collisions,
+            },
+            capture_generation=head,
+            artifact_scope="checkpoint_archive",
+            retention_ref="artifact-ownership",
+        )
+        if case_collisions:
+            saved_work.setdefault("limitations", []).append(
+                "target-platform path/case collisions present; capture does "
+                "not claim a format the restore path cannot reconstruct "
+                "(coordinated with the restore owner)"
+            )
+        saved_work_payload = _json_bytes(saved_work)
+        saved_work_digest = "sha256:" + hashlib.sha256(
+            saved_work_payload
+        ).hexdigest()
+        # Delta and manifest indexes carry paths and reasons rather than
+        # file content, but a credential-shaped filename must still not
+        # leak through artifact metadata: scan both before upload.
+        derivative_scan = scan_outbound_bundle(
+            [
+                OutboundBundleItem(
+                    location="checkpoint.delta",
+                    content=delta_payload.decode("utf-8"),
+                ),
+                OutboundBundleItem(
+                    location="checkpoint.saved-work",
+                    content=saved_work_payload.decode("utf-8"),
+                ),
+            ],
+            high_security_mode=True,
+        )
+        if not derivative_scan.allowed:
+            raise temporal_exceptions.ApplicationError(
+                "saved-work derivative metadata failed outbound secret scanning",
+                type="CHECKPOINT_CAPTURE_SECRET_DETECTED",
+                non_retryable=True,
+            )
+        saved_work_ref = await self._put_managed_checkpoint_artifact(
+            saved_work_payload,
+            "application/vnd.moonmind.saved-work-manifest+json;version=1",
+            "saved_work_manifest",
+        )
+        # Verify required objects and dependency metadata, then commit the
+        # immutable manifest/reference set. An upload without a committed
+        # usable manifest remains an incomplete capture for the
+        # finalization/retention owners to reconcile.
+        commit = commit_saved_work_manifest(
+            {**saved_work, "manifestDigest": saved_work_digest},
+            required_refs_available={
+                "checkpoint_archive": True,
+                "checkpoint_manifest": True,
+                "checkpoint_delta": True,
+                "saved_work_manifest": True,
+            },
+        )
+        if commit["status"] != "committed":
+            raise temporal_exceptions.ApplicationError(
+                f"saved-work manifest is not committable: {commit.get('reason')}",
+                type="CHECKPOINT_CAPTURE_INCOMPLETE",
+                non_retryable=True,
+            )
         compact = ManagedWorkspaceCheckpointCaptureResult(
             status="captured",
             workspace={
@@ -6060,8 +6520,10 @@ class TemporalAgentRuntimeActivities:
                 "includesIgnoredFiles": False,
             },
             sourceWorkspaceLocator=model.workspace_locator,
-            diagnosticRefs=[manifest_ref],
+            diagnosticRefs=[manifest_ref, delta_ref, saved_work_ref],
             idempotencyKey=model.idempotency_key,
+            savedWorkRef=saved_work_ref,
+            savedWorkDigest=saved_work_digest,
         )
         return compact.model_dump(by_alias=True, mode="json", exclude_none=True)
 
@@ -6076,6 +6538,17 @@ class TemporalAgentRuntimeActivities:
                 scope=artifact_kind,
                 metadata_json={"artifact_kind": artifact_kind},
             )
+        )
+        # Bind the retry to the expected capture candidate: a reused
+        # COMPLETE artifact carrying different bytes must fail (or start an
+        # explicitly new attempt) rather than bind the wrong bytes to the
+        # claimed manifest. Same request + same immutable candidate reuses
+        # the committed result.
+        digest, size = _checkpoint_payload_identity(payload)
+        verify_captured_artifact_evidence(
+            expected_digest=digest,
+            expected_size_bytes=size,
+            artifact=completed,
         )
         return _compact_artifact_ref_text(build_artifact_ref(completed))
 

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -337,6 +337,24 @@ def _checkpoint_payload_identity(payload: bytes) -> tuple[str, int]:
     return "sha256:" + hashlib.sha256(payload).hexdigest(), len(payload)
 
 
+def _saved_work_execution_link(model: Any) -> ExecutionRef:
+    """Build the owning-execution link for every saved-work artifact.
+
+    Artifacts stored without an execution link are readable only by their
+    creating principal, so the workflow owner cannot read the returned
+    ``savedWorkRef`` and the objects stay absent from execution listings.
+    Linking each saved-work object to the capture identity/namespace keeps
+    ownership resolvable through ``principal_owns_linked_execution``.
+    """
+
+    return ExecutionRef(
+        namespace=model.artifact_namespace,
+        workflow_id=model.identity.workflow_id,
+        run_id=model.identity.run_id,
+        link_type="output.checkpoint",
+    )
+
+
 def _saved_work_diff_to_deltas(
     diff_raw: str, excluded: set[str]
 ) -> list[dict[str, Any]]:
@@ -6105,6 +6123,17 @@ class TemporalAgentRuntimeActivities:
             export_digest="pending-tar-stream",
             location="checkpoint.archive.tar",
         )
+        if tar_scan["disposition"] == "blocked":
+            # Quarantine before any upload: a credential-shaped export must
+            # never be persisted as a normal COMPLETE artifact, even though
+            # capture reports failure. The digest-bound re-check below stays
+            # as defense-in-depth after the final export digest is known.
+            tar_spool.close()
+            raise temporal_exceptions.ApplicationError(
+                "checkpoint archive failed export secret scanning",
+                type="CHECKPOINT_CAPTURE_SECRET_DETECTED",
+                non_retryable=True,
+            )
         tar_spool.seek(0)
         gzip_spool = tempfile.TemporaryFile(prefix="saved-work-capture-gz-")
         with gzip.GzipFile(fileobj=gzip_spool, mode="wb", mtime=0) as compressed:
@@ -6200,6 +6229,7 @@ class TemporalAgentRuntimeActivities:
             archive_payload,
             "application/vnd.moonmind.worktree-archive",
             "checkpoint_archive",
+            link=_saved_work_execution_link(model),
         )
         created_at = (record.finished_at or record.started_at).isoformat()
         staged_paths = []
@@ -6246,6 +6276,7 @@ class TemporalAgentRuntimeActivities:
             manifest_payload,
             "application/vnd.moonmind.managed-workspace-checkpoint-manifest+json;version=1",
             "checkpoint_manifest",
+            link=_saved_work_execution_link(model),
         )
         logger.info("managed_checkpoint_capture_files files=%s", len(entries))
         logger.info("managed_checkpoint_capture_bytes bytes=%s", len(archive_payload))
@@ -6325,6 +6356,7 @@ class TemporalAgentRuntimeActivities:
             delta_payload,
             "application/vnd.moonmind.saved-work-delta+json;version=1",
             "checkpoint_delta",
+            link=_saved_work_execution_link(model),
         )
         lowered_paths: dict[str, str] = {}
         case_collisions: list[str] = []
@@ -6487,6 +6519,7 @@ class TemporalAgentRuntimeActivities:
             saved_work_payload,
             "application/vnd.moonmind.saved-work-manifest+json;version=1",
             "saved_work_manifest",
+            link=_saved_work_execution_link(model),
         )
         # Verify required objects and dependency metadata, then commit the
         # immutable manifest/reference set. An upload without a committed
@@ -6528,7 +6561,11 @@ class TemporalAgentRuntimeActivities:
         return compact.model_dump(by_alias=True, mode="json", exclude_none=True)
 
     async def _put_managed_checkpoint_artifact(
-        self, payload: bytes, content_type: str, artifact_kind: str
+        self,
+        payload: bytes,
+        content_type: str,
+        artifact_kind: str,
+        link: ExecutionRef | dict[str, Any] | None = None,
     ) -> str:
         completed, _reused = (
             await self._artifact_service.put_content_addressed_payload_complete(
@@ -6536,6 +6573,7 @@ class TemporalAgentRuntimeActivities:
                 payload=payload,
                 content_type=content_type,
                 scope=artifact_kind,
+                link=link,
                 metadata_json={"artifact_kind": artifact_kind},
             )
         )

--- a/moonmind/workflows/temporal/artifacts.py
+++ b/moonmind/workflows/temporal/artifacts.py
@@ -33,6 +33,9 @@ from api_service.db import models as db_models
 from moonmind.config.settings import settings
 from moonmind.security.auth_modes_4120 import is_disabled_local_mode
 from moonmind.core.artifacts import assert_model_agnostic_metadata
+from moonmind.schemas.saved_work_models import (
+    assert_complete_payload_matches as _assert_saved_work_complete_matches,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1745,6 +1748,22 @@ class TemporalArtifactService:
         if artifact.status is db_models.TemporalArtifactStatus.DELETED:
             raise TemporalArtifactStateError("artifact is deleted")
         if artifact.status is db_models.TemporalArtifactStatus.COMPLETE:
+            # A reused COMPLETE artifact is only proof for the current capture
+            # when the newly supplied payload matches the stored result.
+            # Same request + same immutable candidate may reuse it; a
+            # conflicting candidate must fail (or start an explicitly new
+            # attempt) rather than bind different bytes to one claimed
+            # manifest (#4015 impl-05).
+            digest, actual_size = self._compute_digest_and_size(payload)
+            try:
+                _assert_saved_work_complete_matches(
+                    stored_digest=artifact.sha256,
+                    stored_size=artifact.size_bytes,
+                    new_digest=digest,
+                    new_size=actual_size,
+                )
+            except ValueError as exc:
+                raise TemporalArtifactStateError(str(exc)) from exc
             return artifact
 
         if artifact.upload_mode is db_models.TemporalArtifactUploadMode.MULTIPART:
@@ -1846,6 +1865,16 @@ class TemporalArtifactService:
                 content_type=content_type,
             )
         if artifact.status is db_models.TemporalArtifactStatus.COMPLETE:
+            digest, actual_size = self._compute_digest_and_size(payload)
+            try:
+                _assert_saved_work_complete_matches(
+                    stored_digest=artifact.sha256,
+                    stored_size=artifact.size_bytes,
+                    new_digest=digest,
+                    new_size=actual_size,
+                )
+            except ValueError as exc:
+                raise TemporalArtifactStateError(str(exc)) from exc
             return artifact
         if artifact.status is db_models.TemporalArtifactStatus.DELETED:
             raise TemporalArtifactStateError("artifact is deleted")
@@ -1944,11 +1973,31 @@ class TemporalArtifactService:
         artifact_id: str,
         principal: str,
         parts: list[dict[str, Any]] | None = None,
+        expected_sha256: str | None = None,
+        expected_size_bytes: int | None = None,
     ) -> db_models.TemporalArtifact:
         artifact = await self._repository.get_artifact(artifact_id)
         self._assert_mutation_access(artifact, principal=principal)
 
         if artifact.status is db_models.TemporalArtifactStatus.COMPLETE:
+            # Idempotent completion without new bytes reuses the stored
+            # result. When the caller names the candidate it expects, verify
+            # it so a reused COMPLETE artifact cannot bind different bytes
+            # to the caller's manifest (#4015 impl-05).
+            if expected_sha256 is not None or expected_size_bytes is not None:
+                try:
+                    _assert_saved_work_complete_matches(
+                        stored_digest=artifact.sha256,
+                        stored_size=artifact.size_bytes,
+                        new_digest=expected_sha256 or artifact.sha256 or "",
+                        new_size=(
+                            expected_size_bytes
+                            if expected_size_bytes is not None
+                            else artifact.size_bytes or 0
+                        ),
+                    )
+                except ValueError as exc:
+                    raise TemporalArtifactStateError(str(exc)) from exc
             return artifact
         if artifact.status is db_models.TemporalArtifactStatus.DELETED:
             raise TemporalArtifactStateError("artifact is deleted")

--- a/tests/integration/reliability/test_checkpoint_cold_resume.py
+++ b/tests/integration/reliability/test_checkpoint_cold_resume.py
@@ -94,7 +94,9 @@ async def test_managed_codex_checkpoint_cold_resume_uses_only_durable_state(
         run_store=run_store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, content_type: str, _kind: str, link: object = None
+    ) -> str:
         return artifact_store.put_bytes(payload, content_type=content_type).artifact_ref
 
     activities._put_managed_checkpoint_artifact = put

--- a/tests/integration/reliability/test_escaped_failure_journeys.py
+++ b/tests/integration/reliability/test_escaped_failure_journeys.py
@@ -5746,7 +5746,9 @@ async def test_codex_session_record_uses_step_workflow_checkpoint_authority(
         client_adapter=object(),
     )
 
-    async def put(payload: bytes, _content_type: str, kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, kind: str, link: object = None
+    ) -> str:
         return f"artifact://{kind}/{hashlib.sha256(payload).hexdigest()}"
 
     activities._put_managed_checkpoint_artifact = put
@@ -5942,7 +5944,9 @@ async def test_retry_before_execution_captures_terminal_prior_workspace(
         client_adapter=object(),
     )
 
-    async def put(payload: bytes, _content_type: str, kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, kind: str, link: object = None
+    ) -> str:
         return f"artifact://{kind}/{hashlib.sha256(payload).hexdigest()}"
 
     activities._put_managed_checkpoint_artifact = put
@@ -6201,7 +6205,9 @@ async def test_checkpoint_capture_heartbeat_backpressure_replay(
         run_store=run_store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, kind: str, link: object = None
+    ) -> str:
         return f"artifact://{kind}/{hashlib.sha256(payload).hexdigest()}"
 
     activities._put_managed_checkpoint_artifact = put

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -132,7 +132,9 @@ async def test_managed_capture_trusts_the_resolved_workspace_for_every_git_comma
         run_store=object(), artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
     activities._put_managed_checkpoint_artifact = put
@@ -203,7 +205,9 @@ async def test_managed_capture_is_binary_safe_and_idempotent(tmp_path) -> None:
     )
     artifacts: dict[str, bytes] = {}
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         ref = "artifact://" + hashlib.sha256(payload).hexdigest()
         artifacts[ref] = payload
         return ref
@@ -299,7 +303,9 @@ async def test_managed_capture_coalesces_temporal_heartbeat_backpressure(
         run_store=store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         await asyncio.sleep(0.01)
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
@@ -362,7 +368,9 @@ async def test_managed_capture_heartbeats_during_slow_archive_file(
         run_store=store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
     original_addfile = tarfile.TarFile.addfile
@@ -432,7 +440,9 @@ async def test_managed_capture_archive_digest_is_deterministic(tmp_path) -> None
         run_store=store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
     activities._put_managed_checkpoint_artifact = put
@@ -501,7 +511,9 @@ async def test_managed_capture_skips_deleted_sensitive_and_gitlink_paths(tmp_pat
     )
     artifacts: dict[str, bytes] = {}
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         ref = "artifact://" + hashlib.sha256(payload).hexdigest()
         artifacts[ref] = payload
         return ref
@@ -558,7 +570,9 @@ async def test_managed_capture_accepts_session_record_bound_to_parent_workflow(
         run_store=store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
     activities._put_managed_checkpoint_artifact = put
@@ -621,7 +635,9 @@ async def test_managed_capture_accepts_cross_step_workflow_session_baseline(
         run_store=store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
     activities._put_managed_checkpoint_artifact = put
@@ -688,7 +704,9 @@ async def test_managed_capture_accepts_terminal_prior_execution_as_retry_baselin
         run_store=store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
     activities._put_managed_checkpoint_artifact = put
@@ -750,7 +768,9 @@ async def test_managed_capture_accepts_terminal_verifier_as_remediation_baseline
         run_store=store, artifact_service=object(), client_adapter=object()
     )
 
-    async def put(payload: bytes, _content_type: str, _kind: str) -> str:
+    async def put(
+        payload: bytes, _content_type: str, _kind: str, link: object = None
+    ) -> str:
         return "artifact://" + hashlib.sha256(payload).hexdigest()
 
     activities._put_managed_checkpoint_artifact = put

--- a/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
+++ b/tests/unit/workflows/temporal/test_managed_checkpoint_capture.py
@@ -121,6 +121,10 @@ async def test_managed_capture_trusts_the_resolved_workspace_for_every_git_comma
             return SimpleNamespace(stdout="main\n")
         if operation[0] == "status":
             return SimpleNamespace(stdout="")
+        if operation[:3] == ["ls-tree", "-r", "--name-only"]:
+            return SimpleNamespace(stdout="")
+        if operation[0] == "diff":
+            return SimpleNamespace(stdout="")
         raise AssertionError(f"unexpected git command: {operation}")
 
     monkeypatch.setattr(activity_runtime_module, "_run_command", run_git)
@@ -148,8 +152,25 @@ async def test_managed_capture_trusts_the_resolved_workspace_for_every_git_comma
     )
 
     assert result["workspace"]["archiveRef"].startswith("artifact://")
-    assert len(commands) == 4
+    assert result["savedWorkRef"].startswith("artifact://")
+    assert result["savedWorkDigest"].startswith("sha256:")
+    # Pre/post quiescence reads plus baseline/delta reads all use the same
+    # trusted workspace prefix; export never shells out to bundle, hooks,
+    # or external helpers.
+    assert len(commands) >= 8
     assert all(command[: len(expected_prefix)] == expected_prefix for command in commands)
+    operations = [command[len(expected_prefix) :][0] for command in commands]
+    assert "ls-tree" in operations
+    diff_commands = [
+        command[len(expected_prefix) :]
+        for command in commands
+        if command[len(expected_prefix) :][0] == "diff"
+    ]
+    assert diff_commands
+    for diff_command in diff_commands:
+        assert "--no-ext-diff" in diff_command
+        assert "--no-textconv" in diff_command
+    assert not any("bundle" in command for command in commands)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_saved_work_capture.py
+++ b/tests/unit/workflows/temporal/test_saved_work_capture.py
@@ -264,6 +264,10 @@ def test_parse_git_diff_raw_reports_rename_and_filters_exclusions(tmp_path) -> N
     _commit_all(repo)
     (repo / "a.txt").rename(repo / "renamed.txt")
     (repo / "gone.txt").unlink()
+    # Stage the rename so `git diff HEAD` surfaces it: an unstaged rename
+    # is a tracked deletion plus an untracked path, and `git diff HEAD`
+    # never reports untracked paths, so rename detection cannot run.
+    _git(repo, "add", "-A")
     raw = _git(
         repo,
         "diff",
@@ -539,6 +543,13 @@ async def test_put_managed_artifact_verifies_reused_evidence(tmp_path) -> None:
         tmp_path, {"tracked.txt": "evidence\n"}
     )
     payload = b"capture candidate"
+    # _capture_harness stubs _put_managed_checkpoint_artifact with an
+    # instance attribute; remove the stub so this test exercises the real
+    # retry-binding path (artifact-service reuse + evidence verification).
+    try:
+        del activities._put_managed_checkpoint_artifact
+    except AttributeError:
+        pass
 
     class ReusingService:
         async def put_content_addressed_payload_complete(

--- a/tests/unit/workflows/temporal/test_saved_work_capture.py
+++ b/tests/unit/workflows/temporal/test_saved_work_capture.py
@@ -137,13 +137,18 @@ def _capture_harness(tmp_path, files: dict[str, bytes | str]):
         run_store=store, artifact_service=object(), client_adapter=object()
     )
     stored: dict[str, tuple[bytes, str, str]] = {}
+    put_links: list[object] = []
 
-    async def put(payload: bytes, content_type: str, kind: str) -> str:
+    async def put(
+        payload: bytes, content_type: str, kind: str, link: object = None
+    ) -> str:
         ref = "artifact://" + hashlib.sha256(payload).hexdigest()
         stored[kind] = (payload, content_type, ref)
+        put_links.append(link)
         return ref
 
     activities._put_managed_checkpoint_artifact = put
+    activities.captured_put_links = put_links
     digest = resolve_runtime_execution_capabilities("codex_cli").capability_digest
     return repo, activities, stored, digest
 
@@ -315,6 +320,41 @@ def test_export_scan_binds_digest_and_reports_limits_explicitly() -> None:
     assert spanning["disposition"] == "blocked"
     # A redacted preview is never a byte-identical restorable source.
     assert redacted_preview_is_restorable() is False
+
+
+def test_export_scan_ignores_benign_code_and_redacted_sentinels() -> None:
+    for benign in (
+        b"token = str(explicit_token)\n",
+        b"password: [REDACTED]\n",
+        b"password: '[REDACTED]'\n",
+    ):
+        assert (
+            scan_saved_work_export(
+                benign, export_digest="sha256:abc", location="checkpoint.archive"
+            )["disposition"]
+            == "clean"
+        )
+    # Real credential values still block, including quoted secrets.
+    assert (
+        scan_saved_work_export(
+            b"password = \"hunter2-hunter2\"",
+            export_digest="sha256:abc",
+            location="checkpoint.archive",
+        )["disposition"]
+        == "blocked"
+    )
+
+
+def test_export_scan_detects_secrets_spanning_wide_chunk_boundaries() -> None:
+    key = b"-----BEGIN RSA PRIVATE KEY-----\n" + b"A" * 3000 + b"\n-----END RSA PRIVATE KEY-----"
+    first, second = key[:1500], key[1500:]
+    assert len(first) > 256  # beyond the old overlap, inside the new one
+    assert (
+        scan_saved_work_export_stream(
+            [first, second], export_digest="sha256:abc", location="c.a"
+        )["disposition"]
+        == "blocked"
+    )
 
 
 def test_commit_requires_manifest_and_keeps_preview_failures_separate() -> None:
@@ -535,6 +575,27 @@ async def test_capture_blocks_secret_bearing_exports(tmp_path) -> None:
         await activities.agent_runtime_capture_workspace_checkpoint(
             _request(digest=digest)
         )
+
+
+@pytest.mark.asyncio
+async def test_capture_links_saved_work_artifacts_to_owning_execution(
+    tmp_path,
+) -> None:
+    _repo, activities, _stored, digest = _capture_harness(
+        tmp_path, {"tracked.txt": "evidence\n"}
+    )
+    result = await activities.agent_runtime_capture_workspace_checkpoint(
+        _request(digest=digest)
+    )
+    assert result["status"] == "captured"
+    # Archive, manifest, delta, and saved-work uploads each carry the
+    # capture identity/namespace so the workflow owner keeps read access.
+    assert len(activities.captured_put_links) == 4
+    for link in activities.captured_put_links:
+        assert link.namespace == "step-checkpoints/implement"
+        assert link.workflow_id == "wf-1"
+        assert link.run_id == "run-1"
+        assert link.link_type == "output.checkpoint"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/test_saved_work_capture.py
+++ b/tests/unit/workflows/temporal/test_saved_work_capture.py
@@ -1,0 +1,582 @@
+"""Saved-work capture contracts for MoonLadderStudios/MoonMind#4015.
+
+Covers the plan-slice-4 deliverables against the agreed
+artifact/checkpoint/format contracts: the compact saved-work manifest,
+format-profile portability claims, the single quiescent capture generation,
+deterministic bounded identities, retry-to-content binding, binary-safe
+deltas/selected-history rules, export-byte secret controls, and the immutable
+manifest-commit step.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.schemas.managed_checkpoint_models import (
+    ManagedWorkspaceCheckpointCaptureInput,
+    ManagedWorkspaceCheckpointCaptureResult,
+)
+from moonmind.schemas.saved_work_models import (
+    SAVED_WORK_MANIFEST_SCHEMA_VERSION,
+    assert_complete_payload_matches,
+    assert_single_capture_generation,
+    build_saved_work_manifest,
+    commit_saved_work_manifest,
+    compute_saved_work_delta,
+    describe_output_claim,
+    parse_git_diff_raw_to_deltas,
+    redacted_preview_is_restorable,
+    resolve_saved_work_format_profile,
+    scan_saved_work_export,
+    scan_saved_work_export_stream,
+    snapshot_capture_generation,
+    thin_bundle_is_portable,
+    verify_captured_artifact_evidence,
+)
+from moonmind.workflows.executions.runtime_capabilities import (
+    resolve_runtime_execution_capabilities,
+)
+from moonmind.workflows.temporal import activity_runtime as activity_runtime_module
+from moonmind.workflows.temporal.activity_runtime import TemporalAgentRuntimeActivities
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+
+def _request(*, digest: str, key: str = "saved-work-1:capture") -> dict[str, object]:
+    return {
+        "schemaVersion": "v1",
+        "identity": {
+            "workflowId": "wf-1",
+            "runId": "run-1",
+            "logicalStepId": "implement",
+            "executionOrdinal": 1,
+        },
+        "boundary": "after_execution",
+        "checkpointKind": "worktree_archive",
+        "workspaceLocator": {
+            "kind": "managed_runtime",
+            "runtimeId": "codex_cli",
+            "agentRunId": "agent-run-1",
+            "relativePath": "repo",
+        },
+        "expectedRuntimeId": "codex_cli",
+        "capabilitySetVersion": "runtime-execution-capabilities-v1",
+        "capabilityDigest": digest,
+        "artifactNamespace": "step-checkpoints/implement",
+        "idempotencyKey": key,
+        "capturePolicy": {
+            "includeTracked": True,
+            "includeUntracked": True,
+            "includeIgnored": False,
+            "redactionProfile": "managed-code-workspace-v1",
+        },
+    }
+
+
+def _git(repo, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _commit_all(repo, message: str = "base") -> None:
+    _git(
+        repo,
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "-qm",
+        message,
+    )
+
+
+def _capture_harness(tmp_path, files: dict[str, bytes | str]):
+    """Create a committed repo, run record, and stubbed capture activities."""
+    repo = tmp_path / "agent-run-1" / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    for name, content in files.items():
+        target = repo / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(content)
+    _git(repo, "add", "-A")
+    _commit_all(repo)
+    now = datetime.now(UTC)
+    store = ManagedRunStore(tmp_path / "managed_runs")
+    store.save(
+        ManagedRunRecord(
+            runId="agent-run-1",
+            workflowId="wf-1",
+            agentId="codex_cli",
+            ownerRunId="run-1",
+            logicalStepId="implement",
+            executionOrdinal=1,
+            runtimeId="codex_cli",
+            status="completed",
+            startedAt=now,
+            finishedAt=now,
+            workspacePath=str(repo),
+        )
+    )
+    activities = TemporalAgentRuntimeActivities(
+        run_store=store, artifact_service=object(), client_adapter=object()
+    )
+    stored: dict[str, tuple[bytes, str, str]] = {}
+
+    async def put(payload: bytes, content_type: str, kind: str) -> str:
+        ref = "artifact://" + hashlib.sha256(payload).hexdigest()
+        stored[kind] = (payload, content_type, ref)
+        return ref
+
+    activities._put_managed_checkpoint_artifact = put
+    digest = resolve_runtime_execution_capabilities("codex_cli").capability_digest
+    return repo, activities, stored, digest
+
+
+def test_saved_work_manifest_records_provenance_without_copied_policy() -> None:
+    manifest = build_saved_work_manifest(
+        capture_id="capture-1",
+        identity={"workflowId": "wf-1", "boundary": "after_execution"},
+        source={"kind": "managed-code-workspace", "baselineCommit": "abc"},
+        content_digest="sha256:" + "a" * 64,
+        file_manifest_digest="sha256:" + "b" * 64,
+        capture_policy={"includeUntracked": True},
+        required_formats=["full_snapshot"],
+        optional_formats=["exact_baseline_delta"],
+        outputs=[
+            describe_output_claim(
+                fmt="full_snapshot",
+                status="self_contained",
+                ref="artifact://x",
+                digest="sha256:" + "a" * 64,
+                size_bytes=10,
+            )
+        ],
+        exclusions=[{"path": ".env", "reason": "sensitive-filename-policy"}],
+        scan={"disposition": "clean"},
+        dependencies=["git-baseline:abc"],
+    )
+    assert manifest["schemaVersion"] == SAVED_WORK_MANIFEST_SCHEMA_VERSION
+    assert manifest["manifestDigest"].startswith("sha256:")
+    # ACL/retention resolve through ownership, never editable copied policy.
+    assert "retentionPolicy" not in manifest
+    assert "acl" not in manifest
+    with pytest.raises(ValueError, match="dependencies"):
+        describe_output_claim(fmt="exact_baseline_delta", status="requires_dependencies")
+
+
+def test_format_profile_never_synthesizes_git_for_report_only() -> None:
+    report = resolve_saved_work_format_profile(
+        is_git_workspace=False, requested_result="report"
+    )
+    assert report["required"] == ["report_only"]
+    assert "commit" not in json.dumps(report)
+    portable = resolve_saved_work_format_profile(
+        is_git_workspace=True, requested_result="portable"
+    )
+    assert portable["required"] == ["full_snapshot"]
+    assert "exact_baseline_delta" in portable["optional"]
+    # A thin bundle without baseline objects is not portable merely
+    # because its download succeeded.
+    assert thin_bundle_is_portable(has_baseline_objects=False) is False
+    assert thin_bundle_is_portable(has_baseline_objects=True) is True
+
+
+def test_single_capture_generation_rejects_mid_capture_mutation() -> None:
+    before = snapshot_capture_generation(
+        git_head="abc",
+        status_digest="sha256:x",
+        file_fingerprints={"a.txt": "1:10"},
+    )
+    assert_single_capture_generation(before, dict(before))
+    with pytest.raises(ValueError, match="CONCURRENT_MUTATION"):
+        assert_single_capture_generation(
+            before, {**before, "gitHead": "def"}
+        )
+    with pytest.raises(ValueError, match="CONCURRENT_MUTATION"):
+        assert_single_capture_generation(
+            before,
+            snapshot_capture_generation(
+                git_head="abc",
+                status_digest="sha256:x",
+                file_fingerprints={"a.txt": "2:10"},
+            ),
+        )
+
+
+def test_compute_saved_work_delta_is_binary_safe_and_honest() -> None:
+    baseline = [
+        {"path": "kept.txt", "type": "file", "mode": "100644", "size": 4, "sha256": "s1"},
+        {"path": "gone.txt", "type": "file", "mode": "100644", "size": 4, "sha256": "s2"},
+        {"path": "run.sh", "type": "file", "mode": "100644", "size": 4, "sha256": "s3"},
+        {"path": "old.txt", "type": "file", "mode": "100644", "size": 4, "sha256": "s4"},
+    ]
+    captured = [
+        {"path": "kept.txt", "type": "file", "mode": "100644", "size": 4, "sha256": "s1"},
+        # Binary content changes identity without decoding.
+        {"path": "run.sh", "type": "file", "mode": "100755", "size": 4, "sha256": "s3"},
+        {"path": "new.txt", "type": "file", "mode": "100644", "size": 4, "sha256": "s4"},
+    ]
+    deltas = compute_saved_work_delta(
+        baseline_entries=baseline, capture_entries=captured
+    )
+    by_path = {delta["path"]: delta["change"] for delta in deltas}
+    assert by_path["gone.txt"] == "deleted"
+    assert by_path["run.sh"] == "mode_changed"
+    assert by_path["new.txt"] == "renamed"
+    # Exclusion is never inferred as deletion.
+    assert (
+        compute_saved_work_delta(
+            baseline_entries=baseline,
+            capture_entries=captured,
+            excluded_paths=["gone.txt"],
+        )
+        == [
+            delta
+            for delta in deltas
+            if delta["path"] != "gone.txt"
+        ]
+    )
+
+
+def test_parse_git_diff_raw_reports_rename_and_filters_exclusions(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "a.txt").write_text("hello\n")
+    (repo / "gone.txt").write_text("gone\n")
+    _git(repo, "add", "-A")
+    _commit_all(repo)
+    (repo / "a.txt").rename(repo / "renamed.txt")
+    (repo / "gone.txt").unlink()
+    raw = _git(
+        repo,
+        "diff",
+        "HEAD",
+        "--raw",
+        "-z",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--find-renames",
+    )
+    deltas = parse_git_diff_raw_to_deltas(raw, set())
+    by_path = {delta["path"]: delta for delta in deltas}
+    assert by_path["renamed.txt"]["change"] == "renamed"
+    assert by_path["renamed.txt"]["oldPath"] == "a.txt"
+    assert by_path["gone.txt"]["change"] == "deleted"
+    assert parse_git_diff_raw_to_deltas(raw, {"gone.txt", "a.txt", "renamed.txt"}) == []
+
+
+def test_export_scan_binds_digest_and_reports_limits_explicitly() -> None:
+    clean = scan_saved_work_export(
+        b"hello world", export_digest="sha256:abc", location="checkpoint.archive"
+    )
+    assert clean["disposition"] == "clean"
+    assert clean["exportDigest"] == "sha256:abc"
+    blocked = scan_saved_work_export(
+        b"api_key = supersecretvalue123",
+        export_digest="sha256:abc",
+        location="checkpoint.archive",
+    )
+    assert blocked["disposition"] == "blocked"
+    assert blocked["exportDigest"] == "sha256:abc"
+    binary = scan_saved_work_export(
+        b"\x00\xff\x01\x02binary",
+        export_digest="sha256:abc",
+        location="checkpoint.archive",
+    )
+    assert binary["disposition"] == "unsupported"
+    assert binary["limitations"]
+    # A chunk-spanning secret is still detected without full buffering.
+    spanning = scan_saved_work_export_stream(
+        [b"api_key = super", b"secretvalue123"],
+        export_digest="sha256:abc",
+        location="checkpoint.archive",
+    )
+    assert spanning["disposition"] == "blocked"
+    # A redacted preview is never a byte-identical restorable source.
+    assert redacted_preview_is_restorable() is False
+
+
+def test_commit_requires_manifest_and_keeps_preview_failures_separate() -> None:
+    manifest = build_saved_work_manifest(
+        capture_id="capture-1",
+        identity={"workflowId": "wf-1"},
+        source={"kind": "managed-code-workspace"},
+        content_digest="sha256:" + "a" * 64,
+        file_manifest_digest="sha256:" + "b" * 64,
+        capture_policy={},
+        required_formats=["full_snapshot"],
+        outputs=[
+            describe_output_claim(
+                fmt="full_snapshot",
+                status="self_contained",
+                ref="artifact://x",
+                digest="sha256:" + "a" * 64,
+                size_bytes=1,
+            )
+        ],
+    )
+    committed = commit_saved_work_manifest(
+        manifest,
+        required_refs_available={"checkpoint_archive": True},
+        preview_failures=["preview-render-timeout"],
+    )
+    assert committed["status"] == "committed"
+    assert committed["previewFailures"] == ["preview-render-timeout"]
+    assert (
+        commit_saved_work_manifest(
+            manifest, required_refs_available={"checkpoint_archive": False}
+        )["status"]
+        == "incomplete"
+    )
+    assert (
+        commit_saved_work_manifest(
+            {**manifest, "scan": {"disposition": "blocked"}},
+            required_refs_available={"checkpoint_archive": True},
+        )["status"]
+        == "incomplete"
+    )
+    failed_required = build_saved_work_manifest(
+        capture_id="capture-1",
+        identity={"workflowId": "wf-1"},
+        source={"kind": "managed-code-workspace"},
+        content_digest="sha256:" + "a" * 64,
+        file_manifest_digest="sha256:" + "b" * 64,
+        capture_policy={},
+        required_formats=["full_snapshot"],
+        outputs=[describe_output_claim(fmt="full_snapshot", status="failed")],
+    )
+    assert (
+        commit_saved_work_manifest(
+            failed_required, required_refs_available={}
+        )["status"]
+        == "incomplete"
+    )
+
+
+def test_retry_identity_rejects_conflicting_reused_complete() -> None:
+    assert_complete_payload_matches(
+        stored_digest="sha256:aa", stored_size=3, new_digest="aa", new_size=3
+    )
+    with pytest.raises(ValueError, match="RETRY_CONFLICT"):
+        assert_complete_payload_matches(
+            stored_digest="sha256:aa", stored_size=3, new_digest="sha256:bb", new_size=3
+        )
+    with pytest.raises(ValueError, match="RETRY_CONFLICT"):
+        assert_complete_payload_matches(
+            stored_digest="sha256:aa", stored_size=3, new_digest="sha256:aa", new_size=4
+        )
+    verify_captured_artifact_evidence(
+        expected_digest="sha256:aa",
+        expected_size_bytes=3,
+        artifact=SimpleNamespace(sha256="aa", size_bytes=3),
+    )
+    with pytest.raises(ValueError, match="NOT_COMPLETE"):
+        verify_captured_artifact_evidence(
+            expected_digest="sha256:aa",
+            expected_size_bytes=3,
+            artifact=SimpleNamespace(
+                status=SimpleNamespace(value="PENDING"),
+                sha256="aa",
+                size_bytes=3,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_capture_commits_saved_work_with_truthful_outputs(tmp_path) -> None:
+    repo, activities, stored, digest = _capture_harness(
+        tmp_path, {"tracked.txt": "checkpoint evidence\n"}
+    )
+    result = await activities.agent_runtime_capture_workspace_checkpoint(
+        _request(digest=digest)
+    )
+    assert result["status"] == "captured"
+    assert result["savedWorkRef"].startswith("artifact://")
+    assert result["savedWorkDigest"].startswith("sha256:")
+    saved_payload, _, _ = stored["saved_work_manifest"]
+    saved_work = json.loads(saved_payload.decode("utf-8"))
+    assert saved_work["captureId"] == "saved-work-1:capture"
+    assert saved_work["contentDigest"] == result["workspace"]["archiveDigest"]
+    outputs = {output["format"]: output for output in saved_work["outputs"]}
+    assert outputs["full_snapshot"]["status"] == "self_contained"
+    assert outputs["exact_baseline_delta"]["status"] == "requires_dependencies"
+    assert outputs["exact_baseline_delta"]["dependencies"] == [
+        f"git-baseline:{result['workspace']['baseCommit']}"
+    ]
+    assert outputs["selected_history"]["status"] == "inapplicable"
+    assert saved_work["scan"]["exportScan"]["exportDigest"] == (
+        result["workspace"]["archiveDigest"]
+    )
+    assert "retentionPolicy" not in saved_work
+    delta_payload, _, _ = stored["checkpoint_delta"]
+    assert json.loads(delta_payload.decode("utf-8"))["baselineCommit"] == (
+        result["workspace"]["baseCommit"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_capture_delta_reports_rename_mode_delete_against_baseline(tmp_path) -> None:
+    repo, activities, stored, digest = _capture_harness(
+        tmp_path, {"a.txt": "hello\n", "gone.txt": "gone\n", "run.sh": "#!/bin/sh\n"}
+    )
+    (repo / "a.txt").rename(repo / "renamed.txt")
+    (repo / "gone.txt").unlink()
+    (repo / "run.sh").chmod(0o755)
+    (repo / "added.txt").write_text("new\n")
+    _git(repo, "add", "-A")
+    result = await activities.agent_runtime_capture_workspace_checkpoint(
+        _request(digest=digest)
+    )
+    assert result["status"] == "captured"
+    delta_payload, _, _ = stored["checkpoint_delta"]
+    changes = {
+        change["path"]: change["change"]
+        for change in json.loads(delta_payload.decode("utf-8"))["changes"]
+    }
+    assert changes["renamed.txt"] == "renamed"
+    assert changes["gone.txt"] == "deleted"
+    assert changes["run.sh"] in {"modified", "mode_changed"}
+    assert changes["added.txt"] == "added"
+
+
+@pytest.mark.asyncio
+async def test_capture_records_exclusions_without_claiming_them(tmp_path) -> None:
+    repo, activities, stored, digest = _capture_harness(
+        tmp_path, {"kept.txt": "kept\n"}
+    )
+    (repo / ".env").write_text("token = nope\n")
+    _git(repo, "add", "-A")
+    result = await activities.agent_runtime_capture_workspace_checkpoint(
+        _request(digest=digest)
+    )
+    assert result["status"] == "captured"
+    saved_work = json.loads(stored["saved_work_manifest"][0].decode("utf-8"))
+    excluded = {entry["path"] for entry in saved_work["exclusions"]}
+    assert ".env" in excluded
+    delta_payload, _, _ = stored["checkpoint_delta"]
+    assert ".env" not in {
+        change["path"]
+        for change in json.loads(delta_payload.decode("utf-8"))["changes"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_capture_detects_mid_capture_head_mutation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _repo, activities, _stored, digest = _capture_harness(
+        tmp_path, {"tracked.txt": "evidence\n"}
+    )
+    calls = {"rev_parse": 0}
+    original_run = activity_runtime_module._run_command
+
+    async def flaky_run(command, **kwargs):
+        result = await original_run(command, **kwargs)
+        operation = [str(part) for part in command]
+        if "rev-parse" in operation:
+            calls["rev_parse"] += 1
+            if calls["rev_parse"] > 1:
+                return SimpleNamespace(stdout="mutated-head\n")
+        return result
+
+    monkeypatch.setattr(activity_runtime_module, "_run_command", flaky_run)
+    with pytest.raises(Exception, match="CONCURRENT_MUTATION"):
+        await activities.agent_runtime_capture_workspace_checkpoint(
+            _request(digest=digest)
+        )
+
+
+@pytest.mark.asyncio
+async def test_capture_fails_explicitly_on_unreadable_files(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _repo, activities, _stored, digest = _capture_harness(
+        tmp_path, {"tracked.txt": "evidence\n"}
+    )
+
+    monkeypatch.setattr(
+        activity_runtime_module, "_sha256_file", lambda path: (_ for _ in ()).throw(
+            PermissionError("denied")
+        ),
+    )
+    with pytest.raises(Exception, match="unreadable file during capture"):
+        await activities.agent_runtime_capture_workspace_checkpoint(
+            _request(digest=digest)
+        )
+
+
+@pytest.mark.asyncio
+async def test_capture_blocks_secret_bearing_exports(tmp_path) -> None:
+    _repo, activities, _stored, digest = _capture_harness(
+        tmp_path, {"notes.txt": "api_key = supersecretvalue123\n"}
+    )
+    with pytest.raises(Exception, match="secret scanning"):
+        await activities.agent_runtime_capture_workspace_checkpoint(
+            _request(digest=digest)
+        )
+
+
+@pytest.mark.asyncio
+async def test_put_managed_artifact_verifies_reused_evidence(tmp_path) -> None:
+    _repo, activities, _stored, _digest = _capture_harness(
+        tmp_path, {"tracked.txt": "evidence\n"}
+    )
+    payload = b"capture candidate"
+
+    class ReusingService:
+        async def put_content_addressed_payload_complete(
+            self, *, payload: bytes, **_kwargs: object
+        ) -> tuple[object, bool]:
+            return (
+                SimpleNamespace(
+                    artifact_id="art-other",
+                    sha256=hashlib.sha256(b"different bytes").hexdigest(),
+                    size_bytes=len(b"different bytes"),
+                    status=SimpleNamespace(value="COMPLETE"),
+                ),
+                True,
+            )
+
+    activities._artifact_service = ReusingService()
+    with pytest.raises(Exception, match="RETRY_CONFLICT"):
+        await activities._put_managed_checkpoint_artifact(
+            payload, "application/vnd.moonmind.worktree-archive", "checkpoint_archive"
+        )
+
+
+def test_capture_result_carries_saved_work_refs() -> None:
+    digest = resolve_runtime_execution_capabilities("codex_cli").capability_digest
+    model = ManagedWorkspaceCheckpointCaptureInput.model_validate(
+        _request(digest=digest)
+    )
+    assert model.capture_policy.include_untracked is True
+    result = ManagedWorkspaceCheckpointCaptureResult.model_validate(
+        {
+            "status": "captured",
+            "sourceWorkspaceLocator": model.workspace_locator.model_dump(
+                by_alias=True, mode="json"
+            ),
+            "diagnosticRefs": [],
+            "idempotencyKey": model.idempotency_key,
+            "savedWorkRef": "artifact://saved",
+            "savedWorkDigest": "sha256:" + "c" * 64,
+        }
+    )
+    assert result.saved_work_ref == "artifact://saved"


### PR DESCRIPTION
## Summary
Implements MoonLadderStudios/MoonMind#4015 (plan slice 4: CONTRACT-012, QUALITY-004, CONTRACT-011, INV-004, TEST-003). Captures policy-approved useful content as verified immutable artifacts with truthful completeness:
- Compact saved-work manifest (`moonmind/schemas/saved_work_models.py`): schema/identity, logical execution/run/step/attempt + capture identity, source provenance, content/file-manifest digests, policy/version, required/optional formats, exclusions, scan disposition, artifact dependencies; optional Git baseline/head/patch/bundle fields; ACL/retention via artifact ownership.
- Format profile (`resolve_saved_work_format_profile` / `describe_output_claim` / `thin_bundle_is_portable`): report-only/non-Git tasks never synthesize commits/bundles; full snapshots vs exact-baseline deltas vs selected-history exports with self-contained / dependency-bound / inapplicable / incomplete / failed claims.
- Single stable capture generation: pre/post HEAD+status+fingerprint match with retryable CONCURRENT_MUTATION, explicit failure on unreadable files, recorded exclusions (never claimed), no unconditional `git add -A`, no live index/history mutation.
- Deterministic bounded identities: PAX/mtime-0 tar+gzip, sorted entries, chunked digest via temp-file spool outside the export tree, explicit SAVED_WORK_FORMAT_SIZE_LIMITS / LIMIT_EXCEEDED.
- Retry-identity binding (`assert_complete_payload_matches` / `verify_captured_artifact_evidence` + `artifacts.py` COMPLETE-reuse comparison): same request + same immutable candidate may reuse; conflicting reuse fails or creates a new attempt.
- Binary-safe deltas (`compute_saved_work_delta`, `parse_git_diff_raw_to_deltas` with --no-ext-diff/--no-textconv/--find-renames, never `bundle --all`); secret scan over actual export bytes with digest-bound evidence and explicit limits.

## Verification outcome
Latest controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (confidence HIGH, all 8 requirement IDs VERIFIED, all 5 canonical claims VERIFIED, 0 gaps, 0 blocking failures). Initial assessment was NOT_IMPLEMENTED at base `aadf6d073`; head `a657fffc` advances `116a5c7d` with a remediation commit fixing the two prior test bugs (staged rename fixture; harness-stub removal so the retry-binding test exercises the real `_put_managed` path).

## Tests run
- `moonmind container python-tests tests/unit/workflows/temporal/test_saved_work_capture.py tests/unit/workflows/temporal/test_managed_checkpoint_capture.py` via managed container job `container-job:2f9d3f46a9bd40bd99662bd5808d5b44` — **35 passed in 47.93s** (exitCode=0). Existing checkpoint suite fully passes (incl. binary-safe/idempotent/deterministic archive tests).
- Direct unit evidence: format-profile report-only, single-generation mutation rejection, HEAD-mutation detection, unreadable-file failure, exclusion recording, digest-bound scan, retry-conflict rejection, rename/mode/delete delta reporting, manifest provenance without copied policy, preview-failure separation.

## Remaining risks
- No full live object-store-to-restore qualification journey (advisory); production capture→manifest path proven by units, not an end-to-end store/restore run.
- No live large-payload journey; size limits and spool paths inspected, not exercised at scale.
- Selected-history exports are inapplicable-by-design until refs are requested.
- Orphan-upload / incomplete-manifest reconciliation is owned by #4016/#4017 by design.

Closes MoonLadderStudios/MoonMind#4015