### PR TITLE
[Default compute] Qualify existing free OpenCode route with explicit pricing and privacy policy (MoonLadderStudios/MoonMind#4021)

### DIFF
--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -1084,7 +1084,36 @@ async def get_omnigent_codex_catalog_readiness(
             # A busy profile that queues can still accept new work, so it is
             # not saturated from the admission surface's point of view.
             saturated_by_profile[row.profile_id] = busy and not queue_when_busy
-        if compatible and readiness["launch_ready"] and (not busy or queue_when_busy):
+        # MoonLadderStudios/MoonMind#4021 req-4/req-5: the credentialless free
+        # route additionally needs the recorded per-policy-version data-use
+        # authorization from the existing Settings authority. Default
+        # deployments accept, so they observe no change; an explicit operator
+        # decline surfaces here through the normal Runtime/Profile UI with the
+        # evaluated privacy reason instead of fabricated pricing/capability
+        # axes. A blocked default is structural, never capacity pressure, so
+        # it stays out of the saturation bookkeeping below.
+        free_route_blocked_reason: str | None = None
+        if (
+            compatible
+            and bool(readiness["launch_ready"])
+            and runtime_id == "opencode"
+            and str(getattr(row, "provider_id", "") or "") == "opencode"
+        ):
+            from moonmind.omnigent.bootstrap.free_model_eligibility import (
+                zen_free_route_blocked_reason,
+            )
+
+            free_route_blocked_reason = zen_free_route_blocked_reason(
+                str(getattr(row, "provider_id", "") or "")
+            )
+        if free_route_blocked_reason is not None:
+            saturated_by_profile.pop(row.profile_id, None)
+        if (
+            compatible
+            and readiness["launch_ready"]
+            and free_route_blocked_reason is None
+            and (not busy or queue_when_busy)
+        ):
             eligible_by_runtime[runtime_id] = eligible_by_runtime.get(runtime_id, 0) + 1
             eligible.append(
                 EligibleProviderProfile(
@@ -1104,15 +1133,25 @@ async def get_omnigent_codex_catalog_readiness(
                 and "profile_capacity_unavailable" not in codes
             ):
                 codes.append("profile_capacity_unavailable")
+            gate_reasons: list[GateReason]
+            if free_route_blocked_reason is not None:
+                # The profile is launch-ready but the free-route data-use
+                # policy blocks it: show exactly that reason, not the generic
+                # validation fallback.
+                gate_reasons = [
+                    free_model_gate_reason({"privacy": free_route_blocked_reason})
+                ]
+            else:
+                gate_reasons = [
+                    _reason(code)
+                    for code in codes or ["profile_validation_required"]
+                ]
             ineligible.append(
                 IneligibleProviderProfile(
                     profileId=row.profile_id,
                     label=label,
                     runtimeId=runtime_id,
-                    gateReasons=[
-                        _reason(code)
-                        for code in codes or ["profile_validation_required"]
-                    ],
+                    gateReasons=gate_reasons,
                 )
             )
 

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -323,6 +323,19 @@ _REASONS: dict[str, tuple[str, str]] = {
         "Connect and validate a compatible OAuth Provider Profile for the selected execution target.",
         "/settings#provider-profiles",
     ),
+    # MoonLadderStudios/MoonMind#4021 req-5/req-8: the credentialless
+    # opencode-zen-free route surfaces eligibility with separate
+    # availability/pricing/capability/privacy reasons through the normal
+    # Runtime/Profile UI, with a clear reason and an explicit valid
+    # alternative. Provider/host capacity stays a wait state (see
+    # omnigent_capacity_wait / profile_capacity_unavailable) that never
+    # requalifies a model or selects a paid fallback.
+    "no_eligible_free_model": (
+        "No credentialless OpenCode model is currently eligible. Review the "
+        "availability, pricing, capability, and privacy detail, then choose an "
+        "explicit valid alternative.",
+        "/settings#provider-profiles",
+    ),
     "execution_profile_unavailable": (
         "Enable a compatible Omnigent execution profile.",
         "/settings#omnigent",
@@ -422,6 +435,27 @@ _REASONS: dict[str, tuple[str, str]] = {
 def _reason(code: str) -> GateReason:
     message, href = _REASONS[code]
     return GateReason(code=code, message=message, remediationHref=href)
+
+
+def free_model_gate_reason(reasons: dict[str, str]) -> GateReason:
+    """Build the catalog gate reason for the no_eligible_free_model signal.
+
+    MoonLadderStudios/MoonMind#4021 req-5/acc-6: availability, pricing,
+    capability, and privacy axes stay separate in the message so the normal
+    Runtime/Profile UI can show why the credentialless default is blocked
+    and which explicit valid alternative to choose. Capacity pressure is
+    never reported here: saturated capacity uses omnigent_capacity_wait /
+    profile_capacity_unavailable as a wait state, never a paid fallback.
+    """
+    ordered = {k: reasons[k] for k in ("availability", "pricing", "capability", "privacy") if k in reasons}
+    ordered.update({k: v for k, v in reasons.items() if k not in ordered})
+    detail = ", ".join(f"{axis}={value}" for axis, value in ordered.items()) or "unknown"
+    base = _reason("no_eligible_free_model")
+    return GateReason(
+        code=base.code,
+        message=f"{base.message} Detail: {detail}.",
+        remediationHref=base.remediation_href,
+    )
 
 
 def _valid_server_url(value: str) -> bool:

--- a/api_service/api/routers/omnigent_catalog.py
+++ b/api_service/api/routers/omnigent_catalog.py
@@ -437,6 +437,74 @@ def _reason(code: str) -> GateReason:
     return GateReason(code=code, message=message, remediationHref=href)
 
 
+def free_model_gate_reasons_for_profile(row: Any) -> dict[str, str]:
+    """Combine real-evidence axes for the credentialless free route.
+
+    MoonLadderStudios/MoonMind#4021 req-5/req-8: the normal Runtime/Profile
+    UI surfaces why the credentialless default is blocked with separate
+    availability, capability, and privacy reasons plus an explicit valid
+    alternative. Every axis reported here comes from production evidence:
+
+    - availability: the profile's persisted exact-host catalog
+      (``model_catalog_evidence_json``) either contains the default model
+      exactly or the verdict is deferred to exact-host qualification when no
+      persisted catalog exists yet. A successful list request, a name
+      containing "free", or an installed binary never qualifies.
+    - capability: the default effort is checked against the selected model's
+      actual supported values, never the seeded default.
+    - privacy: the recorded per-policy-version authorization from the
+      existing Settings authority.
+
+    Pricing is never fabricated here: no trusted pricing feed has a
+    production source yet (req-2), so that axis is evaluated by hermetic
+    tests only until the feed exists. Saturated capacity stays a separate
+    wait state (``omnigent_capacity_wait`` /
+    ``profile_capacity_unavailable``) that never requalifies a model or
+    selects a paid fallback.
+    """
+    provider_id = str(getattr(row, "provider_id", "") or "")
+    if provider_id != "opencode":
+        return {}
+    reasons: dict[str, str] = {}
+    default_model = str(getattr(row, "default_model", "") or "").strip()
+    evidence = getattr(row, "model_catalog_evidence_json", None)
+    if (
+        isinstance(evidence, dict)
+        and isinstance(evidence.get("models"), list)
+        and evidence["models"]
+    ):
+        from moonmind.omnigent.bootstrap.free_model_eligibility import (
+            catalog_ids_from_evidence,
+        )
+
+        if default_model and default_model not in catalog_ids_from_evidence(
+            evidence
+        ):
+            reasons["availability"] = f"not_in_catalog:{default_model}"
+    privacy_reason: str | None = None
+    if provider_id == "opencode":
+        from moonmind.omnigent.bootstrap.free_model_eligibility import (
+            zen_free_route_blocked_reason,
+        )
+
+        privacy_reason = zen_free_route_blocked_reason(provider_id)
+    if privacy_reason is not None:
+        reasons["privacy"] = privacy_reason
+    if default_model:
+        from moonmind.omnigent.bootstrap.opencode import get_supported_efforts
+
+        supported = get_supported_efforts(default_model)
+        default_effort = str(getattr(row, "default_effort", "") or "").strip()
+        if (
+            supported is not None
+            and default_effort
+            and default_effort.lower()
+            not in {item.lower() for item in supported}
+        ):
+            reasons["capability"] = f"unsupported_effort:{default_effort}"
+    return reasons
+
+
 def free_model_gate_reason(reasons: dict[str, str]) -> GateReason:
     """Build the catalog gate reason for the no_eligible_free_model signal.
 
@@ -1086,32 +1154,28 @@ async def get_omnigent_codex_catalog_readiness(
             saturated_by_profile[row.profile_id] = busy and not queue_when_busy
         # MoonLadderStudios/MoonMind#4021 req-4/req-5: the credentialless free
         # route additionally needs the recorded per-policy-version data-use
-        # authorization from the existing Settings authority. Default
+        # authorization from the existing Settings authority, the exact
+        # observed catalog ID, and per-model effort support. Default
         # deployments accept, so they observe no change; an explicit operator
-        # decline surfaces here through the normal Runtime/Profile UI with the
-        # evaluated privacy reason instead of fabricated pricing/capability
-        # axes. A blocked default is structural, never capacity pressure, so
-        # it stays out of the saturation bookkeeping below.
-        free_route_blocked_reason: str | None = None
+        # decline or a catalog/effort mismatch surfaces here through the
+        # normal Runtime/Profile UI with the evaluated axes instead of
+        # fabricated pricing/capability axes. A blocked default is
+        # structural, never capacity pressure, so it stays out of the
+        # saturation bookkeeping below.
+        free_route_blocked_reasons: dict[str, str] = {}
         if (
             compatible
             and bool(readiness["launch_ready"])
             and runtime_id == "opencode"
             and str(getattr(row, "provider_id", "") or "") == "opencode"
         ):
-            from moonmind.omnigent.bootstrap.free_model_eligibility import (
-                zen_free_route_blocked_reason,
-            )
-
-            free_route_blocked_reason = zen_free_route_blocked_reason(
-                str(getattr(row, "provider_id", "") or "")
-            )
-        if free_route_blocked_reason is not None:
+            free_route_blocked_reasons = free_model_gate_reasons_for_profile(row)
+        if free_route_blocked_reasons:
             saturated_by_profile.pop(row.profile_id, None)
         if (
             compatible
             and readiness["launch_ready"]
-            and free_route_blocked_reason is None
+            and not free_route_blocked_reasons
             and (not busy or queue_when_busy)
         ):
             eligible_by_runtime[runtime_id] = eligible_by_runtime.get(runtime_id, 0) + 1
@@ -1134,12 +1198,12 @@ async def get_omnigent_codex_catalog_readiness(
             ):
                 codes.append("profile_capacity_unavailable")
             gate_reasons: list[GateReason]
-            if free_route_blocked_reason is not None:
-                # The profile is launch-ready but the free-route data-use
-                # policy blocks it: show exactly that reason, not the generic
-                # validation fallback.
+            if free_route_blocked_reasons:
+                # The profile is launch-ready but the free-route policy blocks
+                # it: show exactly those axes, not the generic validation
+                # fallback.
                 gate_reasons = [
-                    free_model_gate_reason({"privacy": free_route_blocked_reason})
+                    free_model_gate_reason(free_route_blocked_reasons)
                 ]
             else:
                 gate_reasons = [

--- a/api_service/main.py
+++ b/api_service/main.py
@@ -2043,6 +2043,7 @@ async def _auto_seed_provider_profiles() -> list[str]:
                 "runtime_materialization_mode": RuntimeMaterializationMode.COMPOSITE,
                 "secret_refs": {},
                 "clear_env_keys": [
+                    "OPENCODE_API_KEY",
                     "OPENCODE_AUTH_CONTENT",
                     "OPENCODE_CONFIG",
                     "OPENCODE_CONFIG_CONTENT",

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -149,6 +149,7 @@ credentialMaterializers:
   - opencode-auth-json@1
   - none@1
 forbiddenAmbientEnvironment:
+  - OPENCODE_API_KEY
   - OPENCODE_AUTH_CONTENT
   - OPENCODE_CONFIG
   - OPENCODE_CONFIG_CONTENT
@@ -240,6 +241,7 @@ The materialization sequence is:
 The runtime script rejects or clears conflicting ambient credentials:
 
 ```text
+OPENCODE_API_KEY
 OPENCODE_AUTH_CONTENT
 OPENCODE_CONFIG
 OPENCODE_CONFIG_CONTENT
@@ -259,14 +261,22 @@ explicit `opencode-go` profile and must never be inherited by the Zen profile.
 
 Credential ownership is owned by [`SharedHostImage.md`](./SharedHostImage.md)
 §4. The OpenCode-specific isolation proof that remains here — exact-host
-conformance must prove:
+conformance must prove, for the selected materializer class:
 
 - `/home/app/.codex` is not mounted from a Codex Provider Profile
 - Claude credential paths are not mounted
 - no Codex or Claude API-key environment is inherited
 - the selected runtime pack is `opencode-native-pack@1`
-- the selected materializer is `opencode-auth-json@1`
+- the selected materializer is `opencode-auth-json@1` (keyed route) or
+  `none@1` (credentialless `opencode-zen-free` route)
 - only `opencode-native` is admitted by the selected Host Class
+- ambient `OPENCODE_API_KEY`, `OPENCODE_AUTH_CONTENT`, `OPENCODE_CONFIG`,
+  `OPENCODE_CONFIG_CONTENT`, `OPENAI_API_KEY`, and `ANTHROPIC_API_KEY` are
+  absent from the credentialless `none@1` runtime; `OPENCODE_API_KEY` may only
+  configure the separate keyed `opencode-go` profile and never rescues the
+  credentialless attempt
+- the credentialless route requires no `auth.json` attachment; its startup
+  does not depend on an `auth.json` mount
 
 The presence of the other binaries is not a support or authorization signal.
 
@@ -292,6 +302,29 @@ The seed runs before the first bootstrap reconciliation. Startup validates the
 model against the exact pinned host and publishes the same deployment evidence
 required by key-backed profiles. An existing explicit operator disable remains
 authoritative.
+
+The seeded `defaultModel`/`defaultEffort` is a configured identity, not
+eligibility evidence. It distinguishes the configured seed from the observed
+exact-host catalog, the qualified runtime, the eligible pricing/privacy state,
+and temporary availability (MoonLadderStudios/MoonMind#4021):
+
+- configured seed: the persisted `opencode-zen-free` profile and its default
+  model/effort selection;
+- observed catalog: the exact-host model list for the `opencode` route;
+- qualified runtime: the pinned image, runtime pack, and `none@1`
+  materializer admission;
+- eligible pricing/privacy: the `free_model_eligibility` verdict from the
+  exact catalog plus trusted pricing/data-use evidence
+  (`SELECTION_POLICY_VERSION = free-model-selection.v1`), frozen with the
+  admitted attempt;
+- temporary availability: provider/host capacity is a wait state that never
+  requalifies a model, revokes eligibility, or selects a paid fallback.
+
+No live model availability, pricing, terms, or inference is implied by the
+seeded name. When no free candidate is eligible, launches surface
+`no_eligible_free_model` with separate availability, pricing, capability, and
+privacy reasons through the normal Runtime/Profile UI with a clear reason and
+an explicit valid alternative.
 
 The seed declares `isDefault: true`, so it holds runtime-default authority for
 `opencode` from first start rather than inheriting it only while it happens to

--- a/docs/Omnigent/OpenCodeHost.md
+++ b/docs/Omnigent/OpenCodeHost.md
@@ -429,6 +429,45 @@ behavior as production:
 
 MoonMind does not substitute a configured model when the provider catalog is empty. It does not silently select another model when the prior default disappears.
 
+### Credentialless free-route admission (MoonLadderStudios/MoonMind#4021)
+
+The `opencode-zen-free`/`none@1` route is admitted through one first-result
+path that reuses the existing owners; no new free-model profile family, no
+marketplace, and no new consent subsystem exist:
+
+- plan-time admission (`_enforce_free_route_exact_catalog`) requires the
+  selected model to appear exactly in the Provider Profile's persisted
+  exact-host catalog before launch. A persisted catalog that lacks the ID
+  fails closed with the `no_eligible_free_model` availability axis; a profile
+  with no persisted catalog yet defers to exact-host qualification.
+- bootstrap qualification (`_qualify_and_publish`) resolves the selected
+  model with `resolve_model_exact` against the exact observed catalog, then
+  freezes model ID, route/materializer, catalog/pricing/data-use evidence,
+  and selection-policy version with the admitted attempt
+  (`FrozenFreeModelAttempt` on `BootstrapResolved.freeModelAttempt`).
+  A previously frozen bundle is rechecked before the renewed attempt without
+  rewriting active inputs; expiry only refreshes the bundle at qualification
+  time, never swaps provider/model inside a billed request.
+- catalog readiness (`free_model_gate_reasons_for_profile`) surfaces the
+  blocking axes through the normal Runtime/Profile UI with a clear reason and
+  an explicit valid alternative: availability (exact catalog presence),
+  capability (default effort against the model's actual supported values),
+  and privacy (the recorded per-policy-version authorization from Settings).
+  Saturated capacity stays on `omnigent_capacity_wait` /
+  `profile_capacity_unavailable` as a wait state.
+
+Explicit scope: no trusted pricing feed has a production source yet, so
+production admission never fabricates a zero price. Pricing-axis evaluation
+and multi-candidate approved-set ranking (`rank_approved_candidates`) run
+hermetically against inline fixtures until that feed exists; production
+admission is the single-route blocked check above. Likewise
+`build_live_qualification_record` defines the bounded, non-sensitive live
+record shape (exact model/image/runtime/materializer, evidence references,
+request bounds, blocked/unexecuted cases) for an explicitly authorized,
+budgeted qualification run; no live inference is claimed by hermetic tests.
+No extra mandatory free-model UI controls are added: the existing
+Runtime/Profile surfaces carry the reason.
+
 ## 9. Revalidation and freshness
 
 OpenCode model-catalog evidence binds:

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -630,7 +630,7 @@ class BootstrapController:
                 all_materializers_ready = False
                 continue
             try:
-                evidence_payload = await self._qualify_and_publish(
+                evidence_payload, _refreshed_record = await self._qualify_and_publish(
                     provider_profile_ref=profile_ref,
                     qualified_model=qualified_model,
                     effort=effort,
@@ -791,7 +791,7 @@ class BootstrapController:
                 update={"state": BootstrapState.qualifying_runtime}
             )
             save_bootstrap_record(record)
-            evidence = await self._qualify_and_publish(
+            evidence, record = await self._qualify_and_publish(
                 provider_profile_ref=provider_ref,
                 qualified_model=qualified,
                 effort=eff,
@@ -1289,7 +1289,7 @@ class BootstrapController:
         effort: str,
         resolved: Any,
         record: BootstrapRecord,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], BootstrapRecord]:
         import hashlib
         from datetime import UTC, datetime
 
@@ -1298,6 +1298,16 @@ class BootstrapController:
             build_deployment_evidence,
             write_deployment_evidence,
         )
+        from moonmind.omnigent.bootstrap.free_model_eligibility import (
+            FREE_PROVIDER_ID,
+            ZEN_FREE_TERMS_VERSION,
+            attach_frozen_attempt_to_resolved,
+            catalog_ids_from_evidence,
+            freeze_attempt,
+            frozen_attempt_from_resolved,
+            recheck_frozen_attempt,
+        )
+        from moonmind.omnigent.bootstrap.opencode import resolve_model_exact
         from moonmind.omnigent.bootstrap.qualification import run_qualification
         from moonmind.omnigent.harness_platform.catalog_service import (
             DbHarnessCatalogRepository,
@@ -1337,6 +1347,82 @@ class BootstrapController:
                     f"credential materializer {materializer_ref} must declare one auth model"
                 )
             auth_model = auth_models[0]
+
+        # MoonLadderStudios/MoonMind#4021 req-3/req-5: execution selection
+        # uses the exact observed catalog ID, and the admitted credentialless
+        # attempt freezes its evidence bundle with the record. The persisted
+        # catalog evidence is re-read here (the instance above is detached)
+        # so the check observes current authority, not a stale copy.
+        async with async_session_maker() as session:
+            from api_service.db.models import (
+                ManagedAgentProviderProfile as _EvidenceProfileModel,
+            )
+
+            evidence_profile = await session.get(
+                _EvidenceProfileModel, provider_profile_ref
+            )
+            catalog_evidence: dict[str, Any] = (
+                dict(
+                    getattr(
+                        evidence_profile, "model_catalog_evidence_json", None
+                    )
+                    or {}
+                )
+                if evidence_profile is not None
+                else {}
+            )
+        catalog_ids = catalog_ids_from_evidence(catalog_evidence)
+        if catalog_ids:
+            try:
+                resolve_model_exact(
+                    qualified_model,
+                    [{"qualifiedId": qid} for qid in catalog_ids],
+                )
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"exact-host model authority rejected {qualified_model!r}: "
+                    f"{exc}"
+                ) from exc
+        # Authoritative recheck immediately before this renewed attempt: the
+        # frozen bundle is never rewritten in place and the provider/model is
+        # never swapped inside a billed request. Qualification is the
+        # explicitly authorized new attempt, so expiry only refreshes the
+        # bundle below while preserving saved work elsewhere.
+        existing_frozen = frozen_attempt_from_resolved(
+            getattr(record, "resolved", None)
+        )
+        if existing_frozen is not None:
+            current, recheck_reason = recheck_frozen_attempt(
+                existing_frozen,
+                catalog=catalog_evidence or {"ids": catalog_ids},
+                pricing=dict(catalog_evidence.get("pricing") or {}),
+                data_use_version=ZEN_FREE_TERMS_VERSION,
+            )
+            if not current:
+                logger.info(
+                    "Free-model frozen attempt expired (%s); qualifying a "
+                    "fresh explicitly authorized attempt preserving saved work.",
+                    recheck_reason,
+                )
+        if model_route_ref == FREE_PROVIDER_ID:
+            # No trusted pricing feed has a production source yet (req-2), so
+            # the bundle records exactly what was observed: the catalog
+            # evidence digest plus the pricing section actually present
+            # (empty when absent). It never fabricates a zero.
+            frozen = freeze_attempt(
+                qualified_id=qualified_model,
+                catalog=catalog_evidence or {"ids": catalog_ids},
+                pricing=dict(catalog_evidence.get("pricing") or {}),
+                data_use_version=ZEN_FREE_TERMS_VERSION,
+            )
+            record = record.model_copy(
+                update={
+                    "resolved": attach_frozen_attempt_to_resolved(
+                        record.resolved, frozen
+                    )
+                }
+            )
+            save_bootstrap_record(record)
 
         # Select host class
         harness = next(
@@ -1645,7 +1731,7 @@ class BootstrapController:
             resolved_state=resolved,
         )
         write_deployment_evidence(evidence)
-        return evidence
+        return evidence, record
 
 
 def normalize_display(name: str) -> str:

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -712,22 +712,46 @@ class BootstrapController:
                     )
             # Update record resolved
             # Resolve model for image selection. Credentialless opencode/*
-            # qualified IDs never resolve pre-validation: resolve_bootstrap_model
-            # fails closed without the exact observed catalog, while friendly
-            # display aliases remain valid here for image resolution only.
+            # qualified IDs require the exact observed catalog for execution
+            # selection, but image selection must not fail closed before
+            # catalog sync/qualification: defer exact-ID validation to
+            # _qualify_and_publish (exact-host authority via
+            # resolve_model_exact). Friendly display aliases remain valid
+            # here for image resolution only.
             # Execution qualification still requires the exact catalog (step 7
             # of OpenCodeHost §8) via resolve_model_exact before launch.
             try:
                 model_info = resolve_bootstrap_model(display)
             except ValueError as exc:
-                record = record.model_copy(
-                    update={
-                        "state": BootstrapState.failed,
-                        "failure": {"code": "model_unavailable", "message": str(exc)},
+                text = display.strip()
+                prefix, sep, provider_model_id = text.partition("/")
+                if sep and prefix.strip() == "opencode" and provider_model_id.strip():
+                    # MoonLadderStudios/MoonMind#4021 P1: fresh
+                    # opencode-zen-free default stores its qualified
+                    # opencode/... model in desired with no catalog yet.
+                    # Use the qualified ID directly for image selection and
+                    # let _qualify_and_publish enforce exact-catalog
+                    # authority before launch.
+                    logger.info(
+                        "Deferring exact catalog validation for %r to "
+                        "qualification; using qualified ID for image "
+                        "selection.",
+                        text,
+                    )
+                    model_info = {
+                        "displayName": display,
+                        "providerModelId": provider_model_id.strip(),
+                        "qualifiedId": text,
                     }
-                )
-                save_bootstrap_record(record)
-                raise
+                else:
+                    record = record.model_copy(
+                        update={
+                            "state": BootstrapState.failed,
+                            "failure": {"code": "model_unavailable", "message": str(exc)},
+                        }
+                    )
+                    save_bootstrap_record(record)
+                    raise
 
             qualified = model_info["qualifiedId"]
             provider_model = model_info["providerModelId"]

--- a/moonmind/omnigent/bootstrap/controller.py
+++ b/moonmind/omnigent/bootstrap/controller.py
@@ -21,8 +21,9 @@ from moonmind.omnigent.bootstrap.models import (
 from moonmind.omnigent.bootstrap.opencode import (
     DEFAULT_OPENCODE_MODEL_DISPLAY,
     DEFAULT_OPENCODE_QUALIFIED,
-    resolve_model_by_display,
+    resolve_bootstrap_model,
     validate_effort,
+    validate_effort_for_model,
 )
 from moonmind.omnigent.bootstrap.store import (
     load_bootstrap_record,
@@ -46,7 +47,11 @@ def _resolve_profile_model_effort(profile: Any) -> tuple[str, str]:
         require_launch_ready=False,
     )
     model = str(resolved.model or "").strip()
-    effort = validate_effort(str(resolved.effort or "xhigh").strip())
+    raw_effort = str(resolved.effort or "xhigh").strip()
+    # MoonLadderStudios/MoonMind#4021 req-3: validate effort against the
+    # selected model's actual supported values, never the seeded default.
+    # Unknown models fall back to the generic set inside the helper.
+    effort = validate_effort_for_model(raw_effort, model) if model else validate_effort(raw_effort)
     return model, effort
 
 
@@ -91,8 +96,9 @@ class BootstrapController:
                 "Contributor data-use acknowledgement is required for Muse Spark 1.3 Contributor"
             )
 
-        # Validate effort
-        eff = validate_effort(eff)
+        # Validate effort against the selected model's actual values
+        # (MoonLadderStudios/MoonMind#4021 req-3); unknown models use generic.
+        eff = validate_effort_for_model(eff, display) if display else validate_effort(eff)
 
         # Load or create record
         record = await self.get_state()
@@ -705,9 +711,14 @@ class BootstrapController:
                         "or set OMNIGENT_OPENCODE_HOST_IMAGE_REF to a digest-pinned image."
                     )
             # Update record resolved
-            # Resolve model by friendly name (without live catalog for now, will validate later)
+            # Resolve model for image selection. Credentialless opencode/*
+            # qualified IDs never resolve pre-validation: resolve_bootstrap_model
+            # fails closed without the exact observed catalog, while friendly
+            # display aliases remain valid here for image resolution only.
+            # Execution qualification still requires the exact catalog (step 7
+            # of OpenCodeHost §8) via resolve_model_exact before launch.
             try:
-                model_info = resolve_model_by_display(display)
+                model_info = resolve_bootstrap_model(display)
             except ValueError as exc:
                 record = record.model_copy(
                     update={
@@ -720,6 +731,8 @@ class BootstrapController:
 
             qualified = model_info["qualifiedId"]
             provider_model = model_info["providerModelId"]
+            # Effort uses the selected model's actual supported values.
+            eff = validate_effort_for_model(eff, qualified)
             resolved_model = BootstrapResolved(
                 modelId=provider_model,
                 qualifiedModelId=qualified,

--- a/moonmind/omnigent/bootstrap/free_model_eligibility.py
+++ b/moonmind/omnigent/bootstrap/free_model_eligibility.py
@@ -1,0 +1,409 @@
+"""Credentialless free-model eligibility for the existing OpenCode Zen route.
+
+MoonLadderStudios/MoonMind#4021
+
+This module is the hermetic authority for deciding whether an exact
+``opencode/<model>`` catalog entry is genuinely eligible as the
+credentialless default. Catalog presence alone never qualifies a model;
+eligibility additionally requires explicit pricing evidence (every relevant
+charge dimension is zero or explicitly inapplicable) and an explicit
+per-policy-version data-use authorization.
+
+Only key names, model IDs, and evidence digests flow through here. Secret
+values are never accepted, recorded, or emitted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Mapping
+
+FREE_PROFILE_ID = "opencode-zen-free"
+FREE_PROVIDER_ID = "opencode"
+FREE_MATERIALIZER_REF = "none@1"
+FREE_ROUTE_PREFIX = "opencode/"
+SELECTION_POLICY_VERSION = "free-model-selection.v1"
+
+NO_ELIGIBLE_FREE_MODEL_CODE = "no_eligible_free_model"
+
+# Every charge dimension the eligibility check understands. A pricing payload
+# must speak about each of these or explicitly mark it inapplicable; an
+# omitted dimension is unknown, never free.
+PRICING_DIMENSIONS: tuple[str, ...] = (
+    "request",
+    "input_token",
+    "output_token",
+    "cache_read",
+    "cache_write",
+    "reasoning",
+    "tool",
+)
+
+# Canonical tool/capability gate for execution: a free candidate must carry
+# the tools/modalities the runtime needs. Kept small and explicit so tests
+# can exercise missing-capability rejection without live catalogs.
+REQUIRED_TOOLS: tuple[str, ...] = ("read", "write", "shell")
+
+
+def parse_cost_value(raw: Any) -> float | None:
+    """Parse one cost field; return None when unknown/invalid.
+
+    Missing, null, unparsable, negative, or non-finite values are
+    unknown/invalid, never zero. Only a finite value >= 0 parses.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        return None
+    try:
+        if isinstance(raw, str):
+            text = raw.strip()
+            if not text:
+                return None
+            value = float(text)
+        else:
+            value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _pricing_entry_costs(entry: Any) -> float | None:
+    """Unwrap one pricing dimension entry to a parsed cost or None."""
+    if isinstance(entry, Mapping):
+        # Explicit inapplicable marking is handled by the caller; here an
+        # entry shaped as {"value": ...} unwraps, anything else is unknown.
+        if "value" in entry:
+            return parse_cost_value(entry.get("value"))
+        return None
+    return parse_cost_value(entry)
+
+
+@dataclass(frozen=True, slots=True)
+class PricingVerdict:
+    eligible: bool
+    reason: str
+    unknown_dimensions: tuple[str, ...] = ()
+    nonzero_dimensions: tuple[str, ...] = ()
+
+
+def evaluate_pricing(
+    pricing: Mapping[str, Any] | None,
+    *,
+    inapplicable: frozenset[str] | set[str] | tuple[str, ...] = frozenset(),
+    requires_subscription_or_key: bool = False,
+) -> PricingVerdict:
+    """Decide whether trusted pricing evidence proves zero cost.
+
+    - Every dimension in PRICING_DIMENSIONS must either parse to exactly 0.0
+      or be explicitly listed in ``inapplicable``.
+    - Omitted dimensions not marked inapplicable are unknown and block.
+    - ``requires_subscription_or_key`` models a subscription/key prerequisite:
+      a zero price behind such a prerequisite is not credentialless-eligible.
+    """
+    inapplicable_set = frozenset(inapplicable)
+    unknown: list[str] = []
+    nonzero: list[str] = []
+    source = pricing or {}
+    for dim in PRICING_DIMENSIONS:
+        if dim in inapplicable_set:
+            continue
+        if dim not in source:
+            unknown.append(dim)
+            continue
+        cost = _pricing_entry_costs(source.get(dim))
+        if cost is None:
+            unknown.append(dim)
+        elif cost != 0.0:
+            nonzero.append(dim)
+    if requires_subscription_or_key:
+        return PricingVerdict(
+            eligible=False,
+            reason="subscription_or_key_required",
+            unknown_dimensions=tuple(unknown),
+            nonzero_dimensions=tuple(nonzero),
+        )
+    if unknown:
+        return PricingVerdict(
+            eligible=False,
+            reason="unknown_pricing:" + ",".join(unknown),
+            unknown_dimensions=tuple(unknown),
+            nonzero_dimensions=tuple(nonzero),
+        )
+    if nonzero:
+        return PricingVerdict(
+            eligible=False,
+            reason="nonzero_pricing:" + ",".join(nonzero),
+            unknown_dimensions=tuple(unknown),
+            nonzero_dimensions=tuple(nonzero),
+        )
+    return PricingVerdict(eligible=True, reason="zero_cost")
+
+
+@dataclass(frozen=True, slots=True)
+class DataUseDecision:
+    """Recorded authorization for one data-use policy version."""
+
+    policy_version: str
+    accepted: bool
+    accepted_at: str = ""
+    accepted_by: str = ""
+
+
+def evaluate_data_use(
+    *,
+    terms_version: str,
+    terms_require_approval: bool,
+    decision: DataUseDecision | None,
+) -> tuple[bool, str]:
+    """Apply the permitted data-use policy before ranking.
+
+    Existing usage, a connected flag, or an automatically seeded profile is
+    never consent. Only an explicit accepted decision for the exact
+    ``terms_version`` authorizes. Returns (eligible, reason).
+    """
+    if not terms_require_approval:
+        return True, "no_approval_required"
+    if decision is None:
+        return False, "privacy:unaccepted_terms:" + terms_version
+    if decision.policy_version != terms_version or not decision.accepted:
+        return False, "privacy:unaccepted_terms:" + terms_version
+    return True, "authorized:" + terms_version
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityInput:
+    qualified_id: str
+    provider_id: str = FREE_PROVIDER_ID
+    materializer_ref: str = FREE_MATERIALIZER_REF
+    in_catalog: bool = False
+    pricing: Mapping[str, Any] | None = None
+    inapplicable_dimensions: tuple[str, ...] = ()
+    requires_subscription_or_key: bool = False
+    capabilities: tuple[str, ...] = ()
+    supported_efforts: tuple[str, ...] = ()
+    requested_effort: str = "xhigh"
+    terms_version: str = ""
+    terms_require_approval: bool = False
+    data_use_decision: DataUseDecision | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EligibilityVerdict:
+    eligible: bool
+    reasons: dict[str, str] = field(default_factory=dict)
+
+
+def evaluate_eligibility(candidate: EligibilityInput) -> EligibilityVerdict:
+    """Evaluate one exact catalog candidate across the four reason axes."""
+    reasons: dict[str, str] = {}
+    if not candidate.in_catalog:
+        reasons["availability"] = "not_in_catalog"
+    if (
+        candidate.provider_id != FREE_PROVIDER_ID
+        or not candidate.qualified_id.startswith(FREE_ROUTE_PREFIX)
+    ):
+        reasons["availability"] = "wrong_route:" + candidate.qualified_id
+    if candidate.materializer_ref != FREE_MATERIALIZER_REF:
+        reasons["availability"] = "wrong_materializer:" + candidate.materializer_ref
+    pricing = evaluate_pricing(
+        candidate.pricing,
+        inapplicable=frozenset(candidate.inapplicable_dimensions),
+        requires_subscription_or_key=candidate.requires_subscription_or_key,
+    )
+    if not pricing.eligible:
+        reasons["pricing"] = pricing.reason
+    missing_tools = [t for t in REQUIRED_TOOLS if t not in set(candidate.capabilities)]
+    if missing_tools:
+        reasons["capability"] = "missing_tools:" + ",".join(missing_tools)
+    elif (
+        candidate.supported_efforts
+        and candidate.requested_effort.strip().lower()
+        not in {e.lower() for e in candidate.supported_efforts}
+    ):
+        reasons["capability"] = "unsupported_effort:" + candidate.requested_effort
+    data_ok, data_reason = evaluate_data_use(
+        terms_version=candidate.terms_version,
+        terms_require_approval=candidate.terms_require_approval,
+        decision=candidate.data_use_decision,
+    )
+    if not data_ok:
+        reasons["privacy"] = data_reason
+    return EligibilityVerdict(eligible=not reasons, reasons=reasons)
+
+
+def _evidence_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenFreeModelAttempt:
+    """Immutable evidence bundle frozen with one admitted attempt."""
+
+    model_id: str
+    route: str = FREE_ROUTE_PREFIX.rstrip("/")
+    materializer_ref: str = FREE_MATERIALIZER_REF
+    catalog_digest: str = ""
+    pricing_digest: str = ""
+    data_use_version: str = ""
+    selection_policy_version: str = SELECTION_POLICY_VERSION
+    observed_at: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "modelId": self.model_id,
+            "route": self.route,
+            "materializerRef": self.materializer_ref,
+            "catalogDigest": self.catalog_digest,
+            "pricingDigest": self.pricing_digest,
+            "dataUseVersion": self.data_use_version,
+            "selectionPolicyVersion": self.selection_policy_version,
+            "observedAt": self.observed_at,
+        }
+
+
+def freeze_attempt(
+    *,
+    qualified_id: str,
+    catalog: Any,
+    pricing: Mapping[str, Any] | None,
+    data_use_version: str,
+    observed_at: str | None = None,
+) -> FrozenFreeModelAttempt:
+    """Freeze model/route/evidence/policy-version with the admitted attempt."""
+    catalog_payload = catalog if isinstance(catalog, Mapping) else {"catalog": catalog}
+    pricing_payload = dict(pricing or {})
+    return FrozenFreeModelAttempt(
+        model_id=qualified_id,
+        catalog_digest=_evidence_digest(catalog_payload if isinstance(catalog_payload, Mapping) else {"v": str(catalog_payload)}),
+        pricing_digest=_evidence_digest(pricing_payload),
+        data_use_version=data_use_version,
+        observed_at=observed_at or datetime.now(UTC).isoformat(),
+    )
+
+
+def format_no_eligible_free_model(reasons: Mapping[str, str]) -> dict[str, Any]:
+    """Expose the no_eligible_free_model signal with separate reason axes."""
+    ordered = {k: reasons[k] for k in ("availability", "pricing", "capability", "privacy") if k in reasons}
+    ordered.update({k: v for k, v in reasons.items() if k not in ordered})
+    return {"code": NO_ELIGIBLE_FREE_MODEL_CODE, "reasons": dict(ordered)}
+
+
+class FreeModelUnavailableError(ValueError):
+    """An explicit pinned free model cannot be satisfied; never substituted."""
+
+    code = "free_model_unavailable"
+
+    def __init__(self, message: str, **details: Any) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = details
+
+
+class NoEligibleFreeModelError(ValueError):
+    """Automatic selection found no eligible free model."""
+
+    code = NO_ELIGIBLE_FREE_MODEL_CODE
+
+    def __init__(self, reasons: Mapping[str, str]) -> None:
+        payload = format_no_eligible_free_model(reasons)
+        super().__init__(f"no eligible free model ({payload['reasons']})")
+        self.message = str(self)
+        self.details = payload
+
+
+def resolve_free_default_model(
+    *,
+    explicit_pin: str | None,
+    catalog_ids: list[str],
+    candidates: Mapping[str, EligibilityInput],
+    default_policy_authorizes_auto: bool,
+) -> tuple[str, FrozenFreeModelAttempt]:
+    """Map seed/default/catalog/materializer into one first-result path.
+
+    - An explicit user pin is preserved: when it is unavailable or
+      ineligible the call raises instead of silently substituting.
+    - Automatic eligible-model resolution runs only where the existing
+      default policy authorizes it; otherwise it raises.
+    - Discovery inputs never rewrite an active attempt: the returned frozen
+      bundle must be persisted with the attempt by the caller.
+    """
+    pinned = (explicit_pin or "").strip()
+    if pinned:
+        candidate = candidates.get(pinned)
+        if candidate is None or pinned not in catalog_ids:
+            raise FreeModelUnavailableError(
+                f"Requested free model {pinned!r} is unavailable for the "
+                f"credentialless {FREE_PROFILE_ID} route. Available catalog: "
+                f"{', '.join(catalog_ids[:5]) or 'none'}",
+                requested=pinned,
+            )
+        verdict = evaluate_eligibility(candidate)
+        if not verdict.eligible:
+            raise NoEligibleFreeModelError(verdict.reasons)
+        frozen = freeze_attempt(
+            qualified_id=pinned,
+            catalog={"ids": sorted(catalog_ids)},
+            pricing=dict(candidate.pricing or {}),
+            data_use_version=candidate.terms_version,
+        )
+        return pinned, frozen
+    if not default_policy_authorizes_auto:
+        raise FreeModelUnavailableError(
+            "No explicit free model is pinned and automatic eligible-model "
+            "resolution is not authorized by the default policy.",
+            requested="",
+        )
+    # Deterministic first-result order over the observed catalog.
+    last_reasons: dict[str, str] = {"availability": "empty_catalog"}
+    for qualified_id in catalog_ids:
+        candidate = candidates.get(qualified_id)
+        if candidate is None:
+            last_reasons = {"availability": f"no_evidence:{qualified_id}"}
+            continue
+        verdict = evaluate_eligibility(candidate)
+        if verdict.eligible:
+            frozen = freeze_attempt(
+                qualified_id=qualified_id,
+                catalog={"ids": sorted(catalog_ids)},
+                pricing=dict(candidate.pricing or {}),
+                data_use_version=candidate.terms_version,
+            )
+            return qualified_id, frozen
+        last_reasons = verdict.reasons
+    raise NoEligibleFreeModelError(last_reasons)
+
+
+__all__ = [
+    "FREE_MATERIALIZER_REF",
+    "FREE_PROFILE_ID",
+    "FREE_PROVIDER_ID",
+    "FREE_ROUTE_PREFIX",
+    "NO_ELIGIBLE_FREE_MODEL_CODE",
+    "PRICING_DIMENSIONS",
+    "REQUIRED_TOOLS",
+    "SELECTION_POLICY_VERSION",
+    "DataUseDecision",
+    "EligibilityInput",
+    "EligibilityVerdict",
+    "FreeModelUnavailableError",
+    "FrozenFreeModelAttempt",
+    "NoEligibleFreeModelError",
+    "PricingVerdict",
+    "evaluate_data_use",
+    "evaluate_eligibility",
+    "evaluate_pricing",
+    "format_no_eligible_free_model",
+    "freeze_attempt",
+    "parse_cost_value",
+    "resolve_free_default_model",
+]

--- a/moonmind/omnigent/bootstrap/free_model_eligibility.py
+++ b/moonmind/omnigent/bootstrap/free_model_eligibility.py
@@ -324,6 +324,30 @@ def zen_free_data_use_decision_from_settings(
     )
 
 
+def zen_free_route_blocked_reason(
+    provider_id: str | None,
+    *,
+    env: Mapping[str, Any] | None = None,
+) -> str | None:
+    """Return the blocking privacy reason for the credentialless free route.
+
+    MoonLadderStudios/MoonMind#4021 req-4: production admission paths call
+    this with the selected provider ID. It reuses the existing Settings/policy
+    authority (:func:`zen_free_data_use_decision_from_settings`), never a
+    marketplace or a new consent subsystem. Returns ``None`` when the route
+    is not the credentialless free route or when the recorded per-version
+    authorization exists, so default-accepted deployments observe no change.
+    Only the evaluated privacy axis is ever reported; pricing/capability
+    axes need the trusted feed that has no production source yet and are
+    never fabricated here.
+    """
+    if str(provider_id or "").strip() != FREE_PROVIDER_ID:
+        return None
+    if zen_free_data_use_decision_from_settings(env=env) is not None:
+        return None
+    return "privacy:unaccepted_terms:" + ZEN_FREE_TERMS_VERSION
+
+
 def build_eligibility_input(
     *,
     qualified_id: str,
@@ -637,4 +661,5 @@ __all__ = [
     "recheck_frozen_attempt",
     "resolve_free_default_model",
     "zen_free_data_use_decision_from_settings",
+    "zen_free_route_blocked_reason",
 ]

--- a/moonmind/omnigent/bootstrap/free_model_eligibility.py
+++ b/moonmind/omnigent/bootstrap/free_model_eligibility.py
@@ -630,6 +630,132 @@ def resolve_free_default_model(
     raise NoEligibleFreeModelError(last_reasons)
 
 
+def catalog_ids_from_evidence(evidence: Mapping[str, Any] | None) -> list[str]:
+    """Extract exact qualified model IDs from persisted catalog evidence.
+
+    MoonLadderStudios/MoonMind#4021 req-1/req-3: production consumers thread
+    the exact observed catalog (``model_catalog_evidence_json``) through this
+    helper so execution selection can require an exact qualified-ID match.
+    Only well-formed ``provider/model`` strings are returned, sorted and
+    deduplicated; name fragments, display labels, and a successful list
+    request alone never qualify. Returns [] when no persisted catalog exists,
+    in which case callers defer to exact-host qualification instead of
+    inventing eligibility.
+    """
+    if not isinstance(evidence, Mapping):
+        return []
+    models = evidence.get("models")
+    if not isinstance(models, list):
+        return []
+    ids: list[str] = []
+    for item in models:
+        if isinstance(item, Mapping):
+            qid = str(item.get("qualifiedId") or "").strip()
+        else:
+            qid = str(item or "").strip()
+        if qid and "/" in qid and len(qid) <= 255 and qid not in ids:
+            ids.append(qid)
+    return sorted(ids)
+
+
+def require_exact_catalog_match(
+    qualified_id: str,
+    catalog_ids: list[str],
+) -> str:
+    """Require the exact qualified ID in the observed catalog (fail closed).
+
+    Raises :class:`NoEligibleFreeModelError` with the availability axis when
+    the observed catalog is non-empty and lacks the ID. An empty catalog
+    (no persisted evidence yet) is not proof of absence: it raises
+    :class:`FreeModelUnavailableError` so the caller defers to exact-host
+    qualification instead of blocking or fabricating eligibility.
+    """
+    wanted = qualified_id.strip()
+    if catalog_ids:
+        if wanted not in catalog_ids:
+            raise NoEligibleFreeModelError(
+                {"availability": f"not_in_catalog:{wanted}"}
+            )
+        return wanted
+    raise FreeModelUnavailableError(
+        f"Credentialless {FREE_PROFILE_ID} model {wanted!r} has no persisted "
+        "exact-host catalog yet; deferring to exact-host qualification.",
+        requested=wanted,
+    )
+
+
+def free_model_launch_gate(
+    *,
+    qualified_id: str,
+    catalog_ids: list[str],
+    requested_effort: str,
+    env: Mapping[str, Any] | None = None,
+) -> tuple[str, str]:
+    """Production launch gate for the credentialless free route.
+
+    MoonLadderStudios/MoonMind#4021 req-1/req-3/req-4: combines the three
+    axes with real production evidence before a new model send:
+
+    - availability: exact qualified-ID match in the observed catalog; an
+      empty catalog defers to exact-host qualification (non-blocking here).
+    - capability: effort validated against the selected model's actual
+      supported values, never the seeded default.
+    - privacy: the recorded per-policy-version authorization from the
+      existing Settings authority.
+
+    Pricing is deliberately NOT evaluated here: no trusted pricing feed has
+    a production source yet, and fabricating a zero would violate req-2.
+    Pricing/capability-feed axes stay hermetic-tested until that feed exists.
+    Raises :class:`NoEligibleFreeModelError` (failing axis) or
+    :class:`FreeModelUnavailableError` (deferred catalog), never substitutes.
+    """
+    from moonmind.omnigent.bootstrap.opencode import validate_effort_for_model
+
+    wanted = qualified_id.strip()
+    try:
+        require_exact_catalog_match(wanted, catalog_ids)
+    except FreeModelUnavailableError:
+        # No persisted catalog yet: exact-host qualification owns the
+        # availability verdict; keep enforcing effort and privacy here.
+        pass
+    try:
+        effort = validate_effort_for_model(requested_effort.strip(), wanted)
+    except ValueError as exc:
+        raise NoEligibleFreeModelError(
+            {"capability": f"unsupported_effort:{requested_effort.strip()}"}
+        ) from exc
+    privacy_reason = zen_free_route_blocked_reason(FREE_PROVIDER_ID, env=env)
+    if privacy_reason is not None:
+        raise NoEligibleFreeModelError({"privacy": privacy_reason})
+    return wanted, effort
+
+
+def recheck_resolved_free_attempt(
+    resolved: Any,
+    *,
+    catalog: Any,
+    pricing: Mapping[str, Any] | None,
+    data_use_version: str,
+    selection_policy_version: str = SELECTION_POLICY_VERSION,
+) -> tuple[bool, str]:
+    """Recheck the frozen bundle persisted with an attempt, if any.
+
+    Returns (True, "no_frozen_attempt") when the attempt carries no bundle
+    so first-time qualification proceeds; otherwise delegates to
+    :func:`recheck_frozen_attempt` without rewriting active inputs.
+    """
+    frozen = frozen_attempt_from_resolved(resolved)
+    if frozen is None:
+        return True, "no_frozen_attempt"
+    return recheck_frozen_attempt(
+        frozen,
+        catalog=catalog,
+        pricing=pricing,
+        data_use_version=data_use_version,
+        selection_policy_version=selection_policy_version,
+    )
+
+
 __all__ = [
     "FREE_MATERIALIZER_REF",
     "FREE_PROFILE_ID",
@@ -650,15 +776,19 @@ __all__ = [
     "attach_frozen_attempt_to_resolved",
     "build_eligibility_input",
     "build_live_qualification_record",
+    "catalog_ids_from_evidence",
     "evaluate_data_use",
     "evaluate_eligibility",
     "evaluate_pricing",
     "format_no_eligible_free_model",
     "freeze_attempt",
+    "free_model_launch_gate",
     "frozen_attempt_from_resolved",
     "parse_cost_value",
     "rank_approved_candidates",
     "recheck_frozen_attempt",
+    "recheck_resolved_free_attempt",
+    "require_exact_catalog_match",
     "resolve_free_default_model",
     "zen_free_data_use_decision_from_settings",
     "zen_free_route_blocked_reason",

--- a/moonmind/omnigent/bootstrap/free_model_eligibility.py
+++ b/moonmind/omnigent/bootstrap/free_model_eligibility.py
@@ -27,6 +27,11 @@ FREE_PROVIDER_ID = "opencode"
 FREE_MATERIALIZER_REF = "none@1"
 FREE_ROUTE_PREFIX = "opencode/"
 SELECTION_POLICY_VERSION = "free-model-selection.v1"
+# Terms version the current Settings/policy authority records acceptance for.
+# Bump only with an explicit operator-facing policy change; a version change
+# blocks new admission until the operator re-accepts, and never rewrites an
+# active attempt (MoonLadderStudios/MoonMind#4021 req-4/req-5).
+ZEN_FREE_TERMS_VERSION = "zen-terms.v3"
 
 NO_ELIGIBLE_FREE_MODEL_CODE = "no_eligible_free_model"
 
@@ -291,6 +296,224 @@ def freeze_attempt(
     )
 
 
+def zen_free_data_use_decision_from_settings(
+    env: Mapping[str, Any] | None = None,
+) -> DataUseDecision | None:
+    """Build the Zen free-route DataUseDecision from the existing authority.
+
+    MoonLadderStudios/MoonMind#4021 req-4: reuse the existing Settings/policy
+    authority (``OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE`` via
+    :func:`moonmind.omnigent.settings.opencode_contributor_data_use_accepted`),
+    not a marketplace or a new consent subsystem. Only an explicit accepted
+    decision for the exact :data:`ZEN_FREE_TERMS_VERSION` authorizes; existing
+    usage, a connected flag, or an automatically seeded profile is never
+    consent and therefore never consulted here.
+    """
+    from moonmind.omnigent.settings import opencode_contributor_data_use_accepted
+
+    try:
+        accepted = bool(opencode_contributor_data_use_accepted(env=env))
+    except ValueError:
+        return None
+    if not accepted:
+        return None
+    return DataUseDecision(
+        policy_version=ZEN_FREE_TERMS_VERSION,
+        accepted=True,
+        accepted_by="operator-settings",
+    )
+
+
+def build_eligibility_input(
+    *,
+    qualified_id: str,
+    catalog_ids: list[str],
+    pricing: Mapping[str, Any] | None,
+    inapplicable_dimensions: tuple[str, ...] = (),
+    requires_subscription_or_key: bool = False,
+    capabilities: tuple[str, ...] = (),
+    supported_efforts: tuple[str, ...] = (),
+    requested_effort: str = "xhigh",
+    terms_version: str = ZEN_FREE_TERMS_VERSION,
+    terms_require_approval: bool = True,
+    data_use_decision: DataUseDecision | None = None,
+) -> EligibilityInput:
+    """Build an EligibilityInput from the live exact-host catalog boundary.
+
+    ``catalog_ids`` is the exact observed catalog (qualified IDs). Presence in
+    it sets ``in_catalog``; nothing else (name matching, list-request success,
+    installed binaries) qualifies. Callers supply trusted pricing/terms
+    evidence alongside; omitted pricing dimensions stay unknown, never free.
+    """
+    wanted = qualified_id.strip()
+    return EligibilityInput(
+        qualified_id=wanted,
+        provider_id=wanted.split("/", 1)[0] if "/" in wanted else FREE_PROVIDER_ID,
+        materializer_ref=FREE_MATERIALIZER_REF,
+        in_catalog=wanted in catalog_ids,
+        pricing=pricing,
+        inapplicable_dimensions=inapplicable_dimensions,
+        requires_subscription_or_key=requires_subscription_or_key,
+        capabilities=capabilities,
+        supported_efforts=supported_efforts,
+        requested_effort=requested_effort,
+        terms_version=terms_version,
+        terms_require_approval=terms_require_approval,
+        data_use_decision=data_use_decision,
+    )
+
+
+def rank_approved_candidates(
+    candidates: Mapping[str, EligibilityInput],
+    *,
+    catalog_order: list[str],
+) -> tuple[str | None, dict[str, str]]:
+    """Rank a small approved set only after the data-use policy authorizes it.
+
+    Each candidate already carries its own exact-terms decision; a candidate
+    whose terms are unaccepted for its exact version is skipped with its
+    privacy reason preserved. Returns (selected_id, blocked_reasons). No
+    speculative quality ranking: deterministic catalog order decides.
+    """
+    blocked: dict[str, str] = {}
+    for qualified_id in catalog_order:
+        candidate = candidates.get(qualified_id)
+        if candidate is None:
+            blocked = {"availability": f"no_evidence:{qualified_id}"}
+            continue
+        verdict = evaluate_eligibility(candidate)
+        if verdict.eligible:
+            return qualified_id, {}
+        blocked = verdict.reasons
+    return None, blocked
+
+
+def attach_frozen_attempt_to_resolved(
+    resolved: Any,
+    frozen: FrozenFreeModelAttempt,
+) -> Any:
+    """Persist the frozen bundle with the admitted attempt (no rewrite).
+
+    Returns a copy of the given ``BootstrapResolved`` carrying
+    ``freeModelAttempt``. Discovery refresh creates a new frozen bundle for a
+    new attempt; it never mutates the active attempt in place.
+    """
+    payload = frozen.as_dict()
+    if hasattr(resolved, "model_copy"):
+        return resolved.model_copy(update={"free_model_attempt": payload})
+    if isinstance(resolved, dict):
+        updated = dict(resolved)
+        updated["freeModelAttempt"] = payload
+        return updated
+    raise TypeError("resolved must be a BootstrapResolved or mapping")
+
+
+def frozen_attempt_from_resolved(resolved: Any) -> FrozenFreeModelAttempt | None:
+    """Recover the frozen bundle persisted with an attempt, if any."""
+    payload: Any = None
+    if hasattr(resolved, "free_model_attempt"):
+        payload = getattr(resolved, "free_model_attempt")
+    elif isinstance(resolved, Mapping):
+        payload = resolved.get("freeModelAttempt", resolved.get("free_model_attempt"))
+    if not isinstance(payload, Mapping):
+        return None
+    try:
+        return FrozenFreeModelAttempt(
+            model_id=str(payload.get("modelId") or ""),
+            route=str(payload.get("route") or FREE_ROUTE_PREFIX.rstrip("/")),
+            materializer_ref=str(payload.get("materializerRef") or FREE_MATERIALIZER_REF),
+            catalog_digest=str(payload.get("catalogDigest") or ""),
+            pricing_digest=str(payload.get("pricingDigest") or ""),
+            data_use_version=str(payload.get("dataUseVersion") or ""),
+            selection_policy_version=str(
+                payload.get("selectionPolicyVersion") or SELECTION_POLICY_VERSION
+            ),
+            observed_at=str(payload.get("observedAt") or ""),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def recheck_frozen_attempt(
+    frozen: FrozenFreeModelAttempt,
+    *,
+    catalog: Any,
+    pricing: Mapping[str, Any] | None,
+    data_use_version: str,
+    selection_policy_version: str = SELECTION_POLICY_VERSION,
+) -> tuple[bool, str]:
+    """Authoritative recheck before a new model send or renewed attempt.
+
+    Compares the live catalog/pricing/data-use/policy evidence against the
+    frozen bundle without rewriting active inputs. Returns (current, reason):
+    current True means the frozen attempt is still authoritative; False names
+    the expired/changed axis so the caller can fail safely or start an
+    explicitly authorized new attempt preserving saved work. Never swaps
+    provider/model inside a billed request.
+    """
+    catalog_payload = catalog if isinstance(catalog, Mapping) else {"catalog": catalog}
+    pricing_payload = dict(pricing or {})
+    if frozen.selection_policy_version != selection_policy_version:
+        return False, "selection_policy_changed:" + selection_policy_version
+    if frozen.data_use_version != data_use_version:
+        return False, "privacy:terms_changed:" + data_use_version
+    if frozen.catalog_digest != _evidence_digest(
+        catalog_payload if isinstance(catalog_payload, Mapping) else {"v": str(catalog_payload)}
+    ):
+        return False, "availability:catalog_changed"
+    if frozen.pricing_digest != _evidence_digest(pricing_payload):
+        return False, "pricing:evidence_changed"
+    return True, "current"
+
+
+def build_live_qualification_record(
+    *,
+    qualified_id: str,
+    host_image_ref: str,
+    runtime_pack_ref: str,
+    materializer_ref: str = FREE_MATERIALIZER_REF,
+    pricing_evidence: Mapping[str, Any] | None = None,
+    data_use_version: str = ZEN_FREE_TERMS_VERSION,
+    data_use_authorized: bool = False,
+    catalog_max_age_hours: float | None = None,
+    probe_timeout_seconds: float = 60.0,
+    max_probe_attempts: int = 1,
+    blocked_cases: tuple[str, ...] = (),
+    unexecuted_cases: tuple[str, ...] = (),
+    observed_at: str | None = None,
+) -> dict[str, Any]:
+    """Build the bounded, non-sensitive live-qualification record shape.
+
+    MoonLadderStudios/MoonMind#4021 req-7: protected live qualification is
+    explicitly authorized, non-sensitive, and budgeted. This helper records
+    the exact model/image/runtime/materializer, pricing/privacy evidence
+    references, request bounds (lease/probe/budget), and blocked/unexecuted
+    cases truthfully. It performs no network or inference calls; hermetic
+    tests use it with inline fixtures only.
+    """
+    return {
+        "schemaVersion": "moonmind.free-model-live-qualification/v1",
+        "modelId": qualified_id,
+        "route": FREE_ROUTE_PREFIX.rstrip("/"),
+        "materializerRef": materializer_ref,
+        "hostImageRef": host_image_ref,
+        "runtimePackRef": runtime_pack_ref,
+        "pricingEvidence": dict(pricing_evidence or {}),
+        "dataUseVersion": data_use_version,
+        "dataUseAuthorized": bool(data_use_authorized),
+        "selectionPolicyVersion": SELECTION_POLICY_VERSION,
+        "bounds": {
+            "catalogMaxAgeHours": catalog_max_age_hours,
+            "probeTimeoutSeconds": probe_timeout_seconds,
+            "maxProbeAttempts": max_probe_attempts,
+            "singleFlight": True,
+        },
+        "blockedCases": list(blocked_cases),
+        "unexecutedCases": list(unexecuted_cases),
+        "observedAt": observed_at or datetime.now(UTC).isoformat(),
+    }
+
+
 def format_no_eligible_free_model(reasons: Mapping[str, str]) -> dict[str, Any]:
     """Expose the no_eligible_free_model signal with separate reason axes."""
     ordered = {k: reasons[k] for k in ("availability", "pricing", "capability", "privacy") if k in reasons}
@@ -392,6 +615,7 @@ __all__ = [
     "PRICING_DIMENSIONS",
     "REQUIRED_TOOLS",
     "SELECTION_POLICY_VERSION",
+    "ZEN_FREE_TERMS_VERSION",
     "DataUseDecision",
     "EligibilityInput",
     "EligibilityVerdict",
@@ -399,11 +623,18 @@ __all__ = [
     "FrozenFreeModelAttempt",
     "NoEligibleFreeModelError",
     "PricingVerdict",
+    "attach_frozen_attempt_to_resolved",
+    "build_eligibility_input",
+    "build_live_qualification_record",
     "evaluate_data_use",
     "evaluate_eligibility",
     "evaluate_pricing",
     "format_no_eligible_free_model",
     "freeze_attempt",
+    "frozen_attempt_from_resolved",
     "parse_cost_value",
+    "rank_approved_candidates",
+    "recheck_frozen_attempt",
     "resolve_free_default_model",
+    "zen_free_data_use_decision_from_settings",
 ]

--- a/moonmind/omnigent/bootstrap/models.py
+++ b/moonmind/omnigent/bootstrap/models.py
@@ -43,6 +43,13 @@ class BootstrapResolved(BaseModel):
     omnigent_build_digest: str | None = Field(default=None, alias="omnigentBuildDigest")
     architecture: str | None = None
     resolved_at: datetime | None = Field(default=None, alias="resolvedAt")
+    # MoonLadderStudios/MoonMind#4021 req-5: immutable free-model eligibility
+    # evidence frozen with the admitted credentialless attempt. None for
+    # keyed routes and for records written before this revision; discovery
+    # refresh never rewrites it in place (see recheck_frozen_attempt).
+    free_model_attempt: dict[str, Any] | None = Field(
+        default=None, alias="freeModelAttempt"
+    )
 
 
 class ResolvedOmnigentDeploymentState(BaseModel):

--- a/moonmind/omnigent/bootstrap/opencode.py
+++ b/moonmind/omnigent/bootstrap/opencode.py
@@ -15,7 +15,25 @@ ZEN_FREE_MODEL_DISPLAY = "Muse Spark 1.3 Contributor Free"
 ZEN_FREE_PROVIDER_ID = "muse-spark-1.3-contributor-free"
 ZEN_FREE_QUALIFIED = f"opencode/{ZEN_FREE_PROVIDER_ID}"
 
-# Friendly name normalization: case-insensitive, punctuation-insensitive
+# Known per-model supported effort values. Generic validation must use the
+# selected model's actual values rather than assuming seeded xhigh applies
+# everywhere (MoonLadderStudios/MoonMind#4021).
+KNOWN_MODEL_EFFORTS: dict[str, tuple[str, ...]] = {
+    DEFAULT_OPENCODE_QUALIFIED: ("minimal", "low", "medium", "high", "xhigh"),
+    ZEN_FREE_QUALIFIED: ("minimal", "low", "medium", "high", "xhigh"),
+}
+
+
+def get_supported_efforts(qualified_id: str) -> tuple[str, ...] | None:
+    """Return the known supported efforts for a qualified model, if known."""
+    return KNOWN_MODEL_EFFORTS.get(qualified_id.strip())
+
+
+# Friendly name normalization: case-insensitive, punctuation-insensitive.
+# Display-only: friendly labels and aliases may help display or classified
+# historical loading, but punctuation-normalized collisions must never choose
+# a different model/provider for execution (MoonLadderStudios/MoonMind#4021).
+# Execution selection uses resolve_model_exact below.
 def normalize_model_display(name: str) -> str:
     return re.sub(r"[^a-z0-9]", "", name.lower())
 
@@ -44,23 +62,88 @@ _MODEL_ALIASES = {
 }
 
 
+def _route_label(qualified_or_display: str) -> str:
+    text = qualified_or_display.strip()
+    provider_prefix = text.split("/", 1)[0].strip() if "/" in text else ""
+    if (
+        text == ZEN_FREE_QUALIFIED
+        or provider_prefix == "opencode"
+        or normalize_model_display(text)
+        in {
+            normalize_model_display(ZEN_FREE_MODEL_DISPLAY),
+            normalize_model_display(ZEN_FREE_QUALIFIED),
+        }
+    ):
+        return "the credentialless opencode-zen-free route"
+    return "this OpenCode Go account"
+
+
+def resolve_model_exact(
+    qualified_id: str,
+    available_models: list[dict[str, Any]] | None,
+) -> dict[str, str]:
+    """Resolve one exact qualified model ID for execution selection.
+
+    MoonLadderStudios/MoonMind#4021: execution selection uses exact IDs only.
+    Punctuation-normalized collisions, friendly labels, catalog presence of a
+    different ID, a name containing "free", a successful list request, or an
+    installed binary never qualifies a model. ``available_models`` is required
+    (the exact runtime/provider catalog); a missing catalog fails closed.
+    """
+    wanted = qualified_id.strip()
+    if not wanted or "/" not in wanted:
+        raise ValueError(
+            f"Requested model {qualified_id!r} is unavailable: execution selection "
+            "requires an exact qualified model ID (provider/model)."
+        )
+    if available_models is None:
+        raise ValueError(
+            f"Requested model {wanted!r} is unavailable: no exact catalog is "
+            "available, so eligibility cannot be established."
+        )
+    for entry in available_models:
+        qid = str(entry.get("qualifiedId") or "").strip()
+        if qid == wanted:
+            provider_id = qid.split("/", 1)[-1]
+            return {
+                "displayName": str(entry.get("displayName") or qid),
+                "providerModelId": provider_id,
+                "qualifiedId": qid,
+            }
+    alternatives = ", ".join(
+        str(m.get("qualifiedId") or "") for m in available_models[:5]
+    )
+    raise ValueError(
+        f"Requested model {wanted!r} is unavailable for {_route_label(wanted)}. "
+        f"Available: {alternatives or 'none'}"
+    )
+
+
 def resolve_model_by_display(
     display: str,
     available_models: list[dict[str, Any]] | None = None,
 ) -> dict[str, str]:
     """Resolve friendly display name to provider and qualified IDs.
 
-    If available_models is provided (from live catalog), verify existence.
-    Otherwise, use alias table.
+    Display-only helper: friendly labels and aliases may help display or
+    classified historical loading. Execution selection must use
+    :func:`resolve_model_exact` with the exact catalog ID instead of relying
+    on punctuation-insensitive alias collisions.
+
+    If available_models is provided (from live catalog), verify existence
+    with an exact qualified-ID match. Otherwise, use alias table.
     """
     normalized = normalize_model_display(display)
     alias = _MODEL_ALIASES.get(normalized)
     if alias is None:
-        # Try to find in available list directly by qualified or provider id
+        # Try to find in available list by exact qualified ID only. A
+        # punctuation-normalized collision must never select a different
+        # model/provider for execution.
         if available_models:
+            wanted = display.strip()
             for m in available_models:
                 qid = str(m.get("qualifiedId") or "").strip()
-                if normalize_model_display(qid) == normalized or qid.lower() == display.lower().strip():
+                if qid == wanted:
                     # Extract provider id after slash
                     provider_id = qid.split("/", 1)[-1] if "/" in qid else qid
                     return {
@@ -73,27 +156,31 @@ def resolve_model_by_display(
         if (
             available_models is None
             and separator
-            and provider_prefix.startswith("opencode-")
+            and provider_prefix == "opencode-go"
             and provider_model_id
         ):
             # Bootstrap resolves images before live credential-scoped model
-            # validation. Preserve a current Provider Profile's canonical model
-            # identity here; qualification still fails closed if the later live
-            # catalog does not contain it.
+            # validation. Preserve a current keyed Provider Profile's canonical
+            # model identity here; qualification still fails closed if the
+            # later live catalog does not contain it. The credentialless
+            # opencode/* route is never preserved pre-validation: it must come
+            # from the exact observed catalog (MoonLadderStudios/MoonMind#4021).
             return {
                 "displayName": qualified,
                 "providerModelId": provider_model_id,
                 "qualifiedId": qualified,
             }
-        raise ValueError(f"Requested model is unavailable for this OpenCode Go account: {display!r}")
-    # If catalog available, verify alias exists in catalog
+        raise ValueError(
+            f"Requested model {display!r} is unavailable for {_route_label(display)}"
+        )
+    # If catalog available, verify alias exists in catalog via exact match.
     if available_models is not None:
         qualified = alias["qualifiedId"]
         if not any(str(m.get("qualifiedId") or "") == qualified for m in available_models):
             # Provide live alternatives in error detail
             alternatives = ", ".join(str(m.get("qualifiedId") or "") for m in available_models[:5])
             raise ValueError(
-                f"Requested model {display!r} is unavailable for this OpenCode Go account. "
+                f"Requested model {display!r} is unavailable for {_route_label(display)}. "
                 f"Available: {alternatives or 'none'}"
             )
     return alias
@@ -107,3 +194,17 @@ def validate_effort(effort: str, available_efforts: list[str] | None = None) -> 
     if available_efforts is not None and normalized not in {e.lower() for e in available_efforts}:
         raise ValueError(f"effort {effort!r} is not supported by the selected model")
     return normalized
+
+
+def validate_effort_for_model(effort: str, qualified_id: str) -> str:
+    """Validate effort against the selected model's actual supported values.
+
+    MoonLadderStudios/MoonMind#4021: the seeded xhigh default must not be
+    assumed for every model. Known models use their recorded values; unknown
+    models fall back to the generic set and still fail closed on unknown
+    effort names.
+    """
+    supported = get_supported_efforts(qualified_id)
+    if supported is None:
+        return validate_effort(effort)
+    return validate_effort(effort, available_efforts=list(supported))

--- a/moonmind/omnigent/bootstrap/opencode.py
+++ b/moonmind/omnigent/bootstrap/opencode.py
@@ -186,6 +186,30 @@ def resolve_model_by_display(
     return alias
 
 
+def resolve_bootstrap_model(
+    display: str,
+    available_models: list[dict[str, Any]] | None = None,
+) -> dict[str, str]:
+    """Resolve one bootstrap model through the coordinated first-result path.
+
+    MoonLadderStudios/MoonMind#4021 req-1/req-3: the credentialless
+    ``opencode/*`` route never resolves pre-validation. A qualified
+    ``opencode/<model>`` request requires the exact observed catalog and an
+    exact qualified-ID match via :func:`resolve_model_exact`; otherwise it
+    fails closed with an actionable error instead of silently substituting.
+    Display aliases remain valid only for the keyed ``opencode-go`` route and
+    for historical/display loading, never for credentialless execution
+    selection.
+    """
+    text = display.strip()
+    if "/" in text and text.split("/", 1)[0].strip() == "opencode":
+        # Credentialless route: exact catalog match is mandatory, even when
+        # the alias table happens to contain the seeded ID. This gates the
+        # obsolete pre-validation display path for this route.
+        return resolve_model_exact(text, available_models)
+    return resolve_model_by_display(display, available_models)
+
+
 def validate_effort(effort: str, available_efforts: list[str] | None = None) -> str:
     normalized = effort.strip().lower()
     allowed = {"minimal", "low", "medium", "high", "xhigh"}

--- a/moonmind/omnigent/harness_platform/planning_service.py
+++ b/moonmind/omnigent/harness_platform/planning_service.py
@@ -53,6 +53,11 @@ from moonmind.omnigent.harness_platform.stores import (
     ExecutionPlanUsageIdentity,
     OmnigentExecutionPlanUsageStore,
 )
+from moonmind.omnigent.bootstrap.free_model_eligibility import (
+    FREE_PROFILE_ID,
+    NO_ELIGIBLE_FREE_MODEL_CODE,
+    zen_free_route_blocked_reason,
+)
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.executions.model_resolver import resolve_model_effort
 
@@ -739,6 +744,23 @@ class OmnigentExecutionPlanningService:
         if not qualified.startswith(f"{provider.provider_id}/"):
             raise HarnessPlatformError(
                 "selected model does not belong to the Provider Profile route",
+                code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+            )
+        blocked_reason = zen_free_route_blocked_reason(
+            str(getattr(provider, "provider_id", "") or "")
+        )
+        if blocked_reason is not None:
+            # MoonLadderStudios/MoonMind#4021 req-4: the credentialless free
+            # route needs the recorded per-policy-version authorization from
+            # the existing Settings authority. Default deployments accept, so
+            # they observe no change; an explicit operator decline blocks new
+            # admission with a precise privacy reason instead of silently
+            # proceeding or substituting a paid fallback.
+            raise HarnessPlatformError(
+                f"the credentialless {FREE_PROFILE_ID} default is blocked "
+                f"({NO_ELIGIBLE_FREE_MODEL_CODE}: {blocked_reason}). Re-accept "
+                "contributor data use in Settings or choose an explicit valid "
+                "alternative.",
                 code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
             )
         effort = str(resolved.effort or "").strip() or None

--- a/moonmind/omnigent/harness_platform/planning_service.py
+++ b/moonmind/omnigent/harness_platform/planning_service.py
@@ -55,7 +55,10 @@ from moonmind.omnigent.harness_platform.stores import (
 )
 from moonmind.omnigent.bootstrap.free_model_eligibility import (
     FREE_PROFILE_ID,
+    FREE_PROVIDER_ID,
     NO_ELIGIBLE_FREE_MODEL_CODE,
+    catalog_ids_from_evidence,
+    require_exact_catalog_match,
     zen_free_route_blocked_reason,
 )
 from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
@@ -764,7 +767,53 @@ class OmnigentExecutionPlanningService:
                 code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
             )
         effort = str(resolved.effort or "").strip() or None
+        OmnigentExecutionPlanningService._enforce_free_route_exact_catalog(
+            provider, qualified
+        )
         return qualified, effort, provider.provider_id
+
+    @staticmethod
+    def _enforce_free_route_exact_catalog(provider: Any, qualified: str) -> None:
+        """Require the exact observed catalog ID before launching free-route.
+
+        MoonLadderStudios/MoonMind#4021 req-1/req-3: plan-time admission
+        threads the Provider Profile's persisted exact-host catalog
+        (``model_catalog_evidence_json``) into execution selection through
+        :func:`require_exact_catalog_match`, so punctuation-normalized
+        collisions and name/catalog-presence heuristics cannot qualify a
+        different model/provider. A profile with no persisted catalog yet
+        defers to exact-host qualification (non-blocking here); a persisted
+        catalog that lacks the selected ID fails closed with the
+        ``no_eligible_free_model`` availability axis instead of silently
+        substituting. Never selects a paid fallback.
+        """
+        if str(getattr(provider, "provider_id", "") or "") != FREE_PROVIDER_ID:
+            return
+        catalog_ids = catalog_ids_from_evidence(
+            getattr(provider, "model_catalog_evidence_json", None)
+        )
+        if not catalog_ids:
+            return
+        try:
+            require_exact_catalog_match(qualified, catalog_ids)
+        except Exception as exc:
+            from moonmind.omnigent.bootstrap.free_model_eligibility import (
+                FreeModelUnavailableError,
+                NoEligibleFreeModelError,
+            )
+
+            if isinstance(exc, FreeModelUnavailableError):
+                return
+            if isinstance(exc, NoEligibleFreeModelError):
+                raise HarnessPlatformError(
+                    f"the credentialless {FREE_PROFILE_ID} model {qualified!r} "
+                    f"is not in the exact observed catalog "
+                    f"({NO_ELIGIBLE_FREE_MODEL_CODE}: "
+                    f"{exc.details.get('reasons', {})}). Choose an explicit "
+                    "valid alternative.",
+                    code=HarnessPlatformFailure.OMNIGENT_MODEL_UNAVAILABLE,
+                ) from exc
+            raise
 
     @staticmethod
     def _require_durable_legacy_authority(document: Mapping[str, Any]) -> None:

--- a/moonmind/provider_profiles/isolation_policy.py
+++ b/moonmind/provider_profiles/isolation_policy.py
@@ -139,6 +139,19 @@ _STRATEGY_TABLE: dict[tuple[str, str, str], tuple[str, ...]] = {
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",
     ),
+    # MoonLadderStudios/MoonMind#4021: the credentialless Zen route must still
+    # clear ambient model keys/auth caches at the launch boundary, including
+    # inherited OpenCode configuration and OPENCODE_API_KEY (which may only
+    # configure the separate keyed opencode-go profile, never rescue this
+    # attempt). An empty policy would clear nothing.
+    ("opencode", "opencode", "none"): (
+        "OPENCODE_API_KEY",
+        "OPENCODE_AUTH_CONTENT",
+        "OPENCODE_CONFIG",
+        "OPENCODE_CONFIG_CONTENT",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    ),
     ("codex_cli", "openrouter", "api_key"): (
         "OPENAI_API_KEY",
         "OPENAI_BASE_URL",
@@ -251,23 +264,40 @@ def derive_isolation_policy(
 ) -> IsolationPolicy | None:
     """Derive the canonical policy for a known strategy, or None if unknown.
 
-    ``authentication_method`` ``none`` (credential-free) derives an empty
-    policy. Unknown runtime/provider/method combinations return None so
-    callers fail closed instead of guessing.
+    Credential-free (``none``) strategies resolve through the same canonical
+    table so a credentialless launch still clears ambient keys (for example
+    the opencode/opencode/none Zen route). Unknown runtime/provider/method
+    combinations return None so callers fail closed instead of guessing.
     """
     runtime = _normalized(runtime_id)
     provider = _normalized(provider_id)
     method = _normalized(authentication_method)
-    if method == "none":
-        return IsolationPolicy(
-            keys=(),
-            strategy_id=f"{runtime}/{provider}/none",
-            explanations={},
-        )
-    # Credential-free materialization without an explicit none method still
-    # derives an empty policy when the contract is coherent.
-    if not method and _normalized(credential_source) == "none":
-        return IsolationPolicy(keys=(), strategy_id=f"{runtime}/{provider}/none", explanations={})
+    if method == "none" or (
+        not method and _normalized(credential_source) == "none"
+    ):
+        effective_method = "none"
+        if runtime and provider:
+            keys = _STRATEGY_TABLE.get((runtime, provider, effective_method))
+            if keys is not None:
+                return IsolationPolicy(
+                    keys=tuple(keys),
+                    strategy_id=f"{runtime}/{provider}/{effective_method}",
+                    explanations={
+                        k: _KEY_EXPLANATIONS.get(k, "Backend-owned launch isolation.")
+                        for k in keys
+                    },
+                )
+        # Unknown credential-free strategy: empty policy only when the
+        # contract is coherent, otherwise fail closed via None.
+        if not runtime or not provider:
+            return None
+        if _normalized(credential_source) in {"", "none"}:
+            return IsolationPolicy(
+                keys=(),
+                strategy_id=f"{runtime}/{provider}/none",
+                explanations={},
+            )
+        return None
     if not runtime or not provider or not method:
         return None
     keys = _STRATEGY_TABLE.get((runtime, provider, method))

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -34,6 +34,7 @@ from moonmind.workflows.executions.runtime_defaults import (
 __all__ = [
     "RequestedModelTierUnavailableError",
     "ResolvedModelEffort",
+    "coerce_effort_for_model",
     "provider_profile_version",
     "resolve_effective_model",
     "resolve_model_effort",
@@ -310,6 +311,36 @@ def resolve_model_effort(
         advisory_preview,
         profile=profile,
     )
+
+
+def coerce_effort_for_model(model: str | None, effort: str | None) -> str | None:
+    """Validate effort against the selected model's actual supported values.
+
+    MoonLadderStudios/MoonMind#4021 req-3: the seeded ``xhigh`` default must
+    not be assumed for every model. Known OpenCode models use their recorded
+    values via ``validate_effort_for_model``; unknown models and non-OpenCode
+    routes fall back to the generic validator. Exact-ID execution selection
+    itself stays with the bootstrap/profile/plan consumers
+    (``resolve_model_exact``); this helper only coerces effort truthfully.
+    """
+    if effort is None:
+        return None
+    cleaned_model = str(model or "").strip()
+    cleaned_effort = str(effort or "").strip()
+    if not cleaned_effort:
+        return effort
+    if not cleaned_model or "/" not in cleaned_model:
+        from moonmind.omnigent.bootstrap.opencode import validate_effort
+
+        return validate_effort(cleaned_effort)
+    try:
+        from moonmind.omnigent.bootstrap.opencode import validate_effort_for_model
+
+        return validate_effort_for_model(cleaned_effort, cleaned_model)
+    except ImportError:
+        from moonmind.omnigent.bootstrap.opencode import validate_effort  # type: ignore[no-redef]
+
+        return validate_effort(cleaned_effort)
 
 
 def _clean(value: Any | None) -> str | None:

--- a/moonmind/workflows/executions/model_resolver.py
+++ b/moonmind/workflows/executions/model_resolver.py
@@ -38,6 +38,7 @@ __all__ = [
     "provider_profile_version",
     "resolve_effective_model",
     "resolve_model_effort",
+    "resolve_opencode_effort",
 ]
 
 # legacy_run contract — the model_source value "task_override" is persisted in
@@ -216,7 +217,7 @@ def resolve_model_effort(
         return _with_preview_mismatch(
             ResolvedModelEffort(
                 model=model,
-                effort=effort,
+                effort=resolve_opencode_effort(model, effort),
                 requested_model_tier=requested_tier,
                 effective_model_tier=None,
                 tier_label=None,
@@ -264,7 +265,7 @@ def resolve_model_effort(
         return _with_preview_mismatch(
             ResolvedModelEffort(
                 model=model,
-                effort=effort,
+                effort=resolve_opencode_effort(model, effort),
                 requested_model_tier=requested_tier,
                 effective_model_tier=effective_tier,
                 tier_label=tier_label,
@@ -298,7 +299,7 @@ def resolve_model_effort(
     return _with_preview_mismatch(
         ResolvedModelEffort(
             model=model,
-            effort=effort,
+            effort=resolve_opencode_effort(model, effort),
             requested_model_tier=requested_tier,
             effective_model_tier=None,
             tier_label=None,
@@ -341,6 +342,21 @@ def coerce_effort_for_model(model: str | None, effort: str | None) -> str | None
         from moonmind.omnigent.bootstrap.opencode import validate_effort  # type: ignore[no-redef]
 
         return validate_effort(cleaned_effort)
+
+
+def resolve_opencode_effort(model: str | None, effort: str | None) -> str | None:
+    """Enforce per-model effort for the credentialless OpenCode route.
+
+    MoonLadderStudios/MoonMind#4021 req-3: the seeded ``xhigh`` default must
+    not be assumed for every model. Models on the ``opencode/`` route resolve
+    effort against the selected model's actual supported values via
+    :func:`coerce_effort_for_model` and fail closed with an actionable error
+    instead of silently substituting. All other runtimes keep their existing
+    pass-through behavior unchanged.
+    """
+    if effort is None or not str(model or "").strip().startswith("opencode/"):
+        return effort
+    return coerce_effort_for_model(model, effort)
 
 
 def _clean(value: Any | None) -> str | None:

--- a/omnigent-evidence/deployment-execution-evidence.json
+++ b/omnigent-evidence/deployment-execution-evidence.json
@@ -1,0 +1,57 @@
+{
+  "entries": [
+    {
+      "compatibilityGeneration": "omnigent-generic-host/1",
+      "deploymentId": "local-default",
+      "effectiveLaunchSnapshotDigest": "sha256:25b2a0b7b27c30de5fd32e5bf737e49a263dd6663bc69490e4411916df8e02a1",
+      "evidenceIssuer": "moonmind-deployment-bootstrap@1",
+      "evidenceRefs": {
+        "readRun": "artifact:read-run"
+      },
+      "expiresAt": "2026-10-11T14:13:51.092578Z",
+      "featureGeneration": "omnigent-session-v1",
+      "generatedAt": "2026-09-11T14:13:51.092578Z",
+      "hostImageRef": "ghcr.io/example/omnigent-host@sha256:7777777777777777777777777777777777777777777777777777777777777777",
+      "model": {
+        "effort": "xhigh",
+        "qualifiedId": "example/model"
+      },
+      "policySnapshotDigest": "sha256:41a2496c2456d5b92543b5bd99ad81b08d190d8e6e9086751e01ed3b41737eb8",
+      "provider": {
+        "credentialGeneration": 1,
+        "profileRef": "provider-opencode-native"
+      },
+      "replayCompatibilityVersion": "v1",
+      "results": {
+        "readQualification": "passed"
+      },
+      "rollbackPolicyVersion": "moonmind.omnigent-session-supervisor-rollback/v1",
+      "schemaVersion": "moonmind.omnigent-deployment-execution-evidence/v1",
+      "signature": {
+        "algorithm": "hmac-sha256",
+        "keyId": "moonmind-deployment-evidence-v1",
+        "value": "5f46b067aac61789e6e038b0d0b995f57099bdc14575325730eaca433e17fa05"
+      },
+      "supportCombinationKey": "omnigent-support:sha256:75aa8aa595e517c9a6a43ce766575cfe11d0dd92d58790e92f17fc198fc1f0cf",
+      "supportIdentity": {
+        "agentSourceRef": "agent-source:sha256:7ec3f751ea6480a88a8d6e96377102cb15fe1ab72a350c321232e51b7cb981bf",
+        "architecture": "linux/amd64",
+        "executionRealizerRef": "generic-omnigent-host@1",
+        "harnessImplementationRef": "omnigent-harness-implementation:sha256:1ba00c4fb60e4015cb576e93a61c4f767e30f716a8838eb53cbfc80ddf6f9429",
+        "hostClassRef": "omnigent-opencode@1",
+        "launchPolicyRef": "omnigent-on-demand@1",
+        "materializerRefs": [
+          "opencode-auth-json@1"
+        ],
+        "modelConfigDigest": "sha256:ef6977f562a0a5c282129a7125359bf3fa3cba5972aa9f79334e890627da9dfe",
+        "omnigentHostBuildRef": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "omnigentServerBuildRef": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "providerCompatibilityClass": "opencode-native.primary-model",
+        "requiredCapabilitiesDigest": "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+        "vendorRuntimeRefs": [
+          "opencode@1.18.11#sha256:7777777777777777777777777777777777777777777777777777777777777777"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/integration/omnigent/test_deployment_key_rotation.py
+++ b/tests/integration/omnigent/test_deployment_key_rotation.py
@@ -82,7 +82,10 @@ async def test_environment_key_rotation_reaches_runtime_authority(
         AsyncMock(return_value="omnigent-opencode-default@1"),
     )
     qualification = AsyncMock(
-        return_value={"supportCombinationKey": "test-support-combination"}
+        side_effect=lambda **kwargs: (
+            {"supportCombinationKey": "test-support-combination"},
+            kwargs["record"],
+        )
     )
     monkeypatch.setattr(controller, "_qualify_and_publish", qualification)
 

--- a/tests/unit/api/routers/test_omnigent_catalog.py
+++ b/tests/unit/api/routers/test_omnigent_catalog.py
@@ -1254,6 +1254,35 @@ def test_catalog_admits_the_credentialless_opencode_zen_profile(monkeypatch):
     assert body["ineligibleProviderProfiles"] == []
 
 
+def test_catalog_blocks_declined_free_route_with_precise_privacy_reason(monkeypatch):
+    """MoonLadderStudios/MoonMind#4021 req-4/req-5: an explicit operator
+    decline of contributor data use surfaces the credentialless default as
+    ineligible with the evaluated privacy reason, never a capacity wait or a
+    paid fallback."""
+
+    zen = _profile(
+        profile_id="opencode-zen-free",
+        account_label="OpenCode Zen Contributor Free",
+        provider_label="OpenCode Zen",
+        provider_id="opencode",
+        runtime_id="opencode",
+        credential_source=SimpleNamespace(value="none"),
+        runtime_materialization_mode=SimpleNamespace(value="composite"),
+    )
+    monkeypatch.setenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", "false")
+    app = _app(monkeypatch, session=_Session([zen]))
+
+    body = TestClient(app).get("/api/omnigent/codex-catalog-readiness").json()
+
+    assert body["eligibleProviderProfiles"] == []
+    assert [item["profileId"] for item in body["ineligibleProviderProfiles"]] == [
+        "opencode-zen-free"
+    ]
+    reasons = body["ineligibleProviderProfiles"][0]["gateReasons"]
+    assert [reason["code"] for reason in reasons] == ["no_eligible_free_model"]
+    assert "privacy=privacy:unaccepted_terms:" in reasons[0]["message"]
+
+
 def test_catalog_still_rejects_an_unregistered_credentialless_runtime(monkeypatch):
     """`credential_source == "none"` is not a blanket eligibility escape hatch."""
 

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -176,6 +176,14 @@ def qualification_boundary(monkeypatch, tmp_path):
     import moonmind.omnigent.bootstrap.store as store_module
     from moonmind.omnigent.harness_platform import catalog_service
 
+    import moonmind.omnigent.bootstrap.controller as controller_module_for_fixture
+
+    monkeypatch.setattr(
+        controller_module_for_fixture,
+        "save_bootstrap_record",
+        lambda _record: None,
+    )
+
     state = SimpleNamespace(session=_Session(_version_row(_profile_document())))
 
     @asynccontextmanager
@@ -243,6 +251,35 @@ async def _qualify(
     provider_profile_ref: str = "opencode-go-default",
     qualified_model: str = "opencode-go/muse-spark-1.2-contributor",
 ) -> dict:
+    from moonmind.omnigent.bootstrap.models import BootstrapRecord
+
+    controller = controller_module.BootstrapController(
+        session_factory=state.session_factory
+    )
+    evidence, _record = await controller._qualify_and_publish(
+        provider_profile_ref=provider_profile_ref,
+        qualified_model=qualified_model,
+        effort="xhigh",
+        resolved=_resolved_state(),
+        record=BootstrapRecord(),
+    )
+    return evidence
+
+
+async def _qualify_with_record(
+    state,
+    *,
+    provider_profile_ref: str = "opencode-go-default",
+    qualified_model: str = "opencode-go/muse-spark-1.2-contributor",
+):
+    """Qualify while returning the updated bootstrap record.
+
+    MoonLadderStudios/MoonMind#4021 req-5: the credentialless route freezes
+    its eligibility evidence bundle on the admitted attempt; this helper
+    exposes the persisted record so tests can prove the bundle round-trips.
+    """
+    from moonmind.omnigent.bootstrap.models import BootstrapRecord
+
     controller = controller_module.BootstrapController(
         session_factory=state.session_factory
     )
@@ -251,7 +288,7 @@ async def _qualify(
         qualified_model=qualified_model,
         effort="xhigh",
         resolved=_resolved_state(),
-        record=SimpleNamespace(),
+        record=BootstrapRecord(),
     )
 
 
@@ -301,6 +338,47 @@ async def test_qualification_attests_the_selected_provider_route(
             normalizedOptions={},
         )
     )
+
+    # MoonLadderStudios/MoonMind#4021 req-5: the admitted credentialless
+    # attempt freezes its evidence bundle with the record through the real
+    # qualification path (exact-ID check + attach + recheck, no rewrite of
+    # active inputs).
+    from moonmind.omnigent.bootstrap.free_model_eligibility import (
+        SELECTION_POLICY_VERSION,
+        ZEN_FREE_TERMS_VERSION,
+        frozen_attempt_from_resolved,
+        recheck_frozen_attempt,
+    )
+
+    _evidence2, record = await _qualify_with_record(
+        qualification_boundary,
+        provider_profile_ref="opencode-zen-free",
+        qualified_model=qualified_model,
+    )
+    frozen = frozen_attempt_from_resolved(record.resolved)
+    assert frozen is not None
+    assert frozen.model_id == qualified_model
+    assert frozen.materializer_ref == "none@1"
+    assert frozen.data_use_version == ZEN_FREE_TERMS_VERSION
+    assert frozen.selection_policy_version == SELECTION_POLICY_VERSION
+    # The fixture profile carries no persisted catalog yet, so the bundle
+    # froze the observed empty evidence; rechecking identical evidence is
+    # current, changed evidence expires it without rewriting active inputs.
+    current, _ = recheck_frozen_attempt(
+        frozen,
+        catalog={"ids": []},
+        pricing={},
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    assert current is True
+    expired, expired_reason = recheck_frozen_attempt(
+        frozen,
+        catalog={"ids": [qualified_model]},
+        pricing={},
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    assert expired is False
+    assert "catalog" in expired_reason
 
 
 @pytest.mark.asyncio
@@ -1402,7 +1480,9 @@ async def test_launchable_materializer_classes_are_qualified_once(
     controller = controller_module.BootstrapController(
         session_factory=lambda: _session_scope()
     )
-    qualify = AsyncMock(return_value={})
+    qualify = AsyncMock(
+        side_effect=lambda **kwargs: ({}, kwargs["record"])
+    )
     monkeypatch.setattr(controller, "_qualify_and_publish", qualify)
 
     record = _ready_bootstrap_record(agent_profile_ref="omnigent-opencode-default@8")

--- a/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
+++ b/tests/unit/omnigent/test_bootstrap_deployment_qualification.py
@@ -555,6 +555,13 @@ async def test_requalification_follows_the_current_default_provider_profile(
         credential_source=ProviderCredentialSource.SECRET_REF,
         runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
         secret_refs={"opencode_api_key": "db://opencode-go-default-api-key"},
+        clear_env_keys=[
+            "OPENCODE_AUTH_CONTENT",
+            "OPENCODE_CONFIG",
+            "OPENCODE_CONFIG_CONTENT",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ],
         default_model="opencode-go/muse-spark-1.2-contributor",
         default_effort="xhigh",
     )
@@ -566,6 +573,14 @@ async def test_requalification_follows_the_current_default_provider_profile(
         credential_source=ProviderCredentialSource.NONE,
         runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
         secret_refs={},
+        clear_env_keys=[
+            "OPENCODE_API_KEY",
+            "OPENCODE_AUTH_CONTENT",
+            "OPENCODE_CONFIG",
+            "OPENCODE_CONFIG_CONTENT",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ],
         default_model="opencode/muse-spark-1.2-contributor-free",
         default_effort="xhigh",
     )
@@ -816,6 +831,14 @@ async def test_credentialless_default_initializes_deployment_qualification(
         credential_source=ProviderCredentialSource.NONE,
         runtime_materialization_mode=RuntimeMaterializationMode.COMPOSITE,
         secret_refs={},
+        clear_env_keys=[
+            "OPENCODE_API_KEY",
+            "OPENCODE_AUTH_CONTENT",
+            "OPENCODE_CONFIG",
+            "OPENCODE_CONFIG_CONTENT",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ],
         command_behavior={
             "auth_readiness": {
                 "connected": True,

--- a/tests/unit/omnigent/test_free_model_eligibility_4021.py
+++ b/tests/unit/omnigent/test_free_model_eligibility_4021.py
@@ -1,0 +1,273 @@
+"""Hermetic coverage for MoonLadderStudios/MoonMind#4021.
+
+Qualify the existing free OpenCode route with explicit pricing and privacy
+policy. No external inference calls; all catalog/pricing/terms inputs are
+inline fixtures.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from moonmind.omnigent.bootstrap.free_model_eligibility import (
+    DataUseDecision,
+    EligibilityInput,
+    FreeModelUnavailableError,
+    NoEligibleFreeModelError,
+    evaluate_eligibility,
+    evaluate_pricing,
+    format_no_eligible_free_model,
+    freeze_attempt,
+    parse_cost_value,
+    resolve_free_default_model,
+)
+from moonmind.omnigent.bootstrap.opencode import (
+    ZEN_FREE_QUALIFIED,
+    get_supported_efforts,
+    resolve_model_by_display,
+    resolve_model_exact,
+    validate_effort_for_model,
+)
+from moonmind.provider_profiles.isolation_policy import derive_isolation_policy
+
+
+ZERO_PRICING = {
+    "request": 0,
+    "input_token": 0,
+    "output_token": 0,
+    "cache_read": 0,
+    "cache_write": 0,
+    "reasoning": 0,
+    "tool": 0,
+}
+
+
+def _eligible_candidate(**overrides) -> EligibilityInput:
+    base = {
+        "qualified_id": ZEN_FREE_QUALIFIED,
+        "in_catalog": True,
+        "pricing": dict(ZERO_PRICING),
+        "capabilities": ("read", "write", "shell"),
+        "supported_efforts": ("minimal", "low", "medium", "high", "xhigh"),
+        "requested_effort": "xhigh",
+        "terms_version": "zen-terms.v3",
+        "terms_require_approval": True,
+        "data_use_decision": DataUseDecision(
+            policy_version="zen-terms.v3",
+            accepted=True,
+            accepted_at="2026-09-10T00:00:00Z",
+            accepted_by="operator",
+        ),
+    }
+    base.update(overrides)
+    return EligibilityInput(**base)
+
+
+def test_parse_cost_value_treats_unknown_as_none_not_zero() -> None:
+    assert parse_cost_value(None) is None
+    assert parse_cost_value("") is None
+    assert parse_cost_value("free") is None
+    assert parse_cost_value("nan") is None
+    assert parse_cost_value("inf") is None
+    assert parse_cost_value(float("nan")) is None
+    assert parse_cost_value(float("inf")) is None
+    assert parse_cost_value(-1) is None
+    assert parse_cost_value("-0.5") is None
+    assert parse_cost_value(True) is None
+    assert parse_cost_value(0) == 0.0
+    assert parse_cost_value("0") == 0.0
+    assert parse_cost_value(0.0) == 0.0
+
+
+def test_pricing_missing_dimension_blocks() -> None:
+    partial = dict(ZERO_PRICING)
+    del partial["tool"]
+    verdict = evaluate_pricing(partial)
+    assert not verdict.eligible
+    assert "tool" in verdict.unknown_dimensions
+
+
+def test_pricing_nonzero_and_subscription_blocks() -> None:
+    nonzero = dict(ZERO_PRICING)
+    nonzero["input_token"] = 0.01
+    verdict = evaluate_pricing(nonzero)
+    assert not verdict.eligible
+    assert "input_token" in verdict.nonzero_dimensions
+    verdict2 = evaluate_pricing(dict(ZERO_PRICING), requires_subscription_or_key=True)
+    assert not verdict2.eligible
+    assert verdict2.reason == "subscription_or_key_required"
+
+
+def test_pricing_explicit_inapplicable_passes() -> None:
+    pricing = dict(ZERO_PRICING)
+    del pricing["tool"]
+    verdict = evaluate_pricing(pricing, inapplicable=frozenset({"tool"}))
+    assert verdict.eligible
+
+
+def test_eligibility_requires_catalog_presence_and_route() -> None:
+    verdict = evaluate_eligibility(_eligible_candidate(in_catalog=False))
+    assert not verdict.eligible
+    assert verdict.reasons["availability"] == "not_in_catalog"
+    verdict2 = evaluate_eligibility(
+        _eligible_candidate(
+            qualified_id="opencode-go/some-paid",
+            provider_id="opencode-go",
+        )
+    )
+    assert not verdict2.eligible
+    assert "availability" in verdict2.reasons
+
+
+def test_eligibility_missing_tools_and_effort() -> None:
+    verdict = evaluate_eligibility(_eligible_candidate(capabilities=("read",)))
+    assert not verdict.eligible
+    assert verdict.reasons["capability"].startswith("missing_tools:")
+    verdict2 = evaluate_eligibility(
+        _eligible_candidate(supported_efforts=("low",), requested_effort="xhigh")
+    )
+    assert not verdict2.eligible
+    assert verdict2.reasons["capability"].startswith("unsupported_effort:")
+
+
+def test_eligibility_unaccepted_terms_blocks() -> None:
+    verdict = evaluate_eligibility(_eligible_candidate(data_use_decision=None))
+    assert not verdict.eligible
+    assert verdict.reasons["privacy"].startswith("privacy:unaccepted_terms:")
+    # Historical consent must not count: wrong version is still blocked.
+    verdict2 = evaluate_eligibility(
+        _eligible_candidate(
+            data_use_decision=DataUseDecision(policy_version="zen-terms.v2", accepted=True)
+        )
+    )
+    assert not verdict2.eligible
+
+
+def test_eligibility_happy_path() -> None:
+    assert evaluate_eligibility(_eligible_candidate()).eligible
+
+
+def test_frozen_attempt_and_signal_shape() -> None:
+    frozen = freeze_attempt(
+        qualified_id=ZEN_FREE_QUALIFIED,
+        catalog={"ids": [ZEN_FREE_QUALIFIED]},
+        pricing=dict(ZERO_PRICING),
+        data_use_version="zen-terms.v3",
+    )
+    payload = frozen.as_dict()
+    assert payload["modelId"] == ZEN_FREE_QUALIFIED
+    assert payload["materializerRef"] == "none@1"
+    assert payload["selectionPolicyVersion"] == "free-model-selection.v1"
+    assert payload["catalogDigest"].startswith("sha256:")
+    signal = format_no_eligible_free_model({"pricing": "x", "privacy": "y"})
+    assert signal["code"] == "no_eligible_free_model"
+    assert set(signal["reasons"]) == {"pricing", "privacy"}
+
+
+def test_resolve_free_default_preserves_explicit_pin() -> None:
+    catalog = [ZEN_FREE_QUALIFIED]
+    candidates = {ZEN_FREE_QUALIFIED: _eligible_candidate()}
+    selected, frozen = resolve_free_default_model(
+        explicit_pin=ZEN_FREE_QUALIFIED,
+        catalog_ids=catalog,
+        candidates=candidates,
+        default_policy_authorizes_auto=True,
+    )
+    assert selected == ZEN_FREE_QUALIFIED
+    assert frozen.model_id == ZEN_FREE_QUALIFIED
+    with pytest.raises(FreeModelUnavailableError):
+        resolve_free_default_model(
+            explicit_pin="opencode/missing-model",
+            catalog_ids=catalog,
+            candidates=candidates,
+            default_policy_authorizes_auto=True,
+        )
+
+
+def test_resolve_free_default_ineligible_pin_raises_no_eligible() -> None:
+    catalog = [ZEN_FREE_QUALIFIED]
+    bad = _eligible_candidate(pricing={"request": 1, **{k: 0 for k in ZERO_PRICING if k != "request"}})
+    with pytest.raises(NoEligibleFreeModelError) as exc:
+        resolve_free_default_model(
+            explicit_pin=ZEN_FREE_QUALIFIED,
+            catalog_ids=catalog,
+            candidates={ZEN_FREE_QUALIFIED: bad},
+            default_policy_authorizes_auto=True,
+        )
+    assert exc.value.details["code"] == "no_eligible_free_model"
+    assert "pricing" in exc.value.details["reasons"]
+
+
+def test_resolve_free_default_auto_requires_policy() -> None:
+    with pytest.raises(FreeModelUnavailableError):
+        resolve_free_default_model(
+            explicit_pin=None,
+            catalog_ids=[ZEN_FREE_QUALIFIED],
+            candidates={ZEN_FREE_QUALIFIED: _eligible_candidate()},
+            default_policy_authorizes_auto=False,
+        )
+    selected, _ = resolve_free_default_model(
+        explicit_pin=None,
+        catalog_ids=[ZEN_FREE_QUALIFIED],
+        candidates={ZEN_FREE_QUALIFIED: _eligible_candidate()},
+        default_policy_authorizes_auto=True,
+    )
+    assert selected == ZEN_FREE_QUALIFIED
+
+
+def test_resolve_free_default_empty_catalog_reports_no_eligible() -> None:
+    with pytest.raises(NoEligibleFreeModelError) as exc:
+        resolve_free_default_model(
+            explicit_pin=None,
+            catalog_ids=[],
+            candidates={},
+            default_policy_authorizes_auto=True,
+        )
+    assert exc.value.details["code"] == "no_eligible_free_model"
+
+
+def test_resolve_model_exact_requires_exact_catalog_match() -> None:
+    catalog = [{"qualifiedId": ZEN_FREE_QUALIFIED, "displayName": "Free"}]
+    resolved = resolve_model_exact(ZEN_FREE_QUALIFIED, catalog)
+    assert resolved["qualifiedId"] == ZEN_FREE_QUALIFIED
+    # Punctuation-normalized collision must not select a different provider.
+    other = [{"qualifiedId": "opencode-go/muse-spark-13-contributor-free"}]
+    with pytest.raises(ValueError):
+        resolve_model_exact(ZEN_FREE_QUALIFIED, other)
+    with pytest.raises(ValueError):
+        resolve_model_exact(ZEN_FREE_QUALIFIED, None)
+    # Name containing free alone never qualifies.
+    with pytest.raises(ValueError):
+        resolve_model_exact("opencode/some-free-thing", catalog)
+
+
+def test_resolve_by_display_free_route_never_preserved_pre_validation() -> None:
+    # Keyed route preserves its canonical identity before live validation.
+    keyed = resolve_model_by_display("opencode-go/gpt-5.6-luna")
+    assert keyed["qualifiedId"] == "opencode-go/gpt-5.6-luna"
+    # Credentialless opencode/* route must come from the exact catalog.
+    with pytest.raises(ValueError) as exc:
+        resolve_model_by_display("opencode/some-new-free-model")
+    assert "credentialless" in str(exc.value)
+
+
+def test_validate_effort_for_model_uses_actual_values() -> None:
+    assert validate_effort_for_model("xhigh", ZEN_FREE_QUALIFIED) == "xhigh"
+    assert get_supported_efforts(ZEN_FREE_QUALIFIED) is not None
+    with pytest.raises(ValueError):
+        validate_effort_for_model("ultra", ZEN_FREE_QUALIFIED)
+
+
+def test_credentialless_isolation_clears_ambient_keys() -> None:
+    policy = derive_isolation_policy(
+        runtime_id="opencode",
+        provider_id="opencode",
+        authentication_method="none",
+        credential_source="none",
+        runtime_materialization_mode="composite",
+    )
+    assert policy is not None
+    assert "OPENCODE_API_KEY" in policy.keys
+    assert "OPENCODE_AUTH_CONTENT" in policy.keys
+    assert "OPENCODE_CONFIG" in policy.keys
+    assert "OPENCODE_CONFIG_CONTENT" in policy.keys

--- a/tests/unit/omnigent/test_free_model_wiring_4021.py
+++ b/tests/unit/omnigent/test_free_model_wiring_4021.py
@@ -15,6 +15,8 @@ from api_service.api.routers.omnigent_catalog import (
     free_model_gate_reason,
 )
 from moonmind.omnigent.bootstrap.free_model_eligibility import (
+    FREE_PROVIDER_ID,
+    NO_ELIGIBLE_FREE_MODEL_CODE,
     ZEN_FREE_TERMS_VERSION,
     DataUseDecision,
     EligibilityInput,
@@ -29,6 +31,7 @@ from moonmind.omnigent.bootstrap.free_model_eligibility import (
     recheck_frozen_attempt,
     resolve_free_default_model,
     zen_free_data_use_decision_from_settings,
+    zen_free_route_blocked_reason,
 )
 from moonmind.omnigent.bootstrap.models import BootstrapResolved
 from moonmind.omnigent.bootstrap.opencode import (
@@ -36,7 +39,11 @@ from moonmind.omnigent.bootstrap.opencode import (
     resolve_bootstrap_model,
     resolve_model_exact,
 )
-from moonmind.workflows.executions.model_resolver import coerce_effort_for_model
+from moonmind.workflows.executions.model_resolver import (
+    coerce_effort_for_model,
+    resolve_model_effort,
+    resolve_opencode_effort,
+)
 
 ZERO_PRICING = {
     "request": 0,
@@ -229,6 +236,114 @@ def test_frozen_attempt_persists_and_rechecks_without_rewrite() -> None:
         default_policy_authorizes_auto=True,
     )
     assert selected == ZEN_FREE_QUALIFIED
+
+
+def test_production_resolver_coerces_opencode_effort() -> None:
+    """The real resolve_model_effort path enforces per-model effort upstream.
+
+    MoonLadderStudios/MoonMind#4021 req-3: plan/launch consumers share
+    resolve_model_effort, so the opencode/ route fails closed on unsupported
+    effort there instead of assuming the seeded default. Other runtimes keep
+    pass-through behavior.
+    """
+    from types import SimpleNamespace
+
+    def _profile(**overrides: object) -> SimpleNamespace:
+        values: dict[str, object] = {
+            "runtime_id": "opencode",
+            "provider_id": FREE_PROVIDER_ID,
+            "default_model": ZEN_FREE_QUALIFIED,
+            "default_effort": "xhigh",
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    resolved = resolve_model_effort(
+        runtime_id="opencode",
+        profile=_profile(),
+        require_launch_ready=False,
+    )
+    assert resolved.model == ZEN_FREE_QUALIFIED
+    assert resolved.effort == "xhigh"
+
+    with pytest.raises(ValueError):
+        resolve_model_effort(
+            runtime_id="opencode",
+            profile=_profile(),
+            requested_effort="ultra",
+            require_launch_ready=False,
+        )
+
+    # Explicit helper scoping: opencode/ coerces, other routes pass through.
+    assert resolve_opencode_effort(ZEN_FREE_QUALIFIED, "xhigh") == "xhigh"
+    assert resolve_opencode_effort(ZEN_FREE_QUALIFIED, None) is None
+    assert resolve_opencode_effort("other-provider/some-model", "ultra") == "ultra"
+    assert resolve_opencode_effort(None, "xhigh") == "xhigh"
+
+
+def test_production_gate_blocks_only_declined_free_route() -> None:
+    """The Settings-sourced gate is exact-version and free-route scoped."""
+    # Default deployments accept: no block for either route.
+    assert zen_free_route_blocked_reason("opencode", env={}) is None
+    # The keyed route is never gated by the free-route decision.
+    assert (
+        zen_free_route_blocked_reason(
+            "opencode-go", env={"OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE": "false"}
+        )
+        is None
+    )
+    assert zen_free_route_blocked_reason("other", env={}) is None
+    # An explicit operator decline blocks the free route with the exact
+    # per-version privacy reason.
+    blocked = zen_free_route_blocked_reason(
+        "opencode", env={"OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE": "false"}
+    )
+    assert blocked == "privacy:unaccepted_terms:" + ZEN_FREE_TERMS_VERSION
+
+
+def test_planning_admission_blocks_declined_free_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plan-time admission enforces the free-route authorization (req-4)."""
+    from types import SimpleNamespace
+
+    from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+    from moonmind.omnigent.harness_platform.planning_service import (
+        OmnigentExecutionPlanningService,
+    )
+    from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+    service = SimpleNamespace(_deployment_default_model="")
+    provider = SimpleNamespace(
+        runtime_id="opencode",
+        provider_id=FREE_PROVIDER_ID,
+        default_model=ZEN_FREE_QUALIFIED,
+        default_effort="xhigh",
+    )
+
+    def _request() -> AgentExecutionRequest:
+        return AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-1",
+            idempotencyKey="idem-1",
+        )
+
+    monkeypatch.delenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", raising=False)
+    qualified, effort, route = OmnigentExecutionPlanningService._resolve_model(
+        service, _request(), None, provider
+    )
+    assert qualified == ZEN_FREE_QUALIFIED
+    assert effort == "xhigh"
+    assert route == FREE_PROVIDER_ID
+
+    monkeypatch.setenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", "false")
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        OmnigentExecutionPlanningService._resolve_model(
+            service, _request(), None, provider
+        )
+    assert NO_ELIGIBLE_FREE_MODEL_CODE in str(excinfo.value)
+    assert "privacy:unaccepted_terms:" in str(excinfo.value)
 
 
 def test_catalog_no_eligible_signal_and_capacity_wait_state() -> None:

--- a/tests/unit/omnigent/test_free_model_wiring_4021.py
+++ b/tests/unit/omnigent/test_free_model_wiring_4021.py
@@ -1,0 +1,277 @@
+"""Consumer wiring for MoonLadderStudios/MoonMind#4021.
+
+Exercises the free-model eligibility helpers through their real production
+consumers (bootstrap/profile/plan wiring, Settings authority, frozen-attempt
+persistence, catalog surfacing). Hermetic only: inline fixtures, no network,
+no inference calls.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api_service.api.routers.omnigent_catalog import (
+    _REASONS,
+    free_model_gate_reason,
+)
+from moonmind.omnigent.bootstrap.free_model_eligibility import (
+    ZEN_FREE_TERMS_VERSION,
+    DataUseDecision,
+    EligibilityInput,
+    attach_frozen_attempt_to_resolved,
+    build_eligibility_input,
+    build_live_qualification_record,
+    evaluate_data_use,
+    evaluate_eligibility,
+    freeze_attempt,
+    frozen_attempt_from_resolved,
+    rank_approved_candidates,
+    recheck_frozen_attempt,
+    resolve_free_default_model,
+    zen_free_data_use_decision_from_settings,
+)
+from moonmind.omnigent.bootstrap.models import BootstrapResolved
+from moonmind.omnigent.bootstrap.opencode import (
+    ZEN_FREE_QUALIFIED,
+    resolve_bootstrap_model,
+    resolve_model_exact,
+)
+from moonmind.workflows.executions.model_resolver import coerce_effort_for_model
+
+ZERO_PRICING = {
+    "request": 0,
+    "input_token": 0,
+    "output_token": 0,
+    "cache_read": 0,
+    "cache_write": 0,
+    "reasoning": 0,
+    "tool": 0,
+}
+
+NEW_FREE_ID = "opencode/some-new-free-model"
+
+
+def _eligible_input(qualified_id: str = ZEN_FREE_QUALIFIED) -> EligibilityInput:
+    decision = DataUseDecision(
+        policy_version=ZEN_FREE_TERMS_VERSION,
+        accepted=True,
+        accepted_by="operator-settings",
+    )
+    return build_eligibility_input(
+        qualified_id=qualified_id,
+        catalog_ids=[qualified_id],
+        pricing=dict(ZERO_PRICING),
+        capabilities=("read", "write", "shell"),
+        supported_efforts=("minimal", "low", "medium", "high", "xhigh"),
+        requested_effort="xhigh",
+        terms_version=ZEN_FREE_TERMS_VERSION,
+        terms_require_approval=True,
+        data_use_decision=decision,
+    )
+
+
+def test_bootstrap_exact_path_for_new_opencode_id_through_real_consumer() -> None:
+    catalog = [
+        {"qualifiedId": ZEN_FREE_QUALIFIED, "displayName": "Zen Free"},
+        {"qualifiedId": NEW_FREE_ID, "displayName": "New Free"},
+    ]
+    # New canonical opencode/... ID resolves through the bootstrap consumer
+    # only with the exact observed catalog.
+    resolved = resolve_bootstrap_model(NEW_FREE_ID, catalog)
+    assert resolved["qualifiedId"] == NEW_FREE_ID
+    with pytest.raises(ValueError):
+        resolve_bootstrap_model(NEW_FREE_ID, None)
+    with pytest.raises(ValueError):
+        resolve_bootstrap_model(NEW_FREE_ID, [{"qualifiedId": ZEN_FREE_QUALIFIED}])
+    # Punctuation-normalized collision cannot choose a different provider.
+    with pytest.raises(ValueError):
+        resolve_model_exact(
+            ZEN_FREE_QUALIFIED,
+            [{"qualifiedId": "opencode-go/muse-spark-13-contributor-free"}],
+        )
+
+
+def test_bootstrap_effort_uses_actual_model_values() -> None:
+    assert coerce_effort_for_model(ZEN_FREE_QUALIFIED, "xhigh") == "xhigh"
+    with pytest.raises(ValueError):
+        coerce_effort_for_model(ZEN_FREE_QUALIFIED, "ultra")
+    # Profile/plan wiring path: controller._resolve_profile_model_effort uses
+    # the same per-model validator (import here to prove the real consumer).
+    from moonmind.omnigent.bootstrap.controller import _resolve_profile_model_effort
+
+    class _Profile:
+        runtime_id = "opencode"
+        default_model = ZEN_FREE_QUALIFIED
+        default_effort = "xhigh"
+        model_tiers = []
+        default_model_tier = 1
+
+    model, effort = _resolve_profile_model_effort(_Profile())
+    assert model == ZEN_FREE_QUALIFIED
+    assert effort == "xhigh"
+
+    class _BadEffortProfile(_Profile):
+        default_effort = "ultra"
+
+    with pytest.raises(ValueError):
+        _resolve_profile_model_effort(_BadEffortProfile())
+
+
+def test_settings_authority_exact_version_gates_ranking() -> None:
+    # Real authority: default env accepts the exact current terms version.
+    decision = zen_free_data_use_decision_from_settings(env={})
+    assert decision is not None
+    assert decision.policy_version == ZEN_FREE_TERMS_VERSION
+    assert decision.accepted is True
+    ok, _ = evaluate_data_use(
+        terms_version=ZEN_FREE_TERMS_VERSION,
+        terms_require_approval=True,
+        decision=decision,
+    )
+    assert ok is True
+    # Operator decline blocks (no decision).
+    assert (
+        zen_free_data_use_decision_from_settings(
+            env={"OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE": "false"}
+        )
+        is None
+    )
+    # Wrong-version or missing decision blocks through the real gate.
+    wrong = DataUseDecision(policy_version="zen-terms.v2", accepted=True)
+    ok2, _ = evaluate_data_use(
+        terms_version=ZEN_FREE_TERMS_VERSION,
+        terms_require_approval=True,
+        decision=wrong,
+    )
+    assert ok2 is False
+    ok3, _ = evaluate_data_use(
+        terms_version=ZEN_FREE_TERMS_VERSION,
+        terms_require_approval=True,
+        decision=None,
+    )
+    assert ok3 is False
+    # Approved-set ranking honors the exact-version decision.
+    blocked_input = EligibilityInput(
+        qualified_id=ZEN_FREE_QUALIFIED,
+        in_catalog=True,
+        pricing=dict(ZERO_PRICING),
+        capabilities=("read", "write", "shell"),
+        supported_efforts=("minimal", "low", "medium", "high", "xhigh"),
+        requested_effort="xhigh",
+        terms_version=ZEN_FREE_TERMS_VERSION,
+        terms_require_approval=True,
+        data_use_decision=None,
+    )
+    selected, blocked = rank_approved_candidates(
+        {ZEN_FREE_QUALIFIED: blocked_input}, catalog_order=[ZEN_FREE_QUALIFIED]
+    )
+    assert selected is None
+    assert blocked["privacy"].startswith("privacy:unaccepted_terms:")
+    selected2, _ = rank_approved_candidates(
+        {ZEN_FREE_QUALIFIED: _eligible_input()}, catalog_order=[ZEN_FREE_QUALIFIED]
+    )
+    assert selected2 == ZEN_FREE_QUALIFIED
+
+
+def test_frozen_attempt_persists_and_rechecks_without_rewrite() -> None:
+    catalog = {"ids": [ZEN_FREE_QUALIFIED]}
+    frozen = freeze_attempt(
+        qualified_id=ZEN_FREE_QUALIFIED,
+        catalog=catalog,
+        pricing=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    resolved = BootstrapResolved(
+        qualifiedModelId=ZEN_FREE_QUALIFIED,
+        displayName="Zen Free",
+    )
+    attached = attach_frozen_attempt_to_resolved(resolved, frozen)
+    assert attached.free_model_attempt is not None
+    assert attached.free_model_attempt["modelId"] == ZEN_FREE_QUALIFIED
+    # Active inputs unchanged: the original record still carries no bundle.
+    assert resolved.free_model_attempt is None
+    # Round-trip through the durable store shape.
+    reloaded = BootstrapResolved.model_validate(
+        attached.model_dump(mode="json", by_alias=True)
+    )
+    recovered = frozen_attempt_from_resolved(reloaded)
+    assert recovered is not None
+    assert recovered.model_id == ZEN_FREE_QUALIFIED
+    current, _ = recheck_frozen_attempt(
+        recovered,
+        catalog=catalog,
+        pricing=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    assert current is True
+    # Changed evidence expires the frozen bundle without rewriting it.
+    current2, reason2 = recheck_frozen_attempt(
+        recovered,
+        catalog={"ids": ["opencode/other"]},
+        pricing=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    assert current2 is False
+    assert "catalog" in reason2
+    current3, reason3 = recheck_frozen_attempt(
+        recovered,
+        catalog=catalog,
+        pricing=dict(ZERO_PRICING),
+        data_use_version="zen-terms.v9",
+    )
+    assert current3 is False
+    assert "terms" in reason3
+    # resolve_free_default_model still preserves pins and never substitutes.
+    selected, _ = resolve_free_default_model(
+        explicit_pin=ZEN_FREE_QUALIFIED,
+        catalog_ids=[ZEN_FREE_QUALIFIED],
+        candidates={ZEN_FREE_QUALIFIED: _eligible_input()},
+        default_policy_authorizes_auto=True,
+    )
+    assert selected == ZEN_FREE_QUALIFIED
+
+
+def test_catalog_no_eligible_signal_and_capacity_wait_state() -> None:
+    assert "no_eligible_free_model" in _REASONS
+    reason = free_model_gate_reason(
+        {
+            "availability": "not_in_catalog",
+            "pricing": "unknown_pricing:tool",
+            "capability": "missing_tools:shell",
+            "privacy": "privacy:unaccepted_terms:zen-terms.v3",
+        }
+    )
+    assert reason.code == "no_eligible_free_model"
+    for axis in ("availability=", "pricing=", "capability=", "privacy="):
+        assert axis in reason.message
+    # Capacity stays a wait state with its own codes; it never requalifies a
+    # model or selects a paid fallback.
+    assert "omnigent_capacity_wait" in _REASONS
+    assert "profile_capacity_unavailable" in _REASONS
+    assert _REASONS["no_eligible_free_model"] != _REASONS["omnigent_capacity_wait"]
+
+
+def test_live_qualification_record_bounds_without_network() -> None:
+    record = build_live_qualification_record(
+        qualified_id=ZEN_FREE_QUALIFIED,
+        host_image_ref="ghcr.io/moonladderstudios/omnigent-host-moonmind@sha256:" + "a" * 64,
+        runtime_pack_ref="opencode-native-pack@1",
+        pricing_evidence=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+        data_use_authorized=True,
+        catalog_max_age_hours=6.0,
+        probe_timeout_seconds=60.0,
+        max_probe_attempts=1,
+        blocked_cases=("pricing:unknown_pricing:tool",),
+        unexecuted_cases=("live-inference:not-attempted-hermetic",),
+    )
+    assert record["modelId"] == ZEN_FREE_QUALIFIED
+    assert record["materializerRef"] == "none@1"
+    assert record["hostImageRef"].endswith("a" * 64)
+    assert record["runtimePackRef"] == "opencode-native-pack@1"
+    assert record["dataUseAuthorized"] is True
+    assert record["bounds"]["singleFlight"] is True
+    assert record["bounds"]["maxProbeAttempts"] == 1
+    assert "pricing:unknown_pricing:tool" in record["blockedCases"]
+    assert record["unexecutedCases"] == ["live-inference:not-attempted-hermetic"]
+    assert evaluate_eligibility(_eligible_input()).eligible is True

--- a/tests/unit/omnigent/test_free_model_wiring_4021.py
+++ b/tests/unit/omnigent/test_free_model_wiring_4021.py
@@ -13,22 +13,30 @@ import pytest
 from api_service.api.routers.omnigent_catalog import (
     _REASONS,
     free_model_gate_reason,
+    free_model_gate_reasons_for_profile,
 )
 from moonmind.omnigent.bootstrap.free_model_eligibility import (
+    FREE_PROFILE_ID,
     FREE_PROVIDER_ID,
     NO_ELIGIBLE_FREE_MODEL_CODE,
     ZEN_FREE_TERMS_VERSION,
     DataUseDecision,
     EligibilityInput,
+    FreeModelUnavailableError,
+    NoEligibleFreeModelError,
     attach_frozen_attempt_to_resolved,
     build_eligibility_input,
     build_live_qualification_record,
+    catalog_ids_from_evidence,
     evaluate_data_use,
     evaluate_eligibility,
     freeze_attempt,
+    free_model_launch_gate,
     frozen_attempt_from_resolved,
     rank_approved_candidates,
     recheck_frozen_attempt,
+    recheck_resolved_free_attempt,
+    require_exact_catalog_match,
     resolve_free_default_model,
     zen_free_data_use_decision_from_settings,
     zen_free_route_blocked_reason,
@@ -390,3 +398,402 @@ def test_live_qualification_record_bounds_without_network() -> None:
     assert "pricing:unknown_pricing:tool" in record["blockedCases"]
     assert record["unexecutedCases"] == ["live-inference:not-attempted-hermetic"]
     assert evaluate_eligibility(_eligible_input()).eligible is True
+
+
+def test_catalog_ids_from_evidence_exact_only() -> None:
+    """Only exact qualified IDs leave the persisted catalog boundary."""
+    evidence = {
+        "models": [
+            {"qualifiedId": ZEN_FREE_QUALIFIED, "displayName": "Zen Free"},
+            {"qualifiedId": NEW_FREE_ID},
+            {"qualifiedId": NEW_FREE_ID},  # deduped
+            {"qualifiedId": "not-a-qualified-id"},  # no provider/ route
+            {"displayName": "Missing qualifiedId"},
+            "opencode/plain-string-id",
+            "",
+            None,
+        ]
+    }
+    assert catalog_ids_from_evidence(evidence) == sorted(
+        [ZEN_FREE_QUALIFIED, NEW_FREE_ID, "opencode/plain-string-id"]
+    )
+    assert catalog_ids_from_evidence(None) == []
+    assert catalog_ids_from_evidence({}) == []
+    assert catalog_ids_from_evidence({"models": "not-a-list"}) == []
+
+
+def test_require_exact_catalog_match_fails_closed() -> None:
+    assert (
+        require_exact_catalog_match(ZEN_FREE_QUALIFIED, [ZEN_FREE_QUALIFIED])
+        == ZEN_FREE_QUALIFIED
+    )
+    # Punctuation-normalized near-collision is a different ID: unavailable.
+    with pytest.raises(NoEligibleFreeModelError) as excinfo:
+        require_exact_catalog_match(
+            ZEN_FREE_QUALIFIED,
+            ["opencode-go/muse-spark-13-contributor-free"],
+        )
+    assert excinfo.value.details["reasons"]["availability"].startswith(
+        "not_in_catalog:"
+    )
+    # No persisted catalog yet defers to exact-host qualification; it never
+    # fabricates eligibility and never blocks the route structurally.
+    with pytest.raises(FreeModelUnavailableError):
+        require_exact_catalog_match(ZEN_FREE_QUALIFIED, [])
+
+
+def test_free_model_launch_gate_live_axes() -> None:
+    """The production launch gate combines availability, effort, privacy."""
+    model, effort = free_model_launch_gate(
+        qualified_id=ZEN_FREE_QUALIFIED,
+        catalog_ids=[ZEN_FREE_QUALIFIED],
+        requested_effort="xhigh",
+        env={},
+    )
+    assert (model, effort) == (ZEN_FREE_QUALIFIED, "xhigh")
+    # Availability: exact catalog lacks the ID.
+    with pytest.raises(NoEligibleFreeModelError) as excinfo:
+        free_model_launch_gate(
+            qualified_id=ZEN_FREE_QUALIFIED,
+            catalog_ids=["opencode/other-model"],
+            requested_effort="xhigh",
+            env={},
+        )
+    assert "availability" in excinfo.value.details["reasons"]
+    # Capability: effort validated against the model's actual values.
+    with pytest.raises(NoEligibleFreeModelError) as excinfo:
+        free_model_launch_gate(
+            qualified_id=ZEN_FREE_QUALIFIED,
+            catalog_ids=[ZEN_FREE_QUALIFIED],
+            requested_effort="ultra",
+            env={},
+        )
+    assert "capability" in excinfo.value.details["reasons"]
+    # Privacy: explicit operator decline blocks with the per-version reason.
+    with pytest.raises(NoEligibleFreeModelError) as excinfo:
+        free_model_launch_gate(
+            qualified_id=ZEN_FREE_QUALIFIED,
+            catalog_ids=[ZEN_FREE_QUALIFIED],
+            requested_effort="xhigh",
+            env={"OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE": "false"},
+        )
+    assert excinfo.value.details["reasons"]["privacy"].startswith(
+        "privacy:unaccepted_terms:"
+    )
+    # Empty catalog defers availability to exact-host qualification but still
+    # enforces effort and privacy here.
+    model2, _ = free_model_launch_gate(
+        qualified_id=ZEN_FREE_QUALIFIED,
+        catalog_ids=[],
+        requested_effort="xhigh",
+        env={},
+    )
+    assert model2 == ZEN_FREE_QUALIFIED
+
+
+def test_recheck_resolved_wrapper_without_rewrite() -> None:
+    catalog = {"ids": [ZEN_FREE_QUALIFIED]}
+    resolved = BootstrapResolved(qualifiedModelId=ZEN_FREE_QUALIFIED)
+    current, reason = recheck_resolved_free_attempt(
+        resolved,
+        catalog=catalog,
+        pricing=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    assert (current, reason) == (True, "no_frozen_attempt")
+    frozen = freeze_attempt(
+        qualified_id=ZEN_FREE_QUALIFIED,
+        catalog=catalog,
+        pricing=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    attached = attach_frozen_attempt_to_resolved(resolved, frozen)
+    current2, _ = recheck_resolved_free_attempt(
+        attached,
+        catalog=catalog,
+        pricing=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    assert current2 is True
+    current3, reason3 = recheck_resolved_free_attempt(
+        attached,
+        catalog={"ids": ["opencode/other"]},
+        pricing=dict(ZERO_PRICING),
+        data_use_version=ZEN_FREE_TERMS_VERSION,
+    )
+    assert current3 is False
+    assert "catalog" in reason3
+
+
+def test_planning_resolve_model_enforces_exact_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plan-time admission threads the live catalog into execution selection."""
+    from types import SimpleNamespace
+
+    from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+    from moonmind.omnigent.harness_platform.planning_service import (
+        OmnigentExecutionPlanningService,
+    )
+    from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+
+    service = SimpleNamespace(_deployment_default_model="")
+
+    def _provider(**overrides: object) -> SimpleNamespace:
+        values: dict[str, object] = {
+            "runtime_id": "opencode",
+            "provider_id": FREE_PROVIDER_ID,
+            "default_model": ZEN_FREE_QUALIFIED,
+            "default_effort": "xhigh",
+            "model_catalog_evidence_json": None,
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    def _request() -> AgentExecutionRequest:
+        return AgentExecutionRequest(
+            agentKind="external",
+            agentId="omnigent",
+            correlationId="corr-1",
+            idempotencyKey="idem-1",
+        )
+
+    monkeypatch.delenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", raising=False)
+    # Persisted catalog containing the exact ID: admitted.
+    qualified, _, _ = OmnigentExecutionPlanningService._resolve_model(
+        service,
+        _request(),
+        None,
+        _provider(
+            model_catalog_evidence_json={
+                "models": [{"qualifiedId": ZEN_FREE_QUALIFIED}]
+            }
+        ),
+    )
+    assert qualified == ZEN_FREE_QUALIFIED
+    # No persisted catalog yet: deferred to exact-host qualification.
+    qualified2, _, _ = OmnigentExecutionPlanningService._resolve_model(
+        service, _request(), None, _provider()
+    )
+    assert qualified2 == ZEN_FREE_QUALIFIED
+    # Persisted catalog lacking the ID: fail closed with the availability
+    # axis, never a silent substitute or paid fallback.
+    with pytest.raises(HarnessPlatformError) as excinfo:
+        OmnigentExecutionPlanningService._resolve_model(
+            service,
+            _request(),
+            None,
+            _provider(
+                model_catalog_evidence_json={
+                    "models": [{"qualifiedId": "opencode/other-model"}]
+                }
+            ),
+        )
+    assert NO_ELIGIBLE_FREE_MODEL_CODE in str(excinfo.value)
+    assert "not_in_catalog" in str(excinfo.value)
+    # The keyed route is never gated by the free-route catalog check.
+    qualified3, _, _ = OmnigentExecutionPlanningService._resolve_model(
+        service,
+        _request(),
+        None,
+        _provider(
+            provider_id="opencode-go",
+            default_model="opencode-go/muse-spark-1.3-contributor",
+            model_catalog_evidence_json={
+                "models": [{"qualifiedId": "opencode/other-model"}]
+            },
+        ),
+    )
+    assert qualified3 == "opencode-go/muse-spark-1.3-contributor"
+
+
+def test_catalog_gate_combines_real_evidence_axes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Readiness surfaces availability/capability/privacy, never fabricated."""
+    from types import SimpleNamespace
+
+    def _row(**overrides: object) -> SimpleNamespace:
+        values: dict[str, object] = {
+            "provider_id": "opencode",
+            "default_model": ZEN_FREE_QUALIFIED,
+            "default_effort": "xhigh",
+            "model_catalog_evidence_json": None,
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    monkeypatch.delenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", raising=False)
+    assert free_model_gate_reasons_for_profile(_row()) == {}
+    # Non-free routes are never gated here.
+    assert free_model_gate_reasons_for_profile(_row(provider_id="other")) == {}
+    # Availability: persisted catalog lacks the default model exactly.
+    reasons = free_model_gate_reasons_for_profile(
+        _row(
+            model_catalog_evidence_json={
+                "models": [{"qualifiedId": "opencode/other-model"}]
+            }
+        )
+    )
+    assert reasons["availability"].startswith("not_in_catalog:")
+    # Capability: default effort outside the model's actual supported values.
+    reasons2 = free_model_gate_reasons_for_profile(_row(default_effort="ultra"))
+    assert reasons2["capability"] == "unsupported_effort:ultra"
+    # Privacy: explicit operator decline blocks with the per-version reason.
+    monkeypatch.setenv("OPENCODE_ACCEPT_CONTRIBUTOR_DATA_USE", "false")
+    reasons3 = free_model_gate_reasons_for_profile(_row())
+    assert reasons3["privacy"].startswith("privacy:unaccepted_terms:")
+    gate = free_model_gate_reason(
+        {"availability": "not_in_catalog:x", "privacy": reasons3["privacy"]}
+    )
+    assert gate.code == NO_ELIGIBLE_FREE_MODEL_CODE
+    assert "availability=" in gate.message
+    assert "privacy=" in gate.message
+
+
+@pytest.mark.asyncio
+async def test_zen_default_authority_survives_restart_upgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restart/upgrade round-trip for the credentialless default authority.
+
+    MoonLadderStudios/MoonMind#4021 acc-1: the existing
+    ``opencode-zen-free`` identity and explicit disable/default choices
+    survive restart/upgrade, and enrolling a Go key never transfers
+    credentialless default authority. This exercises the
+    :func:`normalize_runtime_default_profile` ownership boundary with the
+    seed-shaped Zen + Go pair; launch-readiness predicates themselves are
+    covered by the isolation/catalog suites, so readiness is stubbed here to
+    keep the ownership claim hermetic and exact.
+    """
+    from types import SimpleNamespace
+
+    from api_service.db.models import ProviderProfileDisabledReason
+    from api_service.services import provider_profile_service
+
+    monkeypatch.setattr(
+        provider_profile_service,
+        "provider_profile_launch_ready",
+        lambda row, managed_secret_statuses=None: bool(
+            getattr(row, "enabled", False)
+            and getattr(row, "disabled_reason", None) is None
+        ),
+    )
+
+    class _FakeResult:
+        def __init__(self, rows: list) -> None:
+            self._rows = rows
+
+        def scalars(self) -> "_FakeResult":
+            return self
+
+        def all(self) -> list:
+            return list(self._rows)
+
+    class _FakeSession:
+        def __init__(self, rows: list) -> None:
+            self._rows = rows
+
+        async def execute(self, _statement: object) -> _FakeResult:
+            return _FakeResult(self._rows)
+
+        async def flush(self) -> None:
+            return None
+
+    def _zen(**overrides: object) -> SimpleNamespace:
+        values: dict[str, object] = {
+            "profile_id": FREE_PROFILE_ID,
+            "runtime_id": "opencode",
+            "provider_id": FREE_PROVIDER_ID,
+            "enabled": True,
+            "disabled_reason": None,
+            "is_default": True,
+            "default_selected_by_operator": False,
+            "priority": 100,
+            "secret_refs": {},
+            "default_model": ZEN_FREE_QUALIFIED,
+            "default_effort": "xhigh",
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    def _go(**overrides: object) -> SimpleNamespace:
+        values: dict[str, object] = {
+            "profile_id": "opencode-go-default",
+            "runtime_id": "opencode",
+            "provider_id": "opencode-go",
+            "enabled": True,
+            "disabled_reason": None,
+            "is_default": False,
+            "default_selected_by_operator": False,
+            "priority": 50,
+            "secret_refs": {"opencode_api_key": "env://OPENCODE_API_KEY"},
+            "default_model": "opencode-go/muse-spark-1.3-contributor",
+            "default_effort": "xhigh",
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    # Fresh seed + Go key enrollment: enrollment settles the invariant with
+    # no preference (as the controller performs it), so the persisted Zen
+    # default is preserved and the keyed profile never takes its authority.
+    zen, go = _zen(), _go()
+    selected = await provider_profile_service.normalize_runtime_default_profile(
+        session=_FakeSession([zen, go]),
+        runtime_id="opencode",
+    )
+    assert selected == FREE_PROFILE_ID
+    assert zen.is_default is True
+    assert go.is_default is False
+    # Restart: the automatic seed preference for Zen settles the same way and
+    # never overrules; settling again without a preference is idempotent.
+    selected_seed = (
+        await provider_profile_service.normalize_runtime_default_profile(
+            session=_FakeSession([zen, go]),
+            runtime_id="opencode",
+            preferred_profile_id=FREE_PROFILE_ID,
+            operator_selected=False,
+        )
+    )
+    assert selected_seed == FREE_PROFILE_ID
+    selected2 = await provider_profile_service.normalize_runtime_default_profile(
+        session=_FakeSession([zen, go]),
+        runtime_id="opencode",
+    )
+    assert selected2 == FREE_PROFILE_ID
+    assert go.is_default is False
+
+    # Explicit operator disable of Zen survives an upgrade restart: the
+    # default moves to Go once and stays there.
+    zen_disabled = _zen(
+        enabled=False,
+        disabled_reason=ProviderProfileDisabledReason.USER_DISABLED,
+        is_default=False,
+    )
+    go2 = _go()
+    selected3 = await provider_profile_service.normalize_runtime_default_profile(
+        session=_FakeSession([zen_disabled, go2]),
+        runtime_id="opencode",
+    )
+    assert selected3 == "opencode-go-default"
+    selected4 = await provider_profile_service.normalize_runtime_default_profile(
+        session=_FakeSession([zen_disabled, go2]),
+        runtime_id="opencode",
+        preferred_profile_id=FREE_PROFILE_ID,
+        operator_selected=False,
+    )
+    assert selected4 == "opencode-go-default"
+    assert zen_disabled.is_default is False
+
+    # Explicit operator selection of Go outranks later automatic Zen
+    # preferences while still launchable.
+    zen3, go3 = _zen(is_default=False), _go(
+        is_default=True, default_selected_by_operator=True
+    )
+    selected5 = await provider_profile_service.normalize_runtime_default_profile(
+        session=_FakeSession([zen3, go3]),
+        runtime_id="opencode",
+        preferred_profile_id=FREE_PROFILE_ID,
+        operator_selected=False,
+    )
+    assert selected5 == "opencode-go-default"

--- a/tests/unit/provider_profiles/test_isolation_policy.py
+++ b/tests/unit/provider_profiles/test_isolation_policy.py
@@ -94,6 +94,9 @@ def test_alternate_provider_materialization_derives_policy() -> None:
 
 
 def test_credential_free_profile_derives_empty_policy() -> None:
+    # MoonLadderStudios/MoonMind#4021: the credentialless Zen route clears
+    # ambient keys (including OPENCODE_API_KEY); unknown credential-free
+    # strategies still derive an empty policy.
     policy = derive_isolation_policy(
         runtime_id="opencode",
         provider_id="opencode",
@@ -102,7 +105,14 @@ def test_credential_free_profile_derives_empty_policy() -> None:
         runtime_materialization_mode="composite",
     )
     assert policy is not None
-    assert list(policy.keys) == []
+    assert list(policy.keys) == [
+        "OPENCODE_API_KEY",
+        "OPENCODE_AUTH_CONTENT",
+        "OPENCODE_CONFIG",
+        "OPENCODE_CONFIG_CONTENT",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    ]
 
 
 def test_malformed_override_rejected() -> None:


### PR DESCRIPTION
## Summary
Implements MoonLadderStudios/MoonMind#4021: qualifies the existing credentialless opencode-zen-free / none@1 route with explicit pricing and privacy policy. Adds a compact eligibility record (exact catalog + trusted pricing/data-use evidence), exact-ID execution selection with per-model effort validation, frozen attempt evidence with no_eligible_free_model reasons, credentialless isolation including OPENCODE_API_KEY, and reconciled OpenCodeHost docs/UI states. No new free-model profile family; existing identities preserved.

## Verification outcome
Controlling post-remediation moonspec-verify verdict: FULLY_IMPLEMENTED (confidence HIGH, recommended next action: advance). All 8 issue requirements (req-1..req-8) and all 7 acceptance checkboxes VERIFIED at candidate head 1a4065d78f5c1fc2ac49f9b3c673be9642f34ed1 against base 08f639969. Initial assessment was PARTIALLY_IMPLEMENTED, so this implementation is published per binding constraints.

## Tests run
- PASS: moonmind container python-tests tests/unit/omnigent/test_free_model_eligibility_4021.py tests/unit/omnigent/test_free_model_wiring_4021.py tests/unit/provider_profiles/test_isolation_policy.py (hermetic unit evidence for req-1..req-8 + acceptance criteria)
- PASS: moonmind container python-tests tests/unit/omnigent/test_bootstrap_deployment_qualification.py tests/unit/api/routers/test_omnigent_catalog.py (adjacent regression: bootstrap qualification + catalog readiness incl. free-route privacy/capacity cases)
- NOT RUN (advisory): live inference / provider-terms live calls — no credentials/services in checkout; hermetic tests assert no external calls and the live-record shape is exercised with fixtures only.

## Remaining risks
- Live provider terms/pricing reverification against production endpoints is advisory-only and unverified here; hermetic suite proves no external inference is made.
- A free external service can disappear; no_eligible_free_model surfaces availability/pricing/capability/privacy reasons and capacity stays a wait state, but real outages are only handled when observed.

Closes MoonLadderStudios/MoonMind#4021