### PR TITLE
[Repository access] Persist scoped RepositoryConnections and transactional repository routes (MoonLadderStudios/MoonMind#4005)

### DIFF
--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -5144,6 +5144,12 @@ class RepositoryConnectionRecord(Base):
     credential_config: Mapped[dict[str, Any]] = mapped_column(
         mutable_json_dict(), nullable=False, default=dict
     )
+    projection_policy: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        mutable_json_dict(), nullable=True, default=None
+    )
+    merge_coordinator_policy: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        mutable_json_dict(), nullable=True, default=None
+    )
     lifecycle: Mapped[str] = mapped_column(
         String(16), nullable=False, default="active", server_default="active"
     )
@@ -5222,18 +5228,19 @@ class RepositoryConnectionAssignment(Base):
 class RepositoryRouteDefault(Base):
     """At most one default per (scope, repository, capability bundle).
 
-    ``scope_ref`` is NULL for system scope (NULLs are distinct under both
-    SQLite and Postgres unique indexes per the nullable-key contract, and the
-    service normalizes system scope to NULL so the uniqueness rule holds).
-    ``capability_bundle`` is the sorted, comma-joined operation bundle so one
-    role cannot split reads and writes across different credentials.
+    ``scope_ref`` is NULL for system scope, and NULLs compare distinct under
+    both SQLite and Postgres unique indexes, so the uniqueness key uses the
+    non-null ``scope_key`` (``"system"`` or ``"workspace:<ref>"``) instead of
+    the raw nullable ``scope_ref``.  ``scope_type``/``scope_ref`` remain as
+    readable data columns.  ``capability_bundle`` is the sorted, comma-joined
+    operation bundle so one role cannot split reads and writes across
+    different credentials.
     """
 
     __tablename__ = "repository_route_defaults"
     __table_args__ = (
         UniqueConstraint(
-            "scope_type",
-            "scope_ref",
+            "scope_key",
             "endpoint_normalized",
             "repo_key",
             "capability_bundle",
@@ -5245,6 +5252,7 @@ class RepositoryRouteDefault(Base):
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
     scope_type: Mapped[str] = mapped_column(String(16), nullable=False)
     scope_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    scope_key: Mapped[str] = mapped_column(String(300), nullable=False)
     endpoint_normalized: Mapped[str] = mapped_column(String(1024), nullable=False)
     repo_key: Mapped[str] = mapped_column(String(1024), nullable=False)
     capability_bundle: Mapped[str] = mapped_column(String(1024), nullable=False)

--- a/api_service/db/models.py
+++ b/api_service/db/models.py
@@ -1677,6 +1677,10 @@ __all__ = [
     "AgentSkillDefinition",
     "SkillSet",
     "SkillSetEntry",
+    "RepositoryConnectionRecord",
+    "RepositoryConnectionAssignment",
+    "RepositoryRouteDefault",
+    "RepositoryConnectionAuditEvent",
 ]
 
 
@@ -5093,4 +5097,196 @@ class MergeAutomationReviewRequestRecord(Base):
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repository connections and transactional routes (#4005).
+#
+# Single writable authority for scoped RepositoryConnections, many-to-many
+# assignments, and per-scope route defaults.  Deployment JSON files are
+# versioned read-only snapshots published from these rows (or classified
+# legacy input); they are never an independently editable fallback policy.
+# ---------------------------------------------------------------------------
+
+
+class RepositoryConnectionRecord(Base):
+    """Durable scoped connection (metadata only; no secret bodies).
+
+    ``connection_id`` is the stable ``RepositoryConnection.id``.  Credential
+    configuration is stored as metadata (SecretRef provider/key or App
+    refs); raw PAT values live only in Managed Secrets / trusted delivery.
+    ``tombstone`` marks a deleted identifier so ID reuse cannot adopt old
+    bindings.  ``policy_revision`` is compared on edits (optimistic
+    concurrency); ``credential_revision`` advances only on rotation.
+    """
+
+    __tablename__ = "repository_connection_records"
+    __table_args__ = (
+        Index("ix_repository_connections_owner", "owner_ref"),
+        Index("ix_repository_connections_scope", "scope_type", "scope_ref"),
+        Index("ix_repository_connections_lifecycle", "lifecycle"),
+    )
+
+    connection_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    provider: Mapped[str] = mapped_column(String(16), nullable=False)
+    hosting_service: Mapped[str] = mapped_column(String(32), nullable=False)
+    endpoint_normalized: Mapped[str] = mapped_column(String(1024), nullable=False)
+    endpoint_ref: Mapped[str] = mapped_column(String(1024), nullable=False)
+    trust_bundle_ref: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    allowed_operations: Mapped[list[str]] = mapped_column(
+        mutable_json_list(), nullable=False, default=list
+    )
+    client_policy: Mapped[dict[str, Any]] = mapped_column(
+        mutable_json_dict(), nullable=False, default=dict
+    )
+    credential_config: Mapped[dict[str, Any]] = mapped_column(
+        mutable_json_dict(), nullable=False, default=dict
+    )
+    lifecycle: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="active", server_default="active"
+    )
+    policy_revision: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    credential_revision: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    owner_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+    scope_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    scope_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    allowed_principal_refs: Mapped[list[str]] = mapped_column(
+        mutable_json_list(), nullable=False, default=list
+    )
+    tombstone: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class RepositoryConnectionAssignment(Base):
+    """Many-to-many scoped grant: one row per (connection, repository)."""
+
+    __tablename__ = "repository_connection_assignments"
+    __table_args__ = (
+        UniqueConstraint(
+            "connection_id",
+            "endpoint_normalized",
+            "repo_key",
+            name="uq_repo_assignment_connection_repo",
+        ),
+        Index("ix_repo_assignment_repo", "endpoint_normalized", "repo_key"),
+        Index("ix_repo_assignment_connection", "connection_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    connection_id: Mapped[str] = mapped_column(
+        String(255),
+        ForeignKey("repository_connection_records.connection_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    endpoint_normalized: Mapped[str] = mapped_column(String(1024), nullable=False)
+    repo_key: Mapped[str] = mapped_column(String(1024), nullable=False)
+    provider_repo_id: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    canonical_remote: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    display_name: Mapped[str] = mapped_column(String(2000), nullable=False)
+    operations: Mapped[list[str]] = mapped_column(
+        mutable_json_list(), nullable=False, default=list
+    )
+    revision: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    verified: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class RepositoryRouteDefault(Base):
+    """At most one default per (scope, repository, capability bundle).
+
+    ``scope_ref`` is NULL for system scope (NULLs are distinct under both
+    SQLite and Postgres unique indexes per the nullable-key contract, and the
+    service normalizes system scope to NULL so the uniqueness rule holds).
+    ``capability_bundle`` is the sorted, comma-joined operation bundle so one
+    role cannot split reads and writes across different credentials.
+    """
+
+    __tablename__ = "repository_route_defaults"
+    __table_args__ = (
+        UniqueConstraint(
+            "scope_type",
+            "scope_ref",
+            "endpoint_normalized",
+            "repo_key",
+            "capability_bundle",
+            name="uq_repo_route_default",
+        ),
+        Index("ix_repo_route_default_repo", "endpoint_normalized", "repo_key"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    scope_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    scope_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    endpoint_normalized: Mapped[str] = mapped_column(String(1024), nullable=False)
+    repo_key: Mapped[str] = mapped_column(String(1024), nullable=False)
+    capability_bundle: Mapped[str] = mapped_column(String(1024), nullable=False)
+    connection_id: Mapped[str] = mapped_column(
+        String(255),
+        ForeignKey("repository_connection_records.connection_id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    policy_revision: Mapped[int] = mapped_column(Integer, nullable=False)
+    request_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class RepositoryConnectionAuditEvent(Base):
+    """Append-only metadata-only audit for connection/assignment/default changes."""
+
+    __tablename__ = "repository_connection_audit_events"
+    __table_args__ = (
+        UniqueConstraint("request_id", "action", name="uq_repo_audit_request_action"),
+        Index("ix_repo_audit_connection", "connection_id"),
+        Index("ix_repo_audit_created", "created_at"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    request_id: Mapped[str] = mapped_column(String(256), nullable=False)
+    actor_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+    action: Mapped[str] = mapped_column(String(64), nullable=False)
+    connection_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    scope_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    scope_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    policy_revision: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    detail_json: Mapped[dict[str, Any]] = mapped_column(
+        mutable_json_dict(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/api_service/migrations/versions/377_repository_connections_4005.py
+++ b/api_service/migrations/versions/377_repository_connections_4005.py
@@ -1,0 +1,262 @@
+"""Scoped repository connections and transactional routes (#4005).
+
+Revision ID: 377_repository_connections_4005
+Revises: 376_drop_manifest_registry_4192
+
+Single writable authority for scoped RepositoryConnections, many-to-many
+assignments, and per-scope route defaults.  Deployment JSON files become
+versioned read-only snapshots published from these rows (or classified
+legacy input); they are never an independently editable fallback policy.
+Credential configuration is metadata-only (SecretRef locators / App refs);
+raw secret bodies live only in Managed Secrets and trusted delivery.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+
+revision: str = "377_repository_connections_4005"
+down_revision: Union[str, None] = "376_drop_manifest_registry_4192"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _json_column() -> sa.Column:
+    return sa.Column(
+        postgresql.JSONB(astext_type=sa.Text()).with_variant(sa.JSON(), "sqlite"),
+        nullable=False,
+        server_default=sa.text("'{}'"),
+    )
+
+
+def _json_list_column() -> sa.Column:
+    return sa.Column(
+        postgresql.JSONB(astext_type=sa.Text()).with_variant(sa.JSON(), "sqlite"),
+        nullable=False,
+        server_default=sa.text("'[]'"),
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "repository_connection_records",
+        sa.Column("connection_id", sa.String(length=255), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("provider", sa.String(length=16), nullable=False),
+        sa.Column("hosting_service", sa.String(length=32), nullable=False),
+        sa.Column("endpoint_normalized", sa.String(length=1024), nullable=False),
+        sa.Column("endpoint_ref", sa.String(length=1024), nullable=False),
+        sa.Column("trust_bundle_ref", sa.String(length=1024), nullable=True),
+        sa.Column("allowed_operations", sa.JSON(), nullable=False),
+        sa.Column("client_policy", sa.JSON(), nullable=False),
+        sa.Column("credential_config", sa.JSON(), nullable=False),
+        sa.Column(
+            "lifecycle",
+            sa.String(length=16),
+            nullable=False,
+            server_default="active",
+        ),
+        sa.Column("policy_revision", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "credential_revision", sa.Integer(), nullable=False, server_default="1"
+        ),
+        sa.Column("owner_ref", sa.String(length=255), nullable=False),
+        sa.Column("scope_type", sa.String(length=16), nullable=False),
+        sa.Column("scope_ref", sa.String(length=255), nullable=True),
+        sa.Column("allowed_principal_refs", sa.JSON(), nullable=False),
+        sa.Column(
+            "tombstone", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("connection_id"),
+    )
+    op.create_index(
+        "ix_repository_connections_owner",
+        "repository_connection_records",
+        ["owner_ref"],
+    )
+    op.create_index(
+        "ix_repository_connections_scope",
+        "repository_connection_records",
+        ["scope_type", "scope_ref"],
+    )
+    op.create_index(
+        "ix_repository_connections_lifecycle",
+        "repository_connection_records",
+        ["lifecycle"],
+    )
+
+    op.create_table(
+        "repository_connection_assignments",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("connection_id", sa.String(length=255), nullable=False),
+        sa.Column("endpoint_normalized", sa.String(length=1024), nullable=False),
+        sa.Column("repo_key", sa.String(length=1024), nullable=False),
+        sa.Column("provider_repo_id", sa.String(length=1024), nullable=True),
+        sa.Column("canonical_remote", sa.String(length=1024), nullable=True),
+        sa.Column("display_name", sa.String(length=2000), nullable=False),
+        sa.Column("operations", sa.JSON(), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "verified", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["connection_id"],
+            ["repository_connection_records.connection_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "connection_id",
+            "endpoint_normalized",
+            "repo_key",
+            name="uq_repo_assignment_connection_repo",
+        ),
+    )
+    op.create_index(
+        "ix_repo_assignment_repo",
+        "repository_connection_assignments",
+        ["endpoint_normalized", "repo_key"],
+    )
+    op.create_index(
+        "ix_repo_assignment_connection",
+        "repository_connection_assignments",
+        ["connection_id"],
+    )
+
+    op.create_table(
+        "repository_route_defaults",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("scope_type", sa.String(length=16), nullable=False),
+        sa.Column("scope_ref", sa.String(length=255), nullable=True),
+        sa.Column("endpoint_normalized", sa.String(length=1024), nullable=False),
+        sa.Column("repo_key", sa.String(length=1024), nullable=False),
+        sa.Column("capability_bundle", sa.String(length=1024), nullable=False),
+        sa.Column("connection_id", sa.String(length=255), nullable=False),
+        sa.Column("policy_revision", sa.Integer(), nullable=False),
+        sa.Column("request_id", sa.String(length=256), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["connection_id"],
+            ["repository_connection_records.connection_id"],
+            ondelete="RESTRICT",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "scope_type",
+            "scope_ref",
+            "endpoint_normalized",
+            "repo_key",
+            "capability_bundle",
+            name="uq_repo_route_default",
+        ),
+    )
+    op.create_index(
+        "ix_repo_route_default_repo",
+        "repository_route_defaults",
+        ["endpoint_normalized", "repo_key"],
+    )
+
+    op.create_table(
+        "repository_connection_audit_events",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("request_id", sa.String(length=256), nullable=False),
+        sa.Column("actor_ref", sa.String(length=255), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("connection_id", sa.String(length=255), nullable=False),
+        sa.Column("scope_type", sa.String(length=16), nullable=False),
+        sa.Column("scope_ref", sa.String(length=255), nullable=True),
+        sa.Column("policy_revision", sa.Integer(), nullable=True),
+        sa.Column("detail_json", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "request_id", "action", name="uq_repo_audit_request_action"
+        ),
+    )
+    op.create_index(
+        "ix_repo_audit_connection",
+        "repository_connection_audit_events",
+        ["connection_id"],
+    )
+    op.create_index(
+        "ix_repo_audit_created",
+        "repository_connection_audit_events",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_repo_audit_created", table_name="repository_connection_audit_events")
+    op.drop_index(
+        "ix_repo_audit_connection", table_name="repository_connection_audit_events"
+    )
+    op.drop_table("repository_connection_audit_events")
+    op.drop_index("ix_repo_route_default_repo", table_name="repository_route_defaults")
+    op.drop_table("repository_route_defaults")
+    op.drop_index(
+        "ix_repo_assignment_connection",
+        table_name="repository_connection_assignments",
+    )
+    op.drop_index(
+        "ix_repo_assignment_repo", table_name="repository_connection_assignments"
+    )
+    op.drop_table("repository_connection_assignments")
+    op.drop_index(
+        "ix_repository_connections_lifecycle",
+        table_name="repository_connection_records",
+    )
+    op.drop_index(
+        "ix_repository_connections_scope",
+        table_name="repository_connection_records",
+    )
+    op.drop_index(
+        "ix_repository_connections_owner",
+        table_name="repository_connection_records",
+    )
+    op.drop_table("repository_connection_records")

--- a/api_service/migrations/versions/377_repository_connections_4005.py
+++ b/api_service/migrations/versions/377_repository_connections_4005.py
@@ -63,6 +63,8 @@ def upgrade() -> None:
         sa.Column("allowed_operations", sa.JSON(), nullable=False),
         sa.Column("client_policy", sa.JSON(), nullable=False),
         sa.Column("credential_config", sa.JSON(), nullable=False),
+        sa.Column("projection_policy", sa.JSON(), nullable=True),
+        sa.Column("merge_coordinator_policy", sa.JSON(), nullable=True),
         sa.Column(
             "lifecycle",
             sa.String(length=16),
@@ -165,6 +167,10 @@ def upgrade() -> None:
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("scope_type", sa.String(length=16), nullable=False),
         sa.Column("scope_ref", sa.String(length=255), nullable=True),
+        # Non-null uniqueness key ("system" or "workspace:<ref>"): NULL
+        # scope_ref values compare distinct in unique indexes on both
+        # PostgreSQL and SQLite, so the uniqueness constraint keys on this.
+        sa.Column("scope_key", sa.String(length=300), nullable=False),
         sa.Column("endpoint_normalized", sa.String(length=1024), nullable=False),
         sa.Column("repo_key", sa.String(length=1024), nullable=False),
         sa.Column("capability_bundle", sa.String(length=1024), nullable=False),
@@ -190,8 +196,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
-            "scope_type",
-            "scope_ref",
+            "scope_key",
             "endpoint_normalized",
             "repo_key",
             "capability_bundle",

--- a/api_service/migrations/versions/377_repository_connections_4005.py
+++ b/api_service/migrations/versions/377_repository_connections_4005.py
@@ -19,7 +19,14 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-__all__ = ["revision", "down_revision", "upgrade", "downgrade"]
+__all__ = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
 
 revision: str = "377_repository_connections_4005"
 down_revision: Union[str, None] = "376_drop_manifest_registry_4192"

--- a/api_service/services/repository_connections.py
+++ b/api_service/services/repository_connections.py
@@ -329,7 +329,7 @@ class RepositoryConnectionService:
         record = await self._get_record(connection.id)
         if record is None or record.tombstone:
             raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
-        current = self._check_use(
+        self._check_use(
             record=record,
             principal_ref=principal_ref,
             principal_scope=principal_scope,

--- a/api_service/services/repository_connections.py
+++ b/api_service/services/repository_connections.py
@@ -1,0 +1,847 @@
+"""Single database/service writer for scoped repository connections (#4005).
+
+Canonical writable authority for connections, assignments, and route
+defaults.  Deployment JSON files are versioned read-only snapshots published
+from these rows (or classified legacy input); this service never reads a
+filesystem record as fallback policy and never prefers a stale snapshot
+because the database is unavailable.
+
+All mutations run in one database transaction together with the
+metadata-only audit record.  Concurrent default/disable/assignment changes
+produce one valid admitted snapshot or an explicit conflict, never a dangling
+binding.  Permission checks precede candidate enumeration and mutation.
+Secret bodies are never persisted here: credential configuration carries only
+SecretRef locators or App refs, and raw PAT-looking values are rejected.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Callable, Sequence
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_service.db.models import (
+    RepositoryConnectionAssignment,
+    RepositoryConnectionAuditEvent,
+    RepositoryConnectionRecord,
+    RepositoryRouteDefault,
+)
+from moonmind.workflows.executions.repository_contract import (
+    REPOSITORY_DENIED,
+    REPOSITORY_ID_REUSE,
+    REPOSITORY_POLICY_CONFLICT,
+    REPOSITORY_ROUTE_CONFLICT,
+    REPOSITORY_SETUP_REQUIRED,
+    RepositoryAssignment,
+    RepositoryConnection,
+    RepositoryIdentity,
+    RepositoryRouteError,
+    authorize_connection_use,
+    normalize_endpoint,
+    normalize_scope,
+    validate_endpoint_retarget,
+    validate_scoped_connection_for_write,
+)
+
+
+class RepositoryConnectionConflict(RepositoryRouteError):
+    """Transactional conflict mapped from a uniqueness/revision violation."""
+
+
+def _forbidden_secret_shapes(config: Mapping[str, Any]) -> str | None:
+    """Reject raw secret bodies in metadata-only credential configuration."""
+
+    forbidden_keys = {"token", "pat", "password", "secret", "bearer"}
+    stack: list[Any] = [config]
+    while stack:
+        item = stack.pop()
+        if isinstance(item, Mapping):
+            for key, value in item.items():
+                lowered = str(key).strip().lower()
+                if lowered in forbidden_keys and isinstance(value, str) and len(value) >= 8:
+                    return str(key)
+                stack.append(value)
+        elif isinstance(item, (list, tuple)):
+            stack.extend(item)
+    return None
+
+
+def _credential_config(connection: RepositoryConnection) -> dict[str, Any]:
+    config = connection.credential.model_dump(by_alias=True, mode="json")
+    offending = _forbidden_secret_shapes(config)
+    if offending:
+        raise RepositoryRouteError(
+            REPOSITORY_DENIED,
+            "credential configuration must be metadata-only (SecretRef/App refs)",
+        )
+    return config
+
+
+def _record_to_connection(record: RepositoryConnectionRecord) -> RepositoryConnection:
+    credential = dict(record.credential_config)
+    ownership = {
+        "ownerRef": record.owner_ref,
+        "scopeType": record.scope_type,
+        "allowedPrincipalRefs": list(record.allowed_principal_refs or []),
+    }
+    if record.scope_ref is not None:
+        ownership["scopeRef"] = record.scope_ref
+    return RepositoryConnection.model_validate(
+        {
+            "schemaVersion": "moonmind.repository-connection.v1",
+            "id": record.connection_id,
+            "provider": record.provider,
+            "displayName": record.display_name,
+            "endpointRef": record.endpoint_ref,
+            "allowedOperations": list(record.allowed_operations or []),
+            "clientPolicy": dict(record.client_policy or {}),
+            "credential": credential,
+            "lifecycle": record.lifecycle,
+            "policyRevision": record.policy_revision,
+            "credentialRevision": record.credential_revision,
+            "ownership": ownership,
+            "hostingService": record.hosting_service,
+        }
+    )
+
+
+def _repo_key_for(identity: RepositoryIdentity) -> str:
+    if (identity.provider_repo_id or "").strip():
+        return f"id:{identity.provider_repo_id.strip()}"
+    return f"remote:{(identity.canonical_remote or '').strip()}"
+
+
+def _assignment_to_row(
+    assignment: RepositoryAssignment, *, endpoint_normalized: str
+) -> RepositoryConnectionAssignment:
+    identity = assignment.identity
+    return RepositoryConnectionAssignment(
+        connection_id=assignment.connection_id,
+        endpoint_normalized=endpoint_normalized,
+        repo_key=_repo_key_for(identity),
+        provider_repo_id=(identity.provider_repo_id or None),
+        canonical_remote=(identity.canonical_remote or None),
+        display_name=identity.display_name,
+        operations=list(assignment.operations),
+        revision=assignment.revision,
+        verified=assignment.verified,
+    )
+
+
+class RepositoryConnectionService:
+    """Transactional writer; one instance per AsyncSession."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    # -- internal helpers -------------------------------------------------
+
+    async def _get_record(self, connection_id: str) -> RepositoryConnectionRecord | None:
+        result = await self._session.execute(
+            select(RepositoryConnectionRecord).where(
+                RepositoryConnectionRecord.connection_id == connection_id
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _audit(
+        self,
+        *,
+        request_id: str,
+        actor_ref: str,
+        action: str,
+        connection_id: str,
+        scope_type: str,
+        scope_ref: str | None,
+        policy_revision: int | None,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        self._session.add(
+            RepositoryConnectionAuditEvent(
+                request_id=request_id.strip(),
+                actor_ref=actor_ref.strip(),
+                action=action,
+                connection_id=connection_id,
+                scope_type=scope_type,
+                scope_ref=scope_ref,
+                policy_revision=policy_revision,
+                detail_json=dict(detail or {}),
+            )
+        )
+
+    async def _replayed_action(
+        self, *, request_id: str, action: str, connection_id: str
+    ) -> bool:
+        """Detect a stable-request-identity retry already recorded in this DB."""
+
+        if not request_id.strip():
+            raise RepositoryRouteError(
+                REPOSITORY_SETUP_REQUIRED, "stable request identity required"
+            )
+        existing = (
+            await self._session.execute(
+                select(RepositoryConnectionAuditEvent).where(
+                    RepositoryConnectionAuditEvent.request_id == request_id.strip(),
+                    RepositoryConnectionAuditEvent.action == action,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            return False
+        # No hidden suffix or fallback creation: a retry reuses the exact
+        # request identity; reuse of one identity for a different connection
+        # is a conflict, never a new suffixed row.
+        if existing.connection_id != connection_id:
+            raise RepositoryRouteError(
+                REPOSITORY_ROUTE_CONFLICT, "request identity already used"
+            )
+        return True
+
+    def _check_use(
+        self,
+        *,
+        record: RepositoryConnectionRecord,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+        action: str,
+    ) -> RepositoryConnection:
+        connection = _record_to_connection(record)
+        authorize_connection_use(
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            connection=connection,
+            action=action,
+        )
+        return connection
+
+    # -- connections ------------------------------------------------------
+
+    async def create_connection(
+        self,
+        connection: RepositoryConnection,
+        *,
+        actor_ref: str,
+        request_id: str,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+    ) -> RepositoryConnection:
+        """Create one scoped connection with its audit record, atomically."""
+
+        validate_scoped_connection_for_write(connection)
+        scope_t, scope_n = normalize_scope(
+            connection.ownership.scope_type,  # type: ignore[union-attr]
+            connection.ownership.scope_ref,  # type: ignore[union-attr]
+        )
+        if await self._replayed_action(
+            request_id=request_id, action="connection.create",
+            connection_id=connection.id,
+        ):
+            existing = await self._get_record(connection.id)
+            if existing is None:
+                raise RepositoryRouteError(
+                    REPOSITORY_ROUTE_CONFLICT, "request identity already used"
+                )
+            return _record_to_connection(existing)
+        if connection.ownership is not None and (
+            principal_ref.strip() != connection.ownership.owner_ref.strip()
+            and principal_scope[0] != "system"
+        ):
+            raise RepositoryRouteError(REPOSITORY_DENIED, "creation not admitted")
+        existing = await self._get_record(connection.id)
+        if existing is not None:
+            if existing.tombstone:
+                raise RepositoryRouteError(
+                    REPOSITORY_ID_REUSE, "connection id was deleted and cannot be reused"
+                )
+            raise RepositoryRouteError(
+                REPOSITORY_ROUTE_CONFLICT, "connection id already exists"
+            )
+        endpoint_normalized = normalize_endpoint(connection.endpoint_ref)
+        record = RepositoryConnectionRecord(
+            connection_id=connection.id,
+            display_name=connection.display_name,
+            provider=connection.provider,
+            hosting_service=connection.hosting_service or "",
+            endpoint_normalized=endpoint_normalized,
+            endpoint_ref=connection.endpoint_ref,
+            trust_bundle_ref=connection.trust_bundle_ref,
+            allowed_operations=list(connection.allowed_operations),
+            client_policy=connection.client_policy.model_dump(
+                by_alias=True, mode="json"
+            ),
+            credential_config=_credential_config(connection),
+            lifecycle=connection.lifecycle,
+            policy_revision=connection.policy_revision,
+            credential_revision=connection.credential_revision,
+            owner_ref=connection.ownership.owner_ref.strip(),  # type: ignore[union-attr]
+            scope_type=scope_t,
+            scope_ref=scope_n,
+            allowed_principal_refs=list(
+                connection.ownership.allowed_principal_refs  # type: ignore[union-attr]
+            ),
+        )
+        self._session.add(record)
+        await self._audit(
+            request_id=request_id,
+            actor_ref=actor_ref,
+            action="connection.create",
+            connection_id=connection.id,
+            scope_type=scope_t,
+            scope_ref=scope_n,
+            policy_revision=connection.policy_revision,
+        )
+        try:
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise RepositoryConnectionConflict(
+                REPOSITORY_ROUTE_CONFLICT, "connection creation conflict"
+            ) from exc
+        return connection
+
+    async def update_connection(
+        self,
+        connection: RepositoryConnection,
+        *,
+        actor_ref: str,
+        request_id: str,
+        expected_policy_revision: int | None,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+        explicit_endpoint_revision: bool = False,
+    ) -> RepositoryConnection:
+        """Replace connection policy transactionally with revision compare."""
+
+        validate_scoped_connection_for_write(connection)
+        if await self._replayed_action(
+            request_id=request_id, action="connection.update",
+            connection_id=connection.id,
+        ):
+            record = await self._get_record(connection.id)
+            if record is None:
+                raise RepositoryRouteError(
+                    REPOSITORY_ROUTE_CONFLICT, "request identity already used"
+                )
+            return _record_to_connection(record)
+        record = await self._get_record(connection.id)
+        if record is None or record.tombstone:
+            raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
+        current = self._check_use(
+            record=record,
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            action="edit",
+        )
+        if expected_policy_revision is not None and (
+            record.policy_revision != expected_policy_revision
+        ):
+            raise RepositoryRouteError(
+                REPOSITORY_POLICY_CONFLICT, "stale policy revision"
+            )
+        validate_endpoint_retarget(
+            current_endpoint=record.endpoint_normalized,
+            proposed_endpoint=connection.endpoint_ref,
+            explicit_revision_path=explicit_endpoint_revision
+            or record.endpoint_normalized == normalize_endpoint(connection.endpoint_ref),
+        )
+        if normalize_endpoint(connection.endpoint_ref) != record.endpoint_normalized and (
+            connection.credential_revision == record.credential_revision
+        ):
+            raise RepositoryRouteError(
+                REPOSITORY_POLICY_CONFLICT,
+                "endpoint change requires a credential revision",
+            )
+        endpoint_normalized = normalize_endpoint(connection.endpoint_ref)
+        record.display_name = connection.display_name
+        record.provider = connection.provider
+        record.hosting_service = connection.hosting_service or ""
+        record.endpoint_normalized = endpoint_normalized
+        record.endpoint_ref = connection.endpoint_ref
+        record.trust_bundle_ref = connection.trust_bundle_ref
+        record.allowed_operations = list(connection.allowed_operations)
+        record.client_policy = connection.client_policy.model_dump(
+            by_alias=True, mode="json"
+        )
+        record.credential_config = _credential_config(connection)
+        record.lifecycle = connection.lifecycle
+        record.policy_revision = record.policy_revision + 1
+        record.credential_revision = connection.credential_revision
+        if connection.ownership is not None:
+            scope_t, scope_n = normalize_scope(
+                connection.ownership.scope_type, connection.ownership.scope_ref
+            )
+            record.owner_ref = connection.ownership.owner_ref.strip()
+            record.scope_type = scope_t
+            record.scope_ref = scope_n
+            record.allowed_principal_refs = list(
+                connection.ownership.allowed_principal_refs
+            )
+        await self._audit(
+            request_id=request_id,
+            actor_ref=actor_ref,
+            action="connection.update",
+            connection_id=connection.id,
+            scope_type=record.scope_type,
+            scope_ref=record.scope_ref,
+            policy_revision=record.policy_revision,
+            detail={"expected_revision": expected_policy_revision},
+        )
+        try:
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise RepositoryConnectionConflict(
+                REPOSITORY_ROUTE_CONFLICT, "connection update conflict"
+            ) from exc
+        await self._session.refresh(record)
+        return _record_to_connection(record)
+
+    async def disable_connection(
+        self,
+        connection_id: str,
+        *,
+        actor_ref: str,
+        request_id: str,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+    ) -> RepositoryConnection:
+        """Disable without breaking active cleanup (bindings stay, use denied)."""
+
+        if await self._replayed_action(
+            request_id=request_id, action="connection.disable",
+            connection_id=connection_id,
+        ):
+            record = await self._get_record(connection_id)
+            if record is None:
+                raise RepositoryRouteError(
+                    REPOSITORY_ROUTE_CONFLICT, "request identity already used"
+                )
+            return _record_to_connection(record)
+        record = await self._get_record(connection_id)
+        if record is None or record.tombstone:
+            raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
+        self._check_use(
+            record=record,
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            action="disable",
+        )
+        record.lifecycle = "disabled"
+        record.policy_revision = record.policy_revision + 1
+        await self._audit(
+            request_id=request_id,
+            actor_ref=actor_ref,
+            action="connection.disable",
+            connection_id=connection_id,
+            scope_type=record.scope_type,
+            scope_ref=record.scope_ref,
+            policy_revision=record.policy_revision,
+        )
+        await self._session.commit()
+        await self._session.refresh(record)
+        return _record_to_connection(record)
+
+    async def delete_connection(
+        self,
+        connection_id: str,
+        *,
+        actor_ref: str,
+        request_id: str,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+        has_active_bindings: Callable[[str], bool] | None = None,
+    ) -> None:
+        """Delete only with no active bindings; tombstone blocks ID reuse."""
+
+        if await self._replayed_action(
+            request_id=request_id, action="connection.delete",
+            connection_id=connection_id,
+        ):
+            return
+        record = await self._get_record(connection_id)
+        if record is None or record.tombstone:
+            raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
+        self._check_use(
+            record=record,
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            action="delete",
+        )
+        if has_active_bindings is not None and has_active_bindings(connection_id):
+            raise RepositoryRouteError(
+                REPOSITORY_ROUTE_CONFLICT, "active bindings block deletion"
+            )
+        remaining = (
+            await self._session.execute(
+                select(RepositoryConnectionAssignment).where(
+                    RepositoryConnectionAssignment.connection_id == connection_id
+                )
+            )
+        ).scalars().all()
+        if remaining:
+            raise RepositoryRouteError(
+                REPOSITORY_ROUTE_CONFLICT, "assignments block deletion"
+            )
+        defaults = (
+            await self._session.execute(
+                select(RepositoryRouteDefault).where(
+                    RepositoryRouteDefault.connection_id == connection_id
+                )
+            )
+        ).scalars().all()
+        if defaults:
+            raise RepositoryRouteError(
+                REPOSITORY_ROUTE_CONFLICT, "route defaults block deletion"
+            )
+        record.lifecycle = "deleted"
+        record.tombstone = True
+        record.policy_revision = record.policy_revision + 1
+        await self._audit(
+            request_id=request_id,
+            actor_ref=actor_ref,
+            action="connection.delete",
+            connection_id=connection_id,
+            scope_type=record.scope_type,
+            scope_ref=record.scope_ref,
+            policy_revision=record.policy_revision,
+        )
+        await self._session.commit()
+
+    # -- assignments ------------------------------------------------------
+
+    async def set_assignment(
+        self,
+        assignment: RepositoryAssignment,
+        *,
+        actor_ref: str,
+        request_id: str,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+    ) -> RepositoryAssignment:
+        """Create or replace one assignment atomically with audit."""
+
+        if await self._replayed_action(
+            request_id=request_id, action="assignment.set",
+            connection_id=assignment.connection_id,
+        ):
+            return assignment
+        record = await self._get_record(assignment.connection_id)
+        if record is None or record.tombstone:
+            raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
+        self._check_use(
+            record=record,
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            action="attach",
+        )
+        if record.lifecycle != "active":
+            raise RepositoryRouteError(REPOSITORY_DENIED, "connection is not active")
+        endpoint_normalized = normalize_endpoint(assignment.identity.endpoint)
+        if endpoint_normalized != record.endpoint_normalized:
+            raise RepositoryRouteError(
+                REPOSITORY_DENIED, "assignment endpoint must match the connection"
+            )
+        if assignment.broad_rule:
+            raise RepositoryRouteError(
+                REPOSITORY_SETUP_REQUIRED, "broad rules need explicit grant"
+            )
+        if not assignment.verified:
+            raise RepositoryRouteError(
+                REPOSITORY_SETUP_REQUIRED, "unverified assignments grant nothing"
+            )
+        existing = (
+            await self._session.execute(
+                select(RepositoryConnectionAssignment).where(
+                    RepositoryConnectionAssignment.connection_id
+                    == assignment.connection_id,
+                    RepositoryConnectionAssignment.endpoint_normalized
+                    == endpoint_normalized,
+                    RepositoryConnectionAssignment.repo_key
+                    == _repo_key_for(assignment.identity),
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            self._session.add(
+                _assignment_to_row(assignment, endpoint_normalized=endpoint_normalized)
+            )
+        else:
+            existing.provider_repo_id = assignment.identity.provider_repo_id
+            existing.canonical_remote = assignment.identity.canonical_remote
+            existing.display_name = assignment.identity.display_name
+            existing.operations = list(assignment.operations)
+            existing.revision = existing.revision + 1
+            existing.verified = assignment.verified
+        await self._audit(
+            request_id=request_id,
+            actor_ref=actor_ref,
+            action="assignment.set",
+            connection_id=assignment.connection_id,
+            scope_type=record.scope_type,
+            scope_ref=record.scope_ref,
+            policy_revision=record.policy_revision,
+            detail={"repo_key": _repo_key_for(assignment.identity)},
+        )
+        try:
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise RepositoryConnectionConflict(
+                REPOSITORY_ROUTE_CONFLICT, "assignment conflict"
+            ) from exc
+        return assignment
+
+    async def remove_assignment(
+        self,
+        *,
+        connection_id: str,
+        identity: RepositoryIdentity,
+        actor_ref: str,
+        request_id: str,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+    ) -> None:
+        """Remove one assignment; never leaves a dangling default binding."""
+
+        if await self._replayed_action(
+            request_id=request_id, action="assignment.remove",
+            connection_id=connection_id,
+        ):
+            return
+        record = await self._get_record(connection_id)
+        if record is None or record.tombstone:
+            raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
+        self._check_use(
+            record=record,
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            action="detach",
+        )
+        endpoint_normalized = normalize_endpoint(identity.endpoint)
+        repo_key = _repo_key_for(identity)
+        await self._session.execute(
+            delete(RepositoryConnectionAssignment).where(
+                RepositoryConnectionAssignment.connection_id == connection_id,
+                RepositoryConnectionAssignment.endpoint_normalized
+                == endpoint_normalized,
+                RepositoryConnectionAssignment.repo_key == repo_key,
+            )
+        )
+        # A removed assignment must not leave a dangling default binding.
+        await self._session.execute(
+            delete(RepositoryRouteDefault).where(
+                RepositoryRouteDefault.connection_id == connection_id,
+                RepositoryRouteDefault.endpoint_normalized == endpoint_normalized,
+                RepositoryRouteDefault.repo_key == repo_key,
+            )
+        )
+        await self._audit(
+            request_id=request_id,
+            actor_ref=actor_ref,
+            action="assignment.remove",
+            connection_id=connection_id,
+            scope_type=record.scope_type,
+            scope_ref=record.scope_ref,
+            policy_revision=record.policy_revision,
+            detail={"repo_key": repo_key},
+        )
+        await self._session.commit()
+
+    # -- route defaults ---------------------------------------------------
+
+    async def set_route_default(
+        self,
+        *,
+        scope_type: str,
+        scope_ref: str | None,
+        identity: RepositoryIdentity,
+        capability_bundle: Sequence[str],
+        connection_id: str,
+        actor_ref: str,
+        request_id: str,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+    ) -> None:
+        """Replace the default for one route key transactionally."""
+
+        if await self._replayed_action(
+            request_id=request_id, action="route_default.set",
+            connection_id=connection_id,
+        ):
+            return
+        bundle = ",".join(
+            sorted(
+                {
+                    str(op).strip().lower()
+                    for op in capability_bundle
+                    if str(op).strip()
+                }
+            )
+        )
+        if not bundle:
+            raise RepositoryRouteError(
+                REPOSITORY_SETUP_REQUIRED, "empty capability bundle"
+            )
+        norm_scope_t, norm_scope_n = normalize_scope(scope_type, scope_ref)
+        record = await self._get_record(connection_id)
+        if record is None or record.tombstone:
+            raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
+        self._check_use(
+            record=record,
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            action="edit",
+        )
+        if record.lifecycle != "active":
+            raise RepositoryRouteError(REPOSITORY_DENIED, "connection is not active")
+        endpoint_normalized = normalize_endpoint(identity.endpoint)
+        repo_key = _repo_key_for(identity)
+        assignment = (
+            await self._session.execute(
+                select(RepositoryConnectionAssignment).where(
+                    RepositoryConnectionAssignment.connection_id == connection_id,
+                    RepositoryConnectionAssignment.endpoint_normalized
+                    == endpoint_normalized,
+                    RepositoryConnectionAssignment.repo_key == repo_key,
+                )
+            )
+        ).scalar_one_or_none()
+        if assignment is None or not assignment.verified:
+            raise RepositoryRouteError(
+                REPOSITORY_SETUP_REQUIRED, "default needs a verified assignment"
+            )
+        existing = (
+            await self._session.execute(
+                select(RepositoryRouteDefault).where(
+                    RepositoryRouteDefault.scope_type == norm_scope_t,
+                    RepositoryRouteDefault.scope_ref == norm_scope_n,
+                    RepositoryRouteDefault.endpoint_normalized == endpoint_normalized,
+                    RepositoryRouteDefault.repo_key == repo_key,
+                    RepositoryRouteDefault.capability_bundle == bundle,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is None:
+            self._session.add(
+                RepositoryRouteDefault(
+                    scope_type=norm_scope_t,
+                    scope_ref=norm_scope_n,
+                    endpoint_normalized=endpoint_normalized,
+                    repo_key=repo_key,
+                    capability_bundle=bundle,
+                    connection_id=connection_id,
+                    policy_revision=record.policy_revision,
+                    request_id=request_id.strip(),
+                )
+            )
+        else:
+            existing.connection_id = connection_id
+            existing.policy_revision = record.policy_revision
+            existing.request_id = request_id.strip()
+        await self._audit(
+            request_id=request_id,
+            actor_ref=actor_ref,
+            action="route_default.set",
+            connection_id=connection_id,
+            scope_type=norm_scope_t,
+            scope_ref=norm_scope_n,
+            policy_revision=record.policy_revision,
+            detail={"repo_key": repo_key, "bundle": bundle},
+        )
+        try:
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise RepositoryConnectionConflict(
+                REPOSITORY_ROUTE_CONFLICT, "concurrent default change conflict"
+            ) from exc
+
+    # -- reads (no filesystem fallback) -----------------------------------
+
+    async def list_admitted_routes(
+        self,
+        *,
+        identity: RepositoryIdentity,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+    ) -> list[tuple[RepositoryConnection, RepositoryAssignment]]:
+        """Enumerate candidates only after authorization (no secret bodies)."""
+
+        endpoint_normalized = normalize_endpoint(identity.endpoint)
+        repo_key = _repo_key_for(identity)
+        rows = (
+            await self._session.execute(
+                select(RepositoryConnectionAssignment).where(
+                    RepositoryConnectionAssignment.endpoint_normalized
+                    == endpoint_normalized,
+                    RepositoryConnectionAssignment.repo_key == repo_key,
+                )
+            )
+        ).scalars().all()
+        admitted: list[tuple[RepositoryConnection, RepositoryAssignment]] = []
+        for row in rows:
+            record = await self._get_record(row.connection_id)
+            if record is None or record.tombstone:
+                continue
+            try:
+                connection = self._check_use(
+                    record=record,
+                    principal_ref=principal_ref,
+                    principal_scope=principal_scope,
+                    action="use",
+                )
+            except RepositoryRouteError:
+                # Denied candidates are filtered without metadata leakage.
+                continue
+            admitted.append(
+                (
+                    connection,
+                    RepositoryAssignment(
+                        connectionId=row.connection_id,
+                        identity=RepositoryIdentity(
+                            endpoint=identity.endpoint,
+                            providerRepoId=row.provider_repo_id,
+                            canonicalRemote=row.canonical_remote,
+                            displayName=row.display_name,
+                        ),
+                        operations=tuple(row.operations or ()),
+                        revision=row.revision,
+                        verified=row.verified,
+                    ),
+                )
+            )
+        return admitted
+
+    async def export_snapshot_connections(
+        self,
+        *,
+        principal_ref: str,
+        principal_scope: tuple[str, str | None],
+    ) -> list[RepositoryConnection]:
+        """Export metadata-only connections the principal may discover."""
+
+        rows = (
+            await self._session.execute(select(RepositoryConnectionRecord))
+        ).scalars().all()
+        visible: list[RepositoryConnection] = []
+        for record in rows:
+            if record.tombstone:
+                continue
+            try:
+                visible.append(
+                    self._check_use(
+                        record=record,
+                        principal_ref=principal_ref,
+                        principal_scope=principal_scope,
+                        action="discover",
+                    )
+                )
+            except RepositoryRouteError:
+                continue
+        return visible
+
+
+__all__ = ["RepositoryConnectionConflict", "RepositoryConnectionService"]

--- a/api_service/services/repository_connections.py
+++ b/api_service/services/repository_connections.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, Callable, Sequence
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,6 +42,7 @@ from moonmind.workflows.executions.repository_contract import (
     authorize_connection_use,
     normalize_endpoint,
     normalize_scope,
+    scope_key_for,
     validate_endpoint_retarget,
     validate_scoped_connection_for_write,
 )
@@ -69,8 +70,38 @@ def _forbidden_secret_shapes(config: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _reject_secret_extras(config: Mapping[str, Any]) -> None:
+    """Enforce the metadata-only allowlist: refs carry no extra payload.
+
+    The key denylist below cannot enumerate every field name a raw secret
+    could hide under (``accessToken``, ``apiKey``, ``value``, ...), so any
+    non-empty ``extra`` mapping is rejected outright: a SecretRef is exactly
+    ``provider`` + ``key``, and App refs carry only their identities.
+    """
+
+    stack: list[Any] = [config]
+    while stack:
+        item = stack.pop()
+        if isinstance(item, Mapping):
+            for key, value in item.items():
+                if (
+                    str(key).strip().lower() == "extra"
+                    and isinstance(value, Mapping)
+                    and len(value) > 0
+                ):
+                    raise RepositoryRouteError(
+                        REPOSITORY_DENIED,
+                        "credential configuration must be metadata-only "
+                        "(provider/key refs carry no extra payload)",
+                    )
+                stack.append(value)
+        elif isinstance(item, (list, tuple)):
+            stack.extend(item)
+
+
 def _credential_config(connection: RepositoryConnection) -> dict[str, Any]:
     config = connection.credential.model_dump(by_alias=True, mode="json")
+    _reject_secret_extras(config)
     offending = _forbidden_secret_shapes(config)
     if offending:
         raise RepositoryRouteError(
@@ -78,6 +109,40 @@ def _credential_config(connection: RepositoryConnection) -> dict[str, Any]:
             "credential configuration must be metadata-only (SecretRef/App refs)",
         )
     return config
+
+
+def _check_credential_revision(
+    *,
+    stored_config: Mapping[str, Any],
+    stored_revision: int,
+    new_config: Mapping[str, Any],
+    new_revision: int,
+    endpoint_changed: bool,
+) -> None:
+    """Fence credential changes with an atomic monotonic revision advance.
+
+    Bindings and capability evidence keyed by ``credential_revision`` must
+    keep resolving the credential material they admitted: a changed
+    configuration (or a retargeted endpoint) requires exactly one revision
+    advance, while an ordinary policy edit must leave the revision
+    untouched.  Anything else is a policy conflict, never a silent
+    re-keying.
+    """
+
+    cred_changed = dict(new_config) != dict(stored_config)
+    if cred_changed or endpoint_changed:
+        if new_revision != stored_revision + 1:
+            raise RepositoryRouteError(
+                REPOSITORY_POLICY_CONFLICT,
+                "credential or endpoint change requires exactly one "
+                "credential-revision advance",
+            )
+    elif new_revision != stored_revision:
+        raise RepositoryRouteError(
+            REPOSITORY_POLICY_CONFLICT,
+            "credential revision must not change without a credential "
+            "or endpoint change",
+        )
 
 
 def _record_to_connection(record: RepositoryConnectionRecord) -> RepositoryConnection:
@@ -89,23 +154,28 @@ def _record_to_connection(record: RepositoryConnectionRecord) -> RepositoryConne
     }
     if record.scope_ref is not None:
         ownership["scopeRef"] = record.scope_ref
-    return RepositoryConnection.model_validate(
-        {
-            "schemaVersion": "moonmind.repository-connection.v1",
-            "id": record.connection_id,
-            "provider": record.provider,
-            "displayName": record.display_name,
-            "endpointRef": record.endpoint_ref,
-            "allowedOperations": list(record.allowed_operations or []),
-            "clientPolicy": dict(record.client_policy or {}),
-            "credential": credential,
-            "lifecycle": record.lifecycle,
-            "policyRevision": record.policy_revision,
-            "credentialRevision": record.credential_revision,
-            "ownership": ownership,
-            "hostingService": record.hosting_service,
-        }
-    )
+    payload: dict[str, Any] = {
+        "schemaVersion": "moonmind.repository-connection.v1",
+        "id": record.connection_id,
+        "provider": record.provider,
+        "displayName": record.display_name,
+        "endpointRef": record.endpoint_ref,
+        "allowedOperations": list(record.allowed_operations or []),
+        "clientPolicy": dict(record.client_policy or {}),
+        "credential": credential,
+        "lifecycle": record.lifecycle,
+        "policyRevision": record.policy_revision,
+        "credentialRevision": record.credential_revision,
+        "ownership": ownership,
+        "hostingService": record.hosting_service,
+    }
+    # Lore policy survives the persistent round-trip instead of being
+    # silently dropped on restart, update, or snapshot export.
+    if record.projection_policy is not None:
+        payload["projection"] = dict(record.projection_policy)
+    if record.merge_coordinator_policy is not None:
+        payload["mergeCoordinator"] = dict(record.merge_coordinator_policy)
+    return RepositoryConnection.model_validate(payload)
 
 
 def _repo_key_for(identity: RepositoryIdentity) -> str:
@@ -217,6 +287,47 @@ class RepositoryConnectionService:
         )
         return connection
 
+    async def _lock_record(
+        self, connection_id: str
+    ) -> RepositoryConnectionRecord | None:
+        """Re-read the connection row holding a write lock where supported.
+
+        Assignment/default/retarget mutations serialize against concurrent
+        removers through this parent-row lock on PostgreSQL (SELECT ... FOR
+        UPDATE).  SQLite serializes writers at the database level and does
+        not support FOR UPDATE, so the plain re-read applies there; the
+        revision guards and uniqueness constraints still fail closed on
+        conflict.
+        """
+
+        stmt = select(RepositoryConnectionRecord).where(
+            RepositoryConnectionRecord.connection_id == connection_id
+        )
+        bind = self._session.get_bind()
+        dialect_name = getattr(getattr(bind, "dialect", None), "name", "") or ""
+        if dialect_name not in {"", "sqlite"}:
+            stmt = stmt.with_for_update()
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    @staticmethod
+    def _stored_assignment(
+        row: RepositoryConnectionAssignment, *, endpoint: str
+    ) -> RepositoryAssignment:
+        """Return the persisted assignment, never the newly submitted one."""
+
+        return RepositoryAssignment(
+            connectionId=row.connection_id,
+            identity=RepositoryIdentity(
+                endpoint=endpoint,
+                providerRepoId=row.provider_repo_id,
+                canonicalRemote=row.canonical_remote,
+                displayName=row.display_name,
+            ),
+            operations=tuple(row.operations or ()),
+            revision=row.revision,
+            verified=row.verified,
+        )
+
     # -- connections ------------------------------------------------------
 
     async def create_connection(
@@ -235,6 +346,12 @@ class RepositoryConnectionService:
             connection.ownership.scope_type,  # type: ignore[union-attr]
             connection.ownership.scope_ref,  # type: ignore[union-attr]
         )
+        # A workspace-scoped principal must not mint system connections and
+        # make the credential usable across workspace scopes.
+        if scope_t == "system" and principal_scope[0] != "system":
+            raise RepositoryRouteError(
+                REPOSITORY_DENIED, "system connections require a system principal"
+            )
         if await self._replayed_action(
             request_id=request_id, action="connection.create",
             connection_id=connection.id,
@@ -244,6 +361,14 @@ class RepositoryConnectionService:
                 raise RepositoryRouteError(
                     REPOSITORY_ROUTE_CONFLICT, "request identity already used"
                 )
+            # Request identities are idempotency keys, not bearer
+            # authorization: apply the normal creation admission before
+            # returning the replayed record.
+            if (
+                principal_ref.strip() != existing.owner_ref.strip()
+                and principal_scope[0] != "system"
+            ):
+                raise RepositoryRouteError(REPOSITORY_DENIED, "creation not admitted")
             return _record_to_connection(existing)
         if connection.ownership is not None and (
             principal_ref.strip() != connection.ownership.owner_ref.strip()
@@ -273,6 +398,16 @@ class RepositoryConnectionService:
                 by_alias=True, mode="json"
             ),
             credential_config=_credential_config(connection),
+            projection_policy=(
+                connection.projection.model_dump(by_alias=True, mode="json")
+                if connection.projection is not None
+                else None
+            ),
+            merge_coordinator_policy=(
+                connection.merge_coordinator.model_dump(by_alias=True, mode="json")
+                if connection.merge_coordinator is not None
+                else None
+            ),
             lifecycle=connection.lifecycle,
             policy_revision=connection.policy_revision,
             credential_revision=connection.credential_revision,
@@ -325,8 +460,16 @@ class RepositoryConnectionService:
                 raise RepositoryRouteError(
                     REPOSITORY_ROUTE_CONFLICT, "request identity already used"
                 )
+            # Request identities are idempotency keys, not bearer
+            # authorization: re-authorize before returning replayed data.
+            self._check_use(
+                record=record,
+                principal_ref=principal_ref,
+                principal_scope=principal_scope,
+                action="edit",
+            )
             return _record_to_connection(record)
-        record = await self._get_record(connection.id)
+        record = await self._lock_record(connection.id)
         if record is None or record.tombstone:
             raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
         self._check_use(
@@ -347,48 +490,99 @@ class RepositoryConnectionService:
             explicit_revision_path=explicit_endpoint_revision
             or record.endpoint_normalized == normalize_endpoint(connection.endpoint_ref),
         )
-        if normalize_endpoint(connection.endpoint_ref) != record.endpoint_normalized and (
-            connection.credential_revision == record.credential_revision
-        ):
-            raise RepositoryRouteError(
-                REPOSITORY_POLICY_CONFLICT,
-                "endpoint change requires a credential revision",
-            )
         endpoint_normalized = normalize_endpoint(connection.endpoint_ref)
-        record.display_name = connection.display_name
-        record.provider = connection.provider
-        record.hosting_service = connection.hosting_service or ""
-        record.endpoint_normalized = endpoint_normalized
-        record.endpoint_ref = connection.endpoint_ref
-        record.trust_bundle_ref = connection.trust_bundle_ref
-        record.allowed_operations = list(connection.allowed_operations)
-        record.client_policy = connection.client_policy.model_dump(
-            by_alias=True, mode="json"
+        endpoint_changed = endpoint_normalized != record.endpoint_normalized
+        new_credential_config = _credential_config(connection)
+        _check_credential_revision(
+            stored_config=dict(record.credential_config or {}),
+            stored_revision=record.credential_revision,
+            new_config=new_credential_config,
+            new_revision=connection.credential_revision,
+            endpoint_changed=endpoint_changed,
         )
-        record.credential_config = _credential_config(connection)
-        record.lifecycle = connection.lifecycle
-        record.policy_revision = record.policy_revision + 1
-        record.credential_revision = connection.credential_revision
+        new_policy_revision = record.policy_revision + 1
         if connection.ownership is not None:
             scope_t, scope_n = normalize_scope(
                 connection.ownership.scope_type, connection.ownership.scope_ref
             )
-            record.owner_ref = connection.ownership.owner_ref.strip()
-            record.scope_type = scope_t
-            record.scope_ref = scope_n
-            record.allowed_principal_refs = list(
-                connection.ownership.allowed_principal_refs
+            owner_ref = connection.ownership.owner_ref.strip()
+            allowed_refs = list(connection.ownership.allowed_principal_refs)
+        else:
+            scope_t, scope_n = record.scope_type, record.scope_ref
+            owner_ref = record.owner_ref
+            allowed_refs = list(record.allowed_principal_refs or [])
+        if endpoint_changed:
+            # Verified assignments and defaults are keyed to the old
+            # endpoint; leaving them would select the retargeted credential
+            # across endpoint authorities, so they are invalidated in the
+            # same transaction (defaults first for referential order).
+            await self._session.execute(
+                delete(RepositoryRouteDefault).where(
+                    RepositoryRouteDefault.connection_id == connection.id
+                )
+            )
+            await self._session.execute(
+                delete(RepositoryConnectionAssignment).where(
+                    RepositoryConnectionAssignment.connection_id == connection.id
+                )
             )
         await self._audit(
             request_id=request_id,
             actor_ref=actor_ref,
             action="connection.update",
             connection_id=connection.id,
-            scope_type=record.scope_type,
-            scope_ref=record.scope_ref,
-            policy_revision=record.policy_revision,
+            scope_type=scope_t,
+            scope_ref=scope_n,
+            policy_revision=new_policy_revision,
             detail={"expected_revision": expected_policy_revision},
         )
+        # Compare-and-set on the revision read above: two sessions that both
+        # passed the in-memory comparison cannot both commit, so concurrent
+        # edits produce the documented conflict instead of lost updates.
+        updated = await self._session.execute(
+            update(RepositoryConnectionRecord)
+            .where(
+                RepositoryConnectionRecord.connection_id == connection.id,
+                RepositoryConnectionRecord.policy_revision == record.policy_revision,
+                RepositoryConnectionRecord.tombstone.is_(False),
+            )
+            .values(
+                display_name=connection.display_name,
+                provider=connection.provider,
+                hosting_service=connection.hosting_service or "",
+                endpoint_normalized=endpoint_normalized,
+                endpoint_ref=connection.endpoint_ref,
+                trust_bundle_ref=connection.trust_bundle_ref,
+                allowed_operations=list(connection.allowed_operations),
+                client_policy=connection.client_policy.model_dump(
+                    by_alias=True, mode="json"
+                ),
+                credential_config=new_credential_config,
+                projection_policy=(
+                    connection.projection.model_dump(by_alias=True, mode="json")
+                    if connection.projection is not None
+                    else None
+                ),
+                merge_coordinator_policy=(
+                    connection.merge_coordinator.model_dump(by_alias=True, mode="json")
+                    if connection.merge_coordinator is not None
+                    else None
+                ),
+                lifecycle=connection.lifecycle,
+                policy_revision=new_policy_revision,
+                credential_revision=connection.credential_revision,
+                owner_ref=owner_ref,
+                scope_type=scope_t,
+                scope_ref=scope_n,
+                allowed_principal_refs=allowed_refs,
+            )
+        )
+        if updated.rowcount != 1:
+            await self._session.rollback()
+            raise RepositoryRouteError(
+                REPOSITORY_POLICY_CONFLICT,
+                "concurrent policy change; retry with the current revision",
+            )
         try:
             await self._session.commit()
         except IntegrityError as exc:
@@ -419,6 +613,12 @@ class RepositoryConnectionService:
                 raise RepositoryRouteError(
                     REPOSITORY_ROUTE_CONFLICT, "request identity already used"
                 )
+            self._check_use(
+                record=record,
+                principal_ref=principal_ref,
+                principal_scope=principal_scope,
+                action="disable",
+            )
             return _record_to_connection(record)
         record = await self._get_record(connection_id)
         if record is None or record.tombstone:
@@ -452,14 +652,35 @@ class RepositoryConnectionService:
         request_id: str,
         principal_ref: str,
         principal_scope: tuple[str, str | None],
-        has_active_bindings: Callable[[str], bool] | None = None,
+        has_active_bindings: Callable[[str], bool],
     ) -> None:
-        """Delete only with no active bindings; tombstone blocks ID reuse."""
+        """Delete only with no active bindings; tombstone blocks ID reuse.
 
+        The binding authority check is mandatory: deletion without
+        consulting the owning execution/binding authority would tombstone a
+        connection while admitted work still depends on its credential, so a
+        missing check fails closed instead of silently proceeding.
+        """
+
+        if has_active_bindings is None:
+            raise RepositoryRouteError(
+                REPOSITORY_SETUP_REQUIRED, "binding authority unavailable"
+            )
         if await self._replayed_action(
             request_id=request_id, action="connection.delete",
             connection_id=connection_id,
         ):
+            record = await self._get_record(connection_id)
+            # No connection data is returned here; a retry against an
+            # already-tombstoned record stays successful, while a live
+            # record still requires delete authority.
+            if record is not None and not record.tombstone:
+                self._check_use(
+                    record=record,
+                    principal_ref=principal_ref,
+                    principal_scope=principal_scope,
+                    action="delete",
+                )
             return
         record = await self._get_record(connection_id)
         if record is None or record.tombstone:
@@ -470,7 +691,7 @@ class RepositoryConnectionService:
             principal_scope=principal_scope,
             action="delete",
         )
-        if has_active_bindings is not None and has_active_bindings(connection_id):
+        if has_active_bindings(connection_id):
             raise RepositoryRouteError(
                 REPOSITORY_ROUTE_CONFLICT, "active bindings block deletion"
             )
@@ -527,8 +748,41 @@ class RepositoryConnectionService:
             request_id=request_id, action="assignment.set",
             connection_id=assignment.connection_id,
         ):
-            return assignment
-        record = await self._get_record(assignment.connection_id)
+            record = await self._get_record(assignment.connection_id)
+            if record is None:
+                raise RepositoryRouteError(
+                    REPOSITORY_ROUTE_CONFLICT, "request identity already used"
+                )
+            self._check_use(
+                record=record,
+                principal_ref=principal_ref,
+                principal_scope=principal_scope,
+                action="attach",
+            )
+            # Return the persisted assignment, never the newly submitted
+            # one: a reused request identity for a different repository or
+            # operation set must not grant authority that does not exist.
+            endpoint_normalized = normalize_endpoint(assignment.identity.endpoint)
+            stored = (
+                await self._session.execute(
+                    select(RepositoryConnectionAssignment).where(
+                        RepositoryConnectionAssignment.connection_id
+                        == assignment.connection_id,
+                        RepositoryConnectionAssignment.endpoint_normalized
+                        == endpoint_normalized,
+                        RepositoryConnectionAssignment.repo_key
+                        == _repo_key_for(assignment.identity),
+                    )
+                )
+            ).scalar_one_or_none()
+            if stored is None:
+                raise RepositoryRouteError(
+                    REPOSITORY_ROUTE_CONFLICT, "request identity already used"
+                )
+            return self._stored_assignment(
+                stored, endpoint=assignment.identity.endpoint
+            )
+        record = await self._lock_record(assignment.connection_id)
         if record is None or record.tombstone:
             raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
         self._check_use(
@@ -568,13 +822,33 @@ class RepositoryConnectionService:
             self._session.add(
                 _assignment_to_row(assignment, endpoint_normalized=endpoint_normalized)
             )
+            stored_revision = assignment.revision
         else:
-            existing.provider_repo_id = assignment.identity.provider_repo_id
-            existing.canonical_remote = assignment.identity.canonical_remote
-            existing.display_name = assignment.identity.display_name
-            existing.operations = list(assignment.operations)
-            existing.revision = existing.revision + 1
-            existing.verified = assignment.verified
+            # Compare-and-set on the submitted revision: concurrent editors
+            # of the same row conflict instead of silently restoring
+            # operations the other edit removed.
+            replaced = await self._session.execute(
+                update(RepositoryConnectionAssignment)
+                .where(
+                    RepositoryConnectionAssignment.id == existing.id,
+                    RepositoryConnectionAssignment.revision == assignment.revision,
+                )
+                .values(
+                    provider_repo_id=assignment.identity.provider_repo_id,
+                    canonical_remote=assignment.identity.canonical_remote,
+                    display_name=assignment.identity.display_name,
+                    operations=list(assignment.operations),
+                    revision=assignment.revision + 1,
+                    verified=assignment.verified,
+                )
+            )
+            if replaced.rowcount != 1:
+                await self._session.rollback()
+                raise RepositoryRouteError(
+                    REPOSITORY_POLICY_CONFLICT,
+                    "concurrent assignment change; retry with the current revision",
+                )
+            stored_revision = assignment.revision + 1
         await self._audit(
             request_id=request_id,
             actor_ref=actor_ref,
@@ -583,7 +857,10 @@ class RepositoryConnectionService:
             scope_type=record.scope_type,
             scope_ref=record.scope_ref,
             policy_revision=record.policy_revision,
-            detail={"repo_key": _repo_key_for(assignment.identity)},
+            detail={
+                "repo_key": _repo_key_for(assignment.identity),
+                "revision": stored_revision,
+            },
         )
         try:
             await self._session.commit()
@@ -592,7 +869,7 @@ class RepositoryConnectionService:
             raise RepositoryConnectionConflict(
                 REPOSITORY_ROUTE_CONFLICT, "assignment conflict"
             ) from exc
-        return assignment
+        return assignment.model_copy(update={"revision": stored_revision})
 
     async def remove_assignment(
         self,
@@ -610,8 +887,16 @@ class RepositoryConnectionService:
             request_id=request_id, action="assignment.remove",
             connection_id=connection_id,
         ):
+            record = await self._get_record(connection_id)
+            if record is not None and not record.tombstone:
+                self._check_use(
+                    record=record,
+                    principal_ref=principal_ref,
+                    principal_scope=principal_scope,
+                    action="detach",
+                )
             return
-        record = await self._get_record(connection_id)
+        record = await self._lock_record(connection_id)
         if record is None or record.tombstone:
             raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
         self._check_use(
@@ -622,20 +907,22 @@ class RepositoryConnectionService:
         )
         endpoint_normalized = normalize_endpoint(identity.endpoint)
         repo_key = _repo_key_for(identity)
+        # A removed assignment must not leave a dangling default binding:
+        # defaults are removed first for referential order, in the same
+        # transaction as the assignment delete.
+        await self._session.execute(
+            delete(RepositoryRouteDefault).where(
+                RepositoryRouteDefault.connection_id == connection_id,
+                RepositoryRouteDefault.endpoint_normalized == endpoint_normalized,
+                RepositoryRouteDefault.repo_key == repo_key,
+            )
+        )
         await self._session.execute(
             delete(RepositoryConnectionAssignment).where(
                 RepositoryConnectionAssignment.connection_id == connection_id,
                 RepositoryConnectionAssignment.endpoint_normalized
                 == endpoint_normalized,
                 RepositoryConnectionAssignment.repo_key == repo_key,
-            )
-        )
-        # A removed assignment must not leave a dangling default binding.
-        await self._session.execute(
-            delete(RepositoryRouteDefault).where(
-                RepositoryRouteDefault.connection_id == connection_id,
-                RepositoryRouteDefault.endpoint_normalized == endpoint_normalized,
-                RepositoryRouteDefault.repo_key == repo_key,
             )
         )
         await self._audit(
@@ -671,6 +958,14 @@ class RepositoryConnectionService:
             request_id=request_id, action="route_default.set",
             connection_id=connection_id,
         ):
+            record = await self._get_record(connection_id)
+            if record is not None and not record.tombstone:
+                self._check_use(
+                    record=record,
+                    principal_ref=principal_ref,
+                    principal_scope=principal_scope,
+                    action="edit",
+                )
             return
         bundle = ",".join(
             sorted(
@@ -686,7 +981,20 @@ class RepositoryConnectionService:
                 REPOSITORY_SETUP_REQUIRED, "empty capability bundle"
             )
         norm_scope_t, norm_scope_n = normalize_scope(scope_type, scope_ref)
-        record = await self._get_record(connection_id)
+        # The connection use-check alone never authorizes the requested
+        # default scope: a principal admitted to a shared connection must
+        # not plant defaults for another workspace (or system) scope.
+        if principal_scope[0] != "system":
+            p_scope_t, p_scope_n = normalize_scope(
+                principal_scope[0], principal_scope[1]
+            )
+            if (norm_scope_t, norm_scope_n) != (p_scope_t, p_scope_n):
+                raise RepositoryRouteError(
+                    REPOSITORY_DENIED,
+                    "route default scope must match the principal scope",
+                )
+        scope_key = scope_key_for(scope_type, scope_ref)
+        record = await self._lock_record(connection_id)
         if record is None or record.tombstone:
             raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection not found")
         self._check_use(
@@ -716,8 +1024,7 @@ class RepositoryConnectionService:
         existing = (
             await self._session.execute(
                 select(RepositoryRouteDefault).where(
-                    RepositoryRouteDefault.scope_type == norm_scope_t,
-                    RepositoryRouteDefault.scope_ref == norm_scope_n,
+                    RepositoryRouteDefault.scope_key == scope_key,
                     RepositoryRouteDefault.endpoint_normalized == endpoint_normalized,
                     RepositoryRouteDefault.repo_key == repo_key,
                     RepositoryRouteDefault.capability_bundle == bundle,
@@ -729,6 +1036,7 @@ class RepositoryConnectionService:
                 RepositoryRouteDefault(
                     scope_type=norm_scope_t,
                     scope_ref=norm_scope_n,
+                    scope_key=scope_key,
                     endpoint_normalized=endpoint_normalized,
                     repo_key=repo_key,
                     capability_bundle=bundle,
@@ -751,6 +1059,26 @@ class RepositoryConnectionService:
             policy_revision=record.policy_revision,
             detail={"repo_key": repo_key, "bundle": bundle},
         )
+        # Re-validate the assignment in the same transaction immediately
+        # before commit: a concurrent remover that committed after the first
+        # read (and after the parent-row lock on backends without row
+        # locking) must turn this into a refusal, never a dangling default.
+        assignment = (
+            await self._session.execute(
+                select(RepositoryConnectionAssignment).where(
+                    RepositoryConnectionAssignment.connection_id == connection_id,
+                    RepositoryConnectionAssignment.endpoint_normalized
+                    == endpoint_normalized,
+                    RepositoryConnectionAssignment.repo_key == repo_key,
+                )
+            )
+        ).scalar_one_or_none()
+        if assignment is None or not assignment.verified:
+            await self._session.rollback()
+            raise RepositoryRouteError(
+                REPOSITORY_ROUTE_CONFLICT,
+                "assignment changed while committing the default",
+            )
         try:
             await self._session.commit()
         except IntegrityError as exc:

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -4,13 +4,37 @@ MM-1219 replaces repository-shaped authoring aliases with one discriminated
 target.  This module owns compilation, connection reconciliation, capability
 derivation, and the pre-mutation readiness check so those decisions cannot
 drift across authoring and runtime code.
+
+MoonLadderStudios/MoonMind#4005 (slice 1) extends this same contract with
+scoped routing semantics:
+
+* Canonical owner: the database/service writer
+  (``api_service.services.repository_connections``) is the single writable
+  authority for connections, assignments, and route defaults.  Deployment
+  JSON files are versioned read-only snapshots or classified legacy input,
+  never an independently editable fallback policy.
+* Snapshot lifecycle: snapshots carry producer, revision, and digest, are
+  published atomically, and runtime consumers must reject stale snapshots
+  rather than prefer a filesystem record because the database is temporarily
+  unavailable.  The coordinated legacy cutover is owned by #4023.
+* Legacy boundary: ``RepositoryConnection.allowed_repository_ids == ()``
+  historically means *unrestricted* at the ``validate_connection_and_client``
+  boundary (not "no assignments"), and the legacy check compares the authored
+  repository *name* even though the field is called IDs.  New scoped admission
+  must never inherit that meaning or relabel names as verified provider IDs;
+  it lives only in the historical loader/validator below.
+* No parallel domain: scoped fields extend ``RepositoryConnection`` in
+  place; assignments/routes are supporting types, not a second connection
+  identity.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any, Literal
 from urllib.parse import urlsplit
@@ -165,12 +189,53 @@ class TrustedNetworkDevelopmentCredential(BaseModel):
     source: Literal["trusted_network_development"]
 
 
+class GitHubAppCredential(BaseModel):
+    """Discriminated GitHub App installation configuration (#4005).
+
+    PATs use typed ``SecretRef`` (``SecretRefCredential``); App configuration
+    is a distinct discriminated variant carrying only references (definition
+    and installation identity), never raw token material.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    source: Literal["github_app"]
+    app_ref: str = Field(alias="appRef", min_length=1)
+    installation_ref: str = Field(alias="installationRef", min_length=1)
+
+
 RepositoryCredential = Annotated[
     GitHubResolverCredential
     | SecretRefCredential
-    | TrustedNetworkDevelopmentCredential,
+    | TrustedNetworkDevelopmentCredential
+    | GitHubAppCredential,
     Field(discriminator="source"),
 ]
+
+
+class ConnectionOwnershipPolicy(BaseModel):
+    """System/workspace ownership and principal-use policy (#4005).
+
+    ``scope_type="system"`` normalizes ``scope_ref`` to ``None``; workspace
+    scope requires an explicit ``scope_ref``.  Knowing a ``SecretRef`` never
+    grants use authority; callers must pass an independent authorization
+    decision (see ``authorize_connection_use``).
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    owner_ref: str = Field(alias="ownerRef", min_length=1)
+    scope_type: Literal["system", "workspace"] = Field(alias="scopeType")
+    scope_ref: str | None = Field(None, alias="scopeRef")
+    allowed_principal_refs: tuple[str, ...] = Field(
+        default=(), alias="allowedPrincipalRefs"
+    )
+
+    @model_validator(mode="after")
+    def _validate_scope(self) -> "ConnectionOwnershipPolicy":
+        if self.scope_type == "system" and self.scope_ref is not None:
+            raise ValueError("system scope must not carry a scope_ref")
+        if self.scope_type == "workspace" and not (self.scope_ref or "").strip():
+            raise ValueError("workspace scope requires a scope_ref")
+        return self
 
 
 class ResolvedRepositoryTarget(BaseModel):
@@ -226,6 +291,16 @@ class RepositoryConnection(BaseModel):
         None, alias="mergeCoordinator"
     )
     credential: RepositoryCredential
+    # --- #4005 scoped-persistence extensions (optional so historical JSON
+    # still validates; new writes must populate them via
+    # validate_scoped_connection_for_write). ---
+    lifecycle: Literal["active", "disabled", "deleted"] = "active"
+    policy_revision: int = Field(default=1, alias="policyRevision", ge=1)
+    credential_revision: int = Field(default=1, alias="credentialRevision", ge=1)
+    ownership: ConnectionOwnershipPolicy | None = None
+    hosting_service: Literal["github", "generic_git", "lore"] | None = Field(
+        None, alias="hostingService"
+    )
 
     @model_validator(mode="after")
     def _validate_provider_policy(self) -> "RepositoryConnection":
@@ -234,10 +309,19 @@ class RepositoryConnection(BaseModel):
             and self.credential.source == "trusted_network_development"
         ):
             raise ValueError("Git connections do not support trusted-network credentials")
-        if self.provider == "lore" and self.credential.source == "github_resolver":
+        if self.provider == "lore" and self.credential.source in {
+            "github_resolver",
+            "github_app",
+        }:
             raise ValueError(
-                "Lore connections do not support GitHub resolver credentials"
+                "Lore connections do not support GitHub resolver/App credentials"
             )
+        if self.provider == "git" and self.credential.source not in {
+            "github_resolver",
+            "secret_ref",
+            "github_app",
+        }:
+            raise ValueError("Git connections require a GitHub-backed credential")
         if self.provider == "git" and (
             self.projection is not None or self.merge_coordinator is not None
         ):
@@ -689,30 +773,588 @@ async def ensure_repository_ready(
     return connection
 
 
+# ---------------------------------------------------------------------------
+# #4005 scoped persistence and transactional routing (same contract domain).
+#
+# Everything below extends RepositoryConnection in place.  There is no
+# parallel connection/target domain: new
+# writes populate the optional scoped fields on RepositoryConnection and are
+# checked by validate_scoped_connection_for_write(); assignments/routes are
+# supporting types, not a second connection identity.
+# ---------------------------------------------------------------------------
+
+REPOSITORY_SETUP_REQUIRED = "REPOSITORY_SETUP_REQUIRED"
+REPOSITORY_ROUTE_AMBIGUOUS = "REPOSITORY_ROUTE_AMBIGUOUS"
+REPOSITORY_ROUTE_UNSUPPORTED = "REPOSITORY_ROUTE_UNSUPPORTED"
+REPOSITORY_ROUTE_CONFLICT = "REPOSITORY_ROUTE_CONFLICT"
+REPOSITORY_DENIED = "REPOSITORY_DENIED"
+REPOSITORY_STALE_SNAPSHOT = "REPOSITORY_STALE_SNAPSHOT"
+REPOSITORY_POLICY_CONFLICT = "REPOSITORY_POLICY_CONFLICT"
+REPOSITORY_ID_REUSE = "REPOSITORY_ID_REUSE"
+REPOSITORY_ENDPOINT_RETARGET = "REPOSITORY_ENDPOINT_RETARGET"
+REPOSITORY_TRANSFER_REAUTHORIZATION = "REPOSITORY_TRANSFER_REAUTHORIZATION"
+
+CONNECTION_SNAPSHOT_SCHEMA_VERSION = "moonmind.repository-connection-snapshot.v1"
+CONNECTION_SNAPSHOT_PRODUCER = "repository-connection-service.v1"
+
+
+class RepositoryRouteError(ValueError):
+    """Stable scoped-routing failure with a machine-readable code."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+class RepositoryIdentity(BaseModel):
+    """Endpoint-scoped verified repository identity (#4005 impl-3).
+
+    Exactly one of ``provider_repo_id`` (endpoint-scoped verified identity
+    such as a GitHub repository ID) or ``canonical_remote`` (normalized
+    endpoint/remote for generic Git without a hosting-service ID) is set.
+    ``display_name`` is a mutable alias for display/lookup only and must
+    never be fabricated into a provider ID.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    endpoint: str = Field(min_length=1)
+    provider_repo_id: str | None = Field(None, alias="providerRepoId")
+    canonical_remote: str | None = Field(None, alias="canonicalRemote")
+    display_name: str = Field(alias="displayName", min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_identity(self) -> "RepositoryIdentity":
+        has_id = bool((self.provider_repo_id or "").strip())
+        has_remote = bool((self.canonical_remote or "").strip())
+        if has_id == has_remote:
+            raise ValueError(
+                "exactly one of providerRepoId or canonicalRemote must be set"
+            )
+        return self
+
+    def route_id(self) -> str:
+        """Stable routing discriminator (never the display alias)."""
+        if (self.provider_repo_id or "").strip():
+            return f"id:{normalize_endpoint(self.endpoint)}#{self.provider_repo_id.strip()}"
+        return f"remote:{normalize_endpoint(self.endpoint)}#{self.canonical_remote.strip()}"
+
+
+class RepositoryAssignment(BaseModel):
+    """One scoped grant of a connection to a repository identity (#4005)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    connection_id: str = Field(alias="connectionId", min_length=1)
+    identity: RepositoryIdentity
+    operations: tuple[str, ...] = Field(min_length=1)
+    revision: int = Field(default=1, ge=1)
+    verified: bool = True
+    broad_rule: bool = Field(default=False, alias="broadRule")
+
+
+class ScopedRouteCandidate(BaseModel):
+    """One eligible (connection, assignment) pair presented to selection."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    connection: RepositoryConnection
+    assignment: RepositoryAssignment
+
+
+class ConnectionChangeRequest(BaseModel):
+    """Versioned mutation envelope with stable request identity (#4005 impl-8)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    schema_version: Literal["moonmind.repository-connection-change.v1"] = Field(
+        alias="schemaVersion"
+    )
+    request_id: str = Field(alias="requestId", min_length=1, max_length=256)
+    expected_policy_revision: int | None = Field(
+        None, alias="expectedPolicyRevision", ge=1
+    )
+    actor_ref: str = Field(alias="actorRef", min_length=1)
+    scope_type: Literal["system", "workspace"] = Field(alias="scopeType")
+    scope_ref: str | None = Field(None, alias="scopeRef")
+
+
+class ConnectionAuditRecord(BaseModel):
+    """Metadata-only audit record sharing the mutation transaction (#4005)."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    schema_version: Literal["moonmind.repository-connection-audit.v1"] = Field(
+        alias="schemaVersion"
+    )
+    request_id: str = Field(alias="requestId", min_length=1)
+    actor_ref: str = Field(alias="actorRef", min_length=1)
+    action: str = Field(min_length=1)
+    connection_id: str = Field(alias="connectionId", min_length=1)
+    scope_type: str = Field(alias="scopeType", min_length=1)
+    scope_ref: str | None = Field(None, alias="scopeRef")
+    policy_revision: int | None = Field(None, alias="policyRevision", ge=1)
+    observed_at: str = Field(alias="observedAt", min_length=1)
+
+
+class RepositoryConnectionSnapshot(BaseModel):
+    """Versioned read-only snapshot published atomically by the DB writer."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", frozen=True)
+    schema_version: Literal["moonmind.repository-connection-snapshot.v1"] = Field(
+        alias="schemaVersion"
+    )
+    producer: str = Field(min_length=1)
+    revision: int = Field(ge=1)
+    digest: str = Field(min_length=1)
+    produced_at: str = Field(alias="producedAt", min_length=1)
+    connections: tuple[RepositoryConnection, ...] = ()
+
+
+def normalize_endpoint(endpoint: str) -> str:
+    """Normalize an endpoint for routing/identity comparison."""
+
+    raw = (endpoint or "").strip()
+    if not raw:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "empty endpoint")
+    if "@" in raw.split("/")[0] and "://" not in raw:
+        raise RepositoryRouteError(REPOSITORY_DENIED, "endpoint must not embed credentials")
+    candidate = raw if "://" in raw else f"https://{raw}"
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError as exc:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "unparseable endpoint") from exc
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    if scheme not in {"http", "https", "lore"} or not host:
+        # Allow lore-endpoint logical refs (e.g. "lore-endpoint:tactics").
+        if raw.startswith("lore-endpoint:") or raw.startswith("trust-bundle:"):
+            return raw.lower()
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "unsupported endpoint")
+    if parsed.username or parsed.password:
+        raise RepositoryRouteError(REPOSITORY_DENIED, "endpoint must not embed credentials")
+    port = f":{parsed.port}" if parsed.port not in (None, 80, 443) else ""
+    path = parsed.path.rstrip("/")
+    return f"{scheme}://{host}{port}{path}".rstrip("/")
+
+
+def normalize_scope(
+    scope_type: str, scope_ref: str | None
+) -> tuple[str, str | None]:
+    """Normalize system/workspace scope (system always carries None)."""
+
+    normalized_type = (scope_type or "").strip().lower()
+    if normalized_type not in {"system", "workspace"}:
+        raise RepositoryRouteError(REPOSITORY_DENIED, "unknown scope type")
+    if normalized_type == "system":
+        return ("system", None)
+    ref = (scope_ref or "").strip()
+    if not ref:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "workspace scope needs a ref")
+    return ("workspace", ref)
+
+
+def is_legacy_unrestricted_connection(connection: RepositoryConnection) -> bool:
+    """Report the historical empty-means-unrestricted semantic.
+
+    ``allowed_repository_ids == ()`` is *unrestricted* at the
+    ``validate_connection_and_client`` boundary.  New scoped admission must
+    never inherit this meaning; it is preserved only by the historical
+    loader/validator.
+    """
+
+    return len(connection.allowed_repository_ids) == 0
+
+
+def validate_scoped_connection_for_write(connection: RepositoryConnection) -> None:
+    """Require new-write scoped fields without creating a parallel domain."""
+
+    if connection.lifecycle == "deleted":
+        raise RepositoryRouteError(REPOSITORY_DENIED, "deleted connections are not writable")
+    if connection.ownership is None:
+        raise RepositoryRouteError(
+            REPOSITORY_SETUP_REQUIRED, "scoped connections require ownership"
+        )
+    normalize_scope(connection.ownership.scope_type, connection.ownership.scope_ref)
+    normalize_endpoint(connection.endpoint_ref)
+    if connection.hosting_service is None:
+        raise RepositoryRouteError(
+            REPOSITORY_SETUP_REQUIRED, "scoped connections require hostingService"
+        )
+    if connection.provider == "git" and connection.hosting_service == "lore":
+        raise RepositoryRouteError(REPOSITORY_DENIED, "git provider cannot use lore hosting")
+    if connection.provider == "lore" and connection.hosting_service == "github":
+        raise RepositoryRouteError(REPOSITORY_DENIED, "lore provider cannot use github hosting")
+    # Credential revision, connection-policy revision, and concrete issuance
+    # are distinct: both revisions must advance independently and neither may
+    # be zero.  Secret bodies are never persisted here (metadata-only: only
+    # SecretRef provider/key or App refs cross this boundary).
+    if connection.policy_revision < 1 or connection.credential_revision < 1:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "invalid revision")
+    if connection.credential.source == "secret_ref":
+        ref = connection.credential.credential_ref
+        if not ref.provider.strip() or not ref.key.strip():
+            raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "invalid SecretRef")
+
+
+def route_key_for(
+    *,
+    scope_type: str,
+    scope_ref: str | None,
+    identity: RepositoryIdentity,
+    capability_bundle: Sequence[str],
+) -> str:
+    """Define the route key once (shared with #4007 selection)."""
+
+    scope_t, scope_n = normalize_scope(scope_type, scope_ref)
+    bundle = ",".join(sorted({str(op).strip().lower() for op in capability_bundle if str(op).strip()}))
+    if not bundle:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "empty capability bundle")
+    scope_part = scope_t if scope_n is None else f"{scope_t}:{scope_n}"
+    return f"{scope_part}|{identity.route_id()}|{bundle}"
+
+
+def default_scope_for(
+    scope_type: str, scope_ref: str | None
+) -> tuple[str, str | None]:
+    """Return the normalized default scope for route/default uniqueness."""
+
+    return normalize_scope(scope_type, scope_ref)
+
+
+def authorize_connection_use(
+    *,
+    principal_ref: str,
+    principal_scope: tuple[str, str | None],
+    connection: RepositoryConnection,
+    action: str,
+    has_secret_possession: bool = False,
+) -> None:
+    """Enforce system/workspace + principal-use authorization.
+
+    ``has_secret_possession`` (knowing a SecretRef) never grants use
+    authority; it is accepted only to document that the check was considered
+    and ignored.
+    """
+
+    _ = has_secret_possession  # possession is explicitly not authority
+    if connection.lifecycle != "active":
+        raise RepositoryRouteError(REPOSITORY_DENIED, "connection is not active")
+    if connection.ownership is None:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection has no ownership")
+    conn_scope = normalize_scope(
+        connection.ownership.scope_type, connection.ownership.scope_ref
+    )
+    p_scope_t, p_scope_n = normalize_scope(principal_scope[0], principal_scope[1])
+    if conn_scope[0] == "system":
+        if p_scope_t not in {"system", "workspace"}:
+            raise RepositoryRouteError(REPOSITORY_DENIED, "scope not admitted")
+    elif conn_scope != (p_scope_t, p_scope_n):
+        raise RepositoryRouteError(REPOSITORY_DENIED, "workspace scope mismatch")
+    allowed = {p.strip() for p in connection.ownership.allowed_principal_refs if p.strip()}
+    if allowed and principal_ref.strip() not in allowed:
+        raise RepositoryRouteError(REPOSITORY_DENIED, "principal is not admitted")
+    if not principal_ref.strip() or not action.strip():
+        raise RepositoryRouteError(REPOSITORY_DENIED, "principal/action required")
+
+
+def admit_scoped_route(
+    *,
+    identity: RepositoryIdentity,
+    requested_operations: Sequence[str],
+    candidates: Sequence[ScopedRouteCandidate],
+    principal_ref: str,
+    principal_scope: tuple[str, str | None],
+) -> ScopedRouteCandidate:
+    """Deterministically select one route for the whole admitted bundle.
+
+    Permission checks precede candidate enumeration; exactly one connection
+    must satisfy the entire requested bundle or selection fails as ambiguous
+    / unsupported / setup-required.  A read default and a write default must
+    not split one role across credentials, and callers must never substitute
+    another connection after the selected route fails.
+    """
+
+    requested = tuple(
+        dict.fromkeys(
+            str(op).strip().lower() for op in requested_operations if str(op).strip()
+        )
+    )
+    if not requested:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "empty capability bundle")
+    if not candidates:
+        # New scoped connections with zero assignments authorize nothing;
+        # missing/unverified scope is setup-required, never a wildcard.
+        raise RepositoryRouteError(
+            REPOSITORY_SETUP_REQUIRED, "no scoped assignments; scope setup required"
+        )
+    eligible: list[ScopedRouteCandidate] = []
+    for candidate in candidates:
+        connection = candidate.connection
+        assignment = candidate.assignment
+        # Permission check precedes enumeration for every candidate.
+        authorize_connection_use(
+            principal_ref=principal_ref,
+            principal_scope=principal_scope,
+            connection=connection,
+            action="use",
+        )
+        if connection.lifecycle != "active":
+            continue
+        if connection.id != assignment.connection_id:
+            continue
+        if not assignment.verified:
+            continue
+        if assignment.broad_rule:
+            # A deliberately broad rule needs explicit permission and
+            # representation; an unadorned broad flag is unsupported here.
+            raise RepositoryRouteError(
+                REPOSITORY_ROUTE_UNSUPPORTED, "broad deployment rules need explicit grant"
+            )
+        if assignment.identity.route_id() != identity.route_id():
+            continue
+        if any(op not in assignment.operations for op in requested):
+            continue
+        if any(op not in connection.allowed_operations for op in requested):
+            continue
+        eligible.append(candidate)
+    if not eligible:
+        raise RepositoryRouteError(
+            REPOSITORY_SETUP_REQUIRED,
+            "no eligible scoped route; scope setup required",
+        )
+    distinct_connections = {c.connection.id for c in eligible}
+    if len(distinct_connections) > 1:
+        raise RepositoryRouteError(
+            REPOSITORY_ROUTE_AMBIGUOUS,
+            "multiple connections satisfy the bundle; declare one explicitly",
+        )
+    # One connection satisfies the whole bundle: deterministic, no subset
+    # explosion, no priority-rule engine, no credential split within the role.
+    return eligible[0]
+
+
+def admit_legacy_free_connection(*args: Any, **kwargs: Any) -> None:
+    """Refuse to admit legacy empty-means-unrestricted scope as new authority.
+
+    Historical unrestricted-empty behavior cannot enter new admission through
+    a legacy serializer: new admission must use ``admit_scoped_route`` with
+    verified assignments.
+    """
+
+    raise RepositoryRouteError(
+        REPOSITORY_SETUP_REQUIRED,
+        "legacy unrestricted-empty scope is not admissible; use scoped assignments",
+    )
+
+
+def reconcile_verified_rename(
+    assignment: RepositoryAssignment,
+    *,
+    verified_provider_repo_id: str,
+    new_display_name: str,
+) -> RepositoryAssignment:
+    """Reconcile a verified rename to the same stable object (alias update)."""
+
+    if assignment.identity.provider_repo_id != verified_provider_repo_id:
+        raise RepositoryRouteError(
+            REPOSITORY_DENIED, "rename must keep the verified provider identity"
+        )
+    if not new_display_name.strip():
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "rename needs a display name")
+    return assignment.model_copy(
+        update={
+            "identity": assignment.identity.model_copy(
+                update={"display_name": new_display_name.strip()}
+            )
+        }
+    )
+
+
+def invalidate_on_owner_transfer(
+    assignment: RepositoryAssignment, *, new_owner_ref: str
+) -> RepositoryAssignment:
+    """Invalidate policy/capability evidence until reauthorized after transfer."""
+
+    if not new_owner_ref.strip():
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "transfer needs an owner")
+    # Transfer invalidates evidence: the assignment becomes unverified until
+    # an explicit reauthorization path re-verifies it.
+    return assignment.model_copy(update={"verified": False})
+
+
+def validate_endpoint_retarget(
+    *,
+    current_endpoint: str,
+    proposed_endpoint: str,
+    explicit_revision_path: bool,
+) -> None:
+    """Require an explicit validated revision for endpoint/account retargets.
+
+    Retargeting an existing credential to a different endpoint/account is not
+    a cosmetic label edit.  Credentials must never be forwarded to the
+    proposed endpoint merely to discover whether it is safe.
+    """
+
+    if normalize_endpoint(current_endpoint) == normalize_endpoint(proposed_endpoint):
+        return
+    if not explicit_revision_path:
+        raise RepositoryRouteError(
+            REPOSITORY_ENDPOINT_RETARGET,
+            "endpoint retarget requires an explicit validated revision/new connection",
+        )
+
+
+def build_connection_audit_record(
+    *,
+    actor_ref: str,
+    request_id: str,
+    action: str,
+    connection: RepositoryConnection,
+) -> ConnectionAuditRecord:
+    """Build a metadata-only audit record (no secret bodies)."""
+
+    if connection.ownership is None:
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection has no ownership")
+    if not request_id.strip():
+        raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "stable request identity required")
+    return ConnectionAuditRecord(
+        schemaVersion="moonmind.repository-connection-audit.v1",
+        requestId=request_id.strip(),
+        actorRef=actor_ref.strip(),
+        action=action.strip(),
+        connectionId=connection.id,
+        scopeType=connection.ownership.scope_type,
+        scopeRef=connection.ownership.scope_ref,
+        policyRevision=connection.policy_revision,
+        observedAt=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def route_diagnostic(code: str, *, authorized_for_details: bool) -> str:
+    """Render safe conflict/denial diagnostics without metadata leakage."""
+
+    if authorized_for_details:
+        return code
+    if code in {REPOSITORY_DENIED, REPOSITORY_SETUP_REQUIRED}:
+        return REPOSITORY_DENIED
+    return code
+
+
+def publish_connection_snapshot(
+    connections: Sequence[RepositoryConnection], path: Path, *, revision: int
+) -> RepositoryConnectionSnapshot:
+    """Atomically publish a versioned read-only snapshot (DB writer only)."""
+
+    payload = [c.model_dump(by_alias=True, mode="json") for c in connections]
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    snapshot = RepositoryConnectionSnapshot(
+        schemaVersion=CONNECTION_SNAPSHOT_SCHEMA_VERSION,
+        producer=CONNECTION_SNAPSHOT_PRODUCER,
+        revision=revision,
+        digest=digest,
+        producedAt=datetime.now(timezone.utc).isoformat(),
+        connections=tuple(connections),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(snapshot.model_dump(by_alias=True, mode="json"), sort_keys=True),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+    return snapshot
+
+
+def load_connection_snapshot(
+    path: Path, *, minimum_revision: int = 1, allow_stale: bool = False
+) -> RepositoryConnectionSnapshot:
+    """Load a snapshot; fail on stale/digest mismatch, never silently use it.
+
+    Consumers must never prefer a stale filesystem record because the
+    database is temporarily unavailable; pass ``allow_stale=True`` only for
+    the classified-legacy-input path owned by #4023.
+    """
+
+    try:
+        snapshot = RepositoryConnectionSnapshot.model_validate_json(
+            path.read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError) as exc:
+        raise RepositoryRouteError(
+            REPOSITORY_STALE_SNAPSHOT, "connection snapshot is unavailable"
+        ) from exc
+    payload = [
+        c.model_dump(by_alias=True, mode="json") for c in snapshot.connections
+    ]
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+    if digest != snapshot.digest:
+        raise RepositoryRouteError(REPOSITORY_STALE_SNAPSHOT, "snapshot digest mismatch")
+    if snapshot.revision < minimum_revision and not allow_stale:
+        raise RepositoryRouteError(
+            REPOSITORY_STALE_SNAPSHOT, "snapshot is stale; refresh from the database"
+        )
+    return snapshot
+
+
 __all__ = [
     "AuthoredGitRepositoryTarget",
     "AuthoredLoreRepositoryTarget",
     "AuthoredRepositoryTarget",
     "CapabilityReadinessRegistry",
+    "ConnectionAuditRecord",
+    "ConnectionChangeRequest",
+    "ConnectionOwnershipPolicy",
+    "CONNECTION_SNAPSHOT_PRODUCER",
+    "CONNECTION_SNAPSHOT_SCHEMA_VERSION",
     "DEFAULT_GIT_CONNECTION_REF",
+    "GitHubAppCredential",
     "LEGACY_REPOSITORY_DECODER_VERSION",
+    "REPOSITORY_DENIED",
+    "REPOSITORY_ENDPOINT_RETARGET",
+    "REPOSITORY_ID_REUSE",
+    "REPOSITORY_POLICY_CONFLICT",
+    "REPOSITORY_ROUTE_AMBIGUOUS",
+    "REPOSITORY_ROUTE_CONFLICT",
+    "REPOSITORY_ROUTE_UNSUPPORTED",
+    "REPOSITORY_SETUP_REQUIRED",
+    "REPOSITORY_STALE_SNAPSHOT",
+    "REPOSITORY_TRANSFER_REAUTHORIZATION",
+    "RepositoryAssignment",
     "RepositoryClientEvidence",
     "RepositoryClientPolicy",
+    "RepositoryConnectionSnapshot",
     "RepositoryCredential",
     "RepositoryConnection",
     "RepositoryContractError",
+    "RepositoryIdentity",
+    "RepositoryRouteError",
     "ResolvedRepositoryTarget",
+    "ScopedRouteCandidate",
+    "admit_legacy_free_connection",
+    "admit_scoped_route",
+    "authorize_connection_use",
+    "build_connection_audit_record",
     "compile_repository_target",
     "decode_legacy_repository_history_v1",
+    "default_scope_for",
     "derive_repository_capabilities",
     "ensure_repository_ready",
     "github_repository_name_from_value",
+    "invalidate_on_owner_transfer",
+    "is_legacy_unrestricted_connection",
+    "load_connection_snapshot",
     "load_repository_connection",
     "materialize_resolved_repository_target",
+    "normalize_endpoint",
+    "normalize_scope",
     "persist_repository_connection",
+    "publish_connection_snapshot",
+    "reconcile_default_git_connection",
+    "reconcile_verified_rename",
     "repository_branch_from_value",
     "repository_name_from_value",
-    "reconcile_default_git_connection",
     "resolve_default_git_credential",
+    "route_diagnostic",
+    "route_key_for",
     "validate_connection_and_client",
+    "validate_endpoint_retarget",
+    "validate_scoped_connection_for_write",
 ]

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -32,7 +32,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import tempfile
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -488,13 +490,10 @@ def reconcile_default_git_connection(
 def persist_repository_connection(connection: RepositoryConnection, path: Path) -> None:
     """Atomically reconcile one deployment-owned connection record."""
 
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(
+    _atomic_write_text(
+        path,
         json.dumps(connection.model_dump(by_alias=True, mode="json"), sort_keys=True),
-        encoding="utf-8",
     )
-    temporary.replace(path)
 
 
 def load_repository_connection(path: Path, connection_ref: str) -> RepositoryConnection:
@@ -928,7 +927,11 @@ def normalize_endpoint(endpoint: str) -> str:
         raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "unsupported endpoint")
     if parsed.username or parsed.password:
         raise RepositoryRouteError(REPOSITORY_DENIED, "endpoint must not embed credentials")
-    port = f":{parsed.port}" if parsed.port not in (None, 80, 443) else ""
+    # Strip only the default port for the selected scheme: http://host:443 and
+    # https://host:80 are distinct network authorities and must not compare
+    # equal to their unqualified forms.
+    default_port = {"http": 80, "https": 443}.get(scheme)
+    port = f":{parsed.port}" if parsed.port not in (None, default_port) else ""
     path = parsed.path.rstrip("/")
     return f"{scheme}://{host}{port}{path}".rstrip("/")
 
@@ -976,10 +979,34 @@ def validate_scoped_connection_for_write(connection: RepositoryConnection) -> No
         raise RepositoryRouteError(
             REPOSITORY_SETUP_REQUIRED, "scoped connections require hostingService"
         )
-    if connection.provider == "git" and connection.hosting_service == "lore":
-        raise RepositoryRouteError(REPOSITORY_DENIED, "git provider cannot use lore hosting")
-    if connection.provider == "lore" and connection.hosting_service == "github":
-        raise RepositoryRouteError(REPOSITORY_DENIED, "lore provider cannot use github hosting")
+    # Legacy ambient resolution is read-only history: new scoped writes must
+    # name the PAT or installation owned by the connection (typed SecretRef
+    # or App reference), never resolve ambient credentials.
+    if connection.credential.source == "github_resolver":
+        raise RepositoryRouteError(
+            REPOSITORY_DENIED,
+            "scoped writes require a typed SecretRef or App credential",
+        )
+    # Complete provider x hosting-service x credential matrix (rejecting only
+    # two combinations admits mismatched adapters, e.g. lore+generic_git or a
+    # GitHub App credential on a generic-Git host).
+    if connection.provider == "git":
+        if connection.hosting_service not in {"github", "generic_git"}:
+            raise RepositoryRouteError(
+                REPOSITORY_DENIED, "git provider requires github or generic_git hosting"
+            )
+        if (
+            connection.credential.source == "github_app"
+            and connection.hosting_service != "github"
+        ):
+            raise RepositoryRouteError(
+                REPOSITORY_DENIED, "GitHub App credentials require github hosting"
+            )
+    else:  # provider == "lore"
+        if connection.hosting_service != "lore":
+            raise RepositoryRouteError(
+                REPOSITORY_DENIED, "lore provider requires lore hosting"
+            )
     # Credential revision, connection-policy revision, and concrete issuance
     # are distinct: both revisions must advance independently and neither may
     # be zero.  Secret bodies are never persisted here (metadata-only: only
@@ -1017,6 +1044,20 @@ def default_scope_for(
     return normalize_scope(scope_type, scope_ref)
 
 
+def scope_key_for(scope_type: str, scope_ref: str | None) -> str:
+    """Return the non-null uniqueness key for a scope.
+
+    System scope normalizes ``scope_ref`` to ``None``, and NULLs compare
+    distinct in unique indexes on both SQLite and PostgreSQL, so the route
+    default uniqueness constraint keys on this non-null value instead.
+    """
+
+    scope_t, scope_n = normalize_scope(scope_type, scope_ref)
+    if scope_n is None:
+        return scope_t
+    return f"{scope_t}:{scope_n}"
+
+
 def authorize_connection_use(
     *,
     principal_ref: str,
@@ -1030,13 +1071,28 @@ def authorize_connection_use(
     ``has_secret_possession`` (knowing a SecretRef) never grants use
     authority; it is accepted only to document that the check was considered
     and ignored.
+
+    Use/discovery authority (``use``, ``discover``) is granted to admitted
+    principals on active connections.  Policy-changing actions (everything
+    else: ``edit``, ``attach``, ``detach``, ``disable``, ``delete``, ...) are
+    administrative and additionally require the connection owner or an
+    admitted system principal; the admission list still applies, so a
+    stranger with system scope administers nothing.  Disabled connections
+    stay unavailable for acquisition and attachment, but their owner (or an
+    admitted system principal) may still perform the administrative actions
+    needed to clean up or reactivate them instead of leaving the record
+    permanently stranded.  Deleted connections admit nothing.
     """
 
     _ = has_secret_possession  # possession is explicitly not authority
-    if connection.lifecycle != "active":
-        raise RepositoryRouteError(REPOSITORY_DENIED, "connection is not active")
+    normalized_action = action.strip().lower()
+    if connection.lifecycle == "deleted":
+        raise RepositoryRouteError(REPOSITORY_DENIED, "connection is deleted")
     if connection.ownership is None:
         raise RepositoryRouteError(REPOSITORY_SETUP_REQUIRED, "connection has no ownership")
+    is_admin_action = normalized_action not in {"use", "discover"}
+    if connection.lifecycle != "active" and not is_admin_action:
+        raise RepositoryRouteError(REPOSITORY_DENIED, "connection is not active")
     conn_scope = normalize_scope(
         connection.ownership.scope_type, connection.ownership.scope_ref
     )
@@ -1051,6 +1107,14 @@ def authorize_connection_use(
         raise RepositoryRouteError(REPOSITORY_DENIED, "principal is not admitted")
     if not principal_ref.strip() or not action.strip():
         raise RepositoryRouteError(REPOSITORY_DENIED, "principal/action required")
+    if is_admin_action and (
+        principal_ref.strip() != connection.ownership.owner_ref.strip()
+        and p_scope_t != "system"
+    ):
+        raise RepositoryRouteError(
+            REPOSITORY_DENIED,
+            "administrative action requires owner or system authority",
+        )
 
 
 def admit_scoped_route(
@@ -1227,13 +1291,65 @@ def build_connection_audit_record(
 
 
 def route_diagnostic(code: str, *, authorized_for_details: bool) -> str:
-    """Render safe conflict/denial diagnostics without metadata leakage."""
+    """Render safe conflict/denial diagnostics without metadata leakage.
+
+    Every route-state diagnostic derived from protected connection metadata
+    maps to the same non-enumerating denial for unauthorized callers, so
+    codes like AMBIGUOUS cannot reveal how many connections match a target.
+    Only the local snapshot-file condition (stale/unavailable, identical for
+    all callers) passes through unchanged.
+    """
 
     if authorized_for_details:
         return code
-    if code in {REPOSITORY_DENIED, REPOSITORY_SETUP_REQUIRED}:
-        return REPOSITORY_DENIED
-    return code
+    if code == REPOSITORY_STALE_SNAPSHOT:
+        return code
+    return REPOSITORY_DENIED
+
+
+def _snapshot_envelope(
+    connections: Sequence[RepositoryConnection], *, revision: int, produced_at: str
+) -> dict[str, Any]:
+    """Canonical snapshot envelope covered by the digest (excluding digest)."""
+
+    return {
+        "schemaVersion": CONNECTION_SNAPSHOT_SCHEMA_VERSION,
+        "producer": CONNECTION_SNAPSHOT_PRODUCER,
+        "revision": revision,
+        "producedAt": produced_at,
+        "connections": [c.model_dump(by_alias=True, mode="json") for c in connections],
+    }
+
+
+def _snapshot_digest(envelope: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(envelope, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write through a unique temp file, then atomically replace the target.
+
+    Concurrent publishers to the same path must never share one ``.tmp``
+    pathname: each writer fsyncs its own unique file before replacing.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
 
 
 def publish_connection_snapshot(
@@ -1241,25 +1357,22 @@ def publish_connection_snapshot(
 ) -> RepositoryConnectionSnapshot:
     """Atomically publish a versioned read-only snapshot (DB writer only)."""
 
-    payload = [c.model_dump(by_alias=True, mode="json") for c in connections]
-    digest = hashlib.sha256(
-        json.dumps(payload, sort_keys=True).encode("utf-8")
-    ).hexdigest()
+    produced_at = datetime.now(timezone.utc).isoformat()
+    envelope = _snapshot_envelope(
+        connections, revision=revision, produced_at=produced_at
+    )
     snapshot = RepositoryConnectionSnapshot(
         schemaVersion=CONNECTION_SNAPSHOT_SCHEMA_VERSION,
         producer=CONNECTION_SNAPSHOT_PRODUCER,
         revision=revision,
-        digest=digest,
-        producedAt=datetime.now(timezone.utc).isoformat(),
+        digest=_snapshot_digest(envelope),
+        producedAt=produced_at,
         connections=tuple(connections),
     )
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(
+    _atomic_write_text(
+        path,
         json.dumps(snapshot.model_dump(by_alias=True, mode="json"), sort_keys=True),
-        encoding="utf-8",
     )
-    temporary.replace(path)
     return snapshot
 
 
@@ -1281,11 +1394,16 @@ def load_connection_snapshot(
         raise RepositoryRouteError(
             REPOSITORY_STALE_SNAPSHOT, "connection snapshot is unavailable"
         ) from exc
-    payload = [
-        c.model_dump(by_alias=True, mode="json") for c in snapshot.connections
-    ]
-    digest = hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
-    if digest != snapshot.digest:
+    if snapshot.producer != CONNECTION_SNAPSHOT_PRODUCER:
+        raise RepositoryRouteError(
+            REPOSITORY_STALE_SNAPSHOT, "snapshot producer is not recognized"
+        )
+    envelope = _snapshot_envelope(
+        snapshot.connections,
+        revision=snapshot.revision,
+        produced_at=snapshot.produced_at,
+    )
+    if _snapshot_digest(envelope) != snapshot.digest:
         raise RepositoryRouteError(REPOSITORY_STALE_SNAPSHOT, "snapshot digest mismatch")
     if snapshot.revision < minimum_revision and not allow_stale:
         raise RepositoryRouteError(
@@ -1354,6 +1472,7 @@ __all__ = [
     "resolve_default_git_credential",
     "route_diagnostic",
     "route_key_for",
+    "scope_key_for",
     "validate_connection_and_client",
     "validate_endpoint_retarget",
     "validate_scoped_connection_for_write",

--- a/moonmind/workflows/executions/repository_contract.py
+++ b/moonmind/workflows/executions/repository_contract.py
@@ -1348,6 +1348,8 @@ def _atomic_write_text(path: Path, text: str) -> None:
         try:
             os.unlink(temporary)
         except OSError:
+            # Best-effort temp cleanup only: the file may already be gone;
+            # the original error propagating below is what matters.
             pass
         raise
 

--- a/tests/unit/workflows/executions/test_repository_scoped_routes_4005.py
+++ b/tests/unit/workflows/executions/test_repository_scoped_routes_4005.py
@@ -1,0 +1,626 @@
+"""Acceptance coverage for MoonLadderStudios/MoonMind#4005.
+
+Scoped RepositoryConnections + transactional repository routes: one
+database/service writer, metadata-only PAT wiring, zero-assignments-grant-
+nothing, deterministic whole-bundle selection, transactional uniqueness,
+rename/transfer/endpoint handling, authorization, and versioned snapshots.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from api_service.db.models import (
+    Base,
+    RepositoryConnectionAssignment,
+    RepositoryConnectionAuditEvent,
+    RepositoryConnectionRecord,
+    RepositoryRouteDefault,
+)
+from api_service.services.repository_connections import RepositoryConnectionService
+from moonmind.workflows.executions.repository_contract import (
+    REPOSITORY_DENIED,
+    REPOSITORY_SETUP_REQUIRED,
+    RepositoryAssignment,
+    RepositoryConnection,
+    RepositoryIdentity,
+    RepositoryRouteError,
+    ScopedRouteCandidate,
+    admit_legacy_free_connection,
+    admit_scoped_route,
+    authorize_connection_use,
+    build_connection_audit_record,
+    invalidate_on_owner_transfer,
+    is_legacy_unrestricted_connection,
+    load_connection_snapshot,
+    load_repository_connection,
+    persist_repository_connection,
+    publish_connection_snapshot,
+    reconcile_default_git_connection,
+    reconcile_verified_rename,
+    route_diagnostic,
+    route_key_for,
+    validate_connection_and_client,
+    validate_endpoint_retarget,
+    validate_scoped_connection_for_write,
+)
+
+
+def _policy() -> dict:
+    return {
+        "pinnedVersion": "2.46.0",
+        "toolBundleRef": "tool-bundle:git-2.46",
+        "executableSha256": "sha256:git",
+    }
+
+
+def _pat_connection(
+    connection_id: str,
+    *,
+    owner: str = "owner:team-a",
+    scope: str = "system",
+    scope_ref: str | None = None,
+    operations: tuple[str, ...] = ("read", "write"),
+    secret_key: str = "TEAM_A_PAT",
+) -> RepositoryConnection:
+    ownership: dict = {
+        "ownerRef": owner,
+        "scopeType": scope,
+        "allowedPrincipalRefs": [owner],
+    }
+    if scope_ref is not None:
+        ownership["scopeRef"] = scope_ref
+    return RepositoryConnection.model_validate(
+        {
+            "schemaVersion": "moonmind.repository-connection.v1",
+            "id": connection_id,
+            "provider": "git",
+            "displayName": f"Connection {connection_id}",
+            "endpointRef": "https://github.com",
+            "allowedOperations": list(operations),
+            "clientPolicy": _policy(),
+            "credential": {
+                "source": "secret_ref",
+                "credentialRef": {"provider": "managed", "key": secret_key},
+            },
+            "lifecycle": "active",
+            "policyRevision": 1,
+            "credentialRevision": 1,
+            "ownership": ownership,
+            "hostingService": "github",
+        }
+    )
+
+
+def _identity(
+    repo_id: str, *, display: str = "MoonLadderStudios/MoonMind"
+) -> RepositoryIdentity:
+    return RepositoryIdentity(
+        endpoint="https://github.com",
+        providerRepoId=repo_id,
+        displayName=display,
+    )
+
+
+def _assignment(
+    connection_id: str, repo_id: str, *, operations=("read", "write")
+) -> RepositoryAssignment:
+    return RepositoryAssignment(
+        connectionId=connection_id,
+        identity=_identity(repo_id),
+        operations=tuple(operations),
+        revision=1,
+        verified=True,
+    )
+
+
+@asynccontextmanager
+async def route_db(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path}/repository-routes-4005.db", future=True
+    )
+    sessions = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync: Base.metadata.create_all(
+                sync,
+                tables=[
+                    RepositoryConnectionRecord.__table__,
+                    RepositoryConnectionAssignment.__table__,
+                    RepositoryRouteDefault.__table__,
+                    RepositoryConnectionAuditEvent.__table__,
+                ],
+            )
+        )
+    try:
+        yield sessions
+    finally:
+        await engine.dispose()
+
+
+# -- impl-2: metadata-only PAT wiring --------------------------------------
+
+
+def test_pat_credential_is_metadata_only_and_raw_bodies_rejected() -> None:
+    from api_service.services.repository_connections import _credential_config
+
+    connection = _pat_connection("repository-connection:team-a")
+    dumped = connection.model_dump(by_alias=True, mode="json")
+    assert dumped["credential"]["credentialRef"]["key"] == "TEAM_A_PAT"
+    assert "token" not in dumped["credential"]
+    validate_scoped_connection_for_write(connection)  # good connection passes
+
+    bad = RepositoryConnection.model_validate(
+        {
+            **connection.model_dump(by_alias=True, mode="json"),
+            "credential": {
+                "source": "secret_ref",
+                "credentialRef": {
+                    "provider": "managed",
+                    "key": "TEAM_A_PAT",
+                    "extra": {"token": "ghp_" + "x" * 30},
+                },
+            },
+        }
+    )
+    # Metadata-only enforcement lives at the writer boundary.
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        _credential_config(bad)
+
+
+def test_github_app_is_discriminated_variant() -> None:
+    connection = RepositoryConnection.model_validate(
+        {
+            "schemaVersion": "moonmind.repository-connection.v1",
+            "id": "repository-connection:app",
+            "provider": "git",
+            "displayName": "App connection",
+            "endpointRef": "https://github.com",
+            "allowedOperations": ["read"],
+            "clientPolicy": _policy(),
+            "credential": {
+                "source": "github_app",
+                "appRef": "github-app:moonmind",
+                "installationRef": "installation:123",
+            },
+            "lifecycle": "active",
+            "policyRevision": 1,
+            "credentialRevision": 1,
+            "ownership": {
+                "ownerRef": "owner:team-a",
+                "scopeType": "system",
+                "allowedPrincipalRefs": ["owner:team-a"],
+            },
+            "hostingService": "github",
+        }
+    )
+    assert connection.credential.source == "github_app"
+
+
+# -- impl-3: identity and assignment semantics ------------------------------
+
+
+def test_zero_assignments_grant_nothing_and_legacy_is_refused() -> None:
+    connection = _pat_connection("repository-connection:team-a")
+    identity = _identity("repo-id-1")
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_SETUP_REQUIRED"):
+        admit_scoped_route(
+            identity=identity,
+            requested_operations=["read"],
+            candidates=[],
+            principal_ref="owner:team-a",
+            principal_scope=("system", None),
+        )
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_SETUP_REQUIRED"):
+        admit_legacy_free_connection()
+    # Historical semantic is preserved but classified: empty allowlist is
+    # unrestricted at the legacy boundary only.
+    legacy = reconcile_default_git_connection(
+        client_policy=RepositoryConnection.model_validate(
+            {
+                "schemaVersion": "moonmind.repository-connection.v1",
+                "id": "x",
+                "provider": "git",
+                "displayName": "x",
+                "endpointRef": "https://github.com",
+                "allowedOperations": ["read"],
+                "clientPolicy": _policy(),
+                "credential": {"source": "github_resolver"},
+            }
+        ).client_policy
+    )
+    assert is_legacy_unrestricted_connection(legacy) is True
+
+
+def test_names_are_aliases_not_fabricated_ids() -> None:
+    same_name_a = RepositoryIdentity(
+        endpoint="https://github.example-a.com",
+        providerRepoId="verified-id-1",
+        displayName="acme/app",
+    )
+    same_name_b = RepositoryIdentity(
+        endpoint="https://github.example-b.com",
+        providerRepoId="verified-id-9",
+        displayName="acme/app",
+    )
+    assert same_name_a.route_id() != same_name_b.route_id()
+    with pytest.raises(ValueError):
+        RepositoryIdentity(
+            endpoint="https://github.com",
+            providerRepoId="",
+            canonicalRemote="",
+            displayName="acme/app",
+        )
+
+
+def test_route_key_is_deterministic_for_bundle() -> None:
+    identity = _identity("repo-id-1")
+    assert route_key_for(
+        scope_type="system",
+        scope_ref=None,
+        identity=identity,
+        capability_bundle=["write", "read"],
+    ) == route_key_for(
+        scope_type="system",
+        scope_ref=None,
+        identity=identity,
+        capability_bundle=["read", "write"],
+    )
+
+
+# -- impl-4: whole-bundle deterministic selection ----------------------------
+
+
+def test_selection_requires_one_connection_for_whole_bundle() -> None:
+    conn_a = _pat_connection("repository-connection:a", operations=("read", "write"))
+    conn_b = _pat_connection("repository-connection:b", operations=("read", "write"))
+    identity = _identity("repo-id-1")
+    candidates = [
+        ScopedRouteCandidate(connection=conn_a, assignment=_assignment(conn_a.id, "repo-id-1", operations=("read",))),
+        ScopedRouteCandidate(connection=conn_b, assignment=_assignment(conn_b.id, "repo-id-1", operations=("write",))),
+    ]
+    # Neither connection covers the whole bundle -> setup-required, not a
+    # split across credentials.
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_SETUP_REQUIRED"):
+        admit_scoped_route(
+            identity=identity,
+            requested_operations=["read", "write"],
+            candidates=candidates,
+            principal_ref="owner:team-a",
+            principal_scope=("system", None),
+        )
+    ambiguous = [
+        ScopedRouteCandidate(connection=conn_a, assignment=_assignment(conn_a.id, "repo-id-1")),
+        ScopedRouteCandidate(connection=conn_b, assignment=_assignment(conn_b.id, "repo-id-1")),
+    ]
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_ROUTE_AMBIGUOUS"):
+        admit_scoped_route(
+            identity=identity,
+            requested_operations=["read"],
+            candidates=ambiguous,
+            principal_ref="owner:team-a",
+            principal_scope=("system", None),
+        )
+
+
+# -- impl-6: rename / transfer / endpoint -----------------------------------
+
+
+def test_verified_rename_keeps_stable_object_and_transfer_invalidates() -> None:
+    assignment = _assignment("repository-connection:a", "verified-id-1")
+    renamed = reconcile_verified_rename(
+        assignment, verified_provider_repo_id="verified-id-1", new_display_name="acme/renamed"
+    )
+    assert renamed.identity.display_name == "acme/renamed"
+    assert renamed.identity.provider_repo_id == "verified-id-1"
+    with pytest.raises(RepositoryRouteError):
+        reconcile_verified_rename(
+            assignment, verified_provider_repo_id="other-id", new_display_name="x"
+        )
+    transferred = invalidate_on_owner_transfer(assignment, new_owner_ref="owner:team-b")
+    assert transferred.verified is False
+
+
+def test_endpoint_retarget_requires_explicit_revision() -> None:
+    validate_endpoint_retarget(
+        current_endpoint="https://github.com",
+        proposed_endpoint="https://github.com/",
+        explicit_revision_path=False,
+    )
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_ENDPOINT_RETARGET"):
+        validate_endpoint_retarget(
+            current_endpoint="https://github.com",
+            proposed_endpoint="https://ghe.example.com",
+            explicit_revision_path=False,
+        )
+
+
+# -- impl-7: authorization ---------------------------------------------------
+
+
+def test_secret_possession_is_not_use_authority() -> None:
+    connection = _pat_connection("repository-connection:a")
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        authorize_connection_use(
+            principal_ref="owner:intruder",
+            principal_scope=("system", None),
+            connection=connection,
+            action="use",
+            has_secret_possession=True,
+        )
+
+
+def test_denial_diagnostics_do_not_leak_metadata() -> None:
+    assert route_diagnostic(REPOSITORY_DENIED, authorized_for_details=False) == REPOSITORY_DENIED
+    assert (
+        route_diagnostic(REPOSITORY_SETUP_REQUIRED, authorized_for_details=False)
+        == REPOSITORY_DENIED
+    )
+
+
+def test_audit_record_is_metadata_only() -> None:
+    connection = _pat_connection("repository-connection:a")
+    record = build_connection_audit_record(
+        actor_ref="owner:team-a",
+        request_id="req-1",
+        action="connection.create",
+        connection=connection,
+    )
+    assert record.model_dump(by_alias=True)["requestId"] == "req-1"
+    assert "TEAM_A_PAT" not in record.model_dump_json()
+
+
+# -- impl-1/5: database writer, restart survival, transactions --------------
+
+
+@pytest.mark.asyncio
+async def test_two_pat_connections_and_assignments_survive_restart(tmp_path: Path) -> None:
+    db_path = tmp_path / "repository-routes-4005.db"
+    engine_url = f"sqlite+aiosqlite:///{db_path}"
+    engine = create_async_engine(engine_url, future=True)
+    sessions = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync: Base.metadata.create_all(
+                sync,
+                tables=[
+                    RepositoryConnectionRecord.__table__,
+                    RepositoryConnectionAssignment.__table__,
+                    RepositoryRouteDefault.__table__,
+                    RepositoryConnectionAuditEvent.__table__,
+                ],
+            )
+        )
+    conn_a = _pat_connection("repository-connection:team-a", secret_key="TEAM_A_PAT")
+    conn_b = _pat_connection("repository-connection:team-b", owner="owner:team-b", secret_key="TEAM_B_PAT")
+    async with sessions() as session:
+        service = RepositoryConnectionService(session)
+        await service.create_connection(
+            conn_a, actor_ref="owner:team-a", request_id="req-a",
+            principal_ref="owner:team-a", principal_scope=("system", None),
+        )
+        await service.create_connection(
+            conn_b, actor_ref="owner:team-b", request_id="req-b",
+            principal_ref="owner:team-b", principal_scope=("system", None),
+        )
+        await service.set_assignment(
+            _assignment(conn_a.id, "repo-id-1"), actor_ref="owner:team-a",
+            request_id="req-a1", principal_ref="owner:team-a",
+            principal_scope=("system", None),
+        )
+        await service.set_assignment(
+            _assignment(conn_a.id, "repo-id-2"), actor_ref="owner:team-a",
+            request_id="req-a2", principal_ref="owner:team-a",
+            principal_scope=("system", None),
+        )
+        await service.set_assignment(
+            _assignment(conn_b.id, "repo-id-2"), actor_ref="owner:team-b",
+            request_id="req-b2", principal_ref="owner:team-b",
+            principal_scope=("system", None),
+        )
+    await engine.dispose()
+
+    # Restart: new engine over the same file must see everything (no second
+    # editable policy store, no copied secrets).
+    engine2 = create_async_engine(engine_url, future=True)
+    sessions2 = sessionmaker(engine2, class_=AsyncSession, expire_on_commit=False)
+    async with sessions2() as session:
+        rows = (await session.execute(select(RepositoryConnectionRecord))).scalars().all()
+        assert {r.connection_id for r in rows} == {conn_a.id, conn_b.id}
+        for row in rows:
+            assert "ghp_" not in str(row.credential_config)
+            assert row.credential_config["source"] == "secret_ref"
+        assignments = (await session.execute(select(RepositoryConnectionAssignment))).scalars().all()
+        assert len(assignments) == 3
+        audits = (await session.execute(select(RepositoryConnectionAuditEvent))).scalars().all()
+        assert len(audits) == 5
+        service = RepositoryConnectionService(session)
+        admitted = await service.list_admitted_routes(
+            identity=_identity("repo-id-2"),
+            principal_ref="owner:team-a",
+            principal_scope=("system", None),
+        )
+        # team-a sees only its own connection's assignment.
+        assert [c.id for c, _ in admitted] == [conn_a.id]
+    await engine2.dispose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_default_change_and_disable_yield_valid_snapshot_or_conflict(
+    tmp_path: Path,
+) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            await service.set_assignment(
+                _assignment(conn.id, "repo-id-1"), actor_ref="owner:team-a",
+                request_id="req-2", principal_ref="owner:team-a",
+                principal_scope=("system", None),
+            )
+            await service.set_route_default(
+                scope_type="system", scope_ref=None, identity=_identity("repo-id-1"),
+                capability_bundle=["read"], connection_id=conn.id,
+                actor_ref="owner:team-a", request_id="req-3",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+        # Independent transaction disables the connection...
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            await service.disable_connection(
+                conn.id, actor_ref="owner:team-a", request_id="req-4",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+        # ...so a later default write against the disabled connection fails
+        # closed instead of leaving a dangling binding.
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+                await service.set_route_default(
+                    scope_type="system", scope_ref=None, identity=_identity("repo-id-1"),
+                    capability_bundle=["read"], connection_id=conn.id,
+                    actor_ref="owner:team-a", request_id="req-5",
+                    principal_ref="owner:team-a", principal_scope=("system", None),
+                )
+        # Assignment removal cascades the default: no dangling binding.
+        conn2 = _pat_connection("repository-connection:b", owner="owner:team-b")
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            await service.create_connection(
+                conn2, actor_ref="owner:team-b", request_id="req-6",
+                principal_ref="owner:team-b", principal_scope=("system", None),
+            )
+            await service.set_assignment(
+                _assignment(conn2.id, "repo-id-9"), actor_ref="owner:team-b",
+                request_id="req-7", principal_ref="owner:team-b",
+                principal_scope=("system", None),
+            )
+            await service.set_route_default(
+                scope_type="system", scope_ref=None, identity=_identity("repo-id-9", display="x"),
+                capability_bundle=["read"], connection_id=conn2.id,
+                actor_ref="owner:team-b", request_id="req-8",
+                principal_ref="owner:team-b", principal_scope=("system", None),
+            )
+            await service.remove_assignment(
+                connection_id=conn2.id, identity=_identity("repo-id-9", display="x"),
+                actor_ref="owner:team-b", request_id="req-9",
+                principal_ref="owner:team-b", principal_scope=("system", None),
+            )
+            remaining = (
+                await session.execute(select(RepositoryRouteDefault))
+            ).scalars().all()
+            assert [d for d in remaining if d.connection_id == conn2.id] == []
+
+
+@pytest.mark.asyncio
+async def test_revision_compare_and_workspace_scope_and_id_reuse(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            ws = _pat_connection(
+                "repository-connection:ws", owner="owner:ws",
+                scope="workspace", scope_ref="workspace:1",
+            )
+            await service.create_connection(
+                ws, actor_ref="owner:ws", request_id="req-1",
+                principal_ref="owner:ws", principal_scope=("workspace", "workspace:1"),
+            )
+            # Stale expected revision fails with a policy conflict.
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_POLICY_CONFLICT"):
+                await service.update_connection(
+                    ws, actor_ref="owner:ws", request_id="req-2",
+                    expected_policy_revision=999,
+                    principal_ref="owner:ws",
+                    principal_scope=("workspace", "workspace:1"),
+                )
+            # Wrong workspace scope is denied without metadata leakage.
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+                await service.disable_connection(
+                    ws.id, actor_ref="owner:other", request_id="req-3",
+                    principal_ref="owner:other",
+                    principal_scope=("workspace", "workspace:other"),
+                )
+            # Deletion tombstones the id: reuse is refused.
+            await service.delete_connection(
+                ws.id, actor_ref="owner:ws", request_id="req-4",
+                principal_ref="owner:ws",
+                principal_scope=("workspace", "workspace:1"),
+            )
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_ID_REUSE"):
+                await service.create_connection(
+                    ws, actor_ref="owner:ws", request_id="req-5",
+                    principal_ref="owner:ws",
+                    principal_scope=("workspace", "workspace:1"),
+                )
+
+
+@pytest.mark.asyncio
+async def test_guessed_secretref_and_unauthorized_attach_fail(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+                await service.set_assignment(
+                    _assignment(conn.id, "repo-id-1"), actor_ref="owner:intruder",
+                    request_id="req-2", principal_ref="owner:intruder",
+                    principal_scope=("system", None),
+                )
+
+
+# -- impl-8: snapshots, legacy boundary, existing checks --------------------
+
+
+def test_snapshot_publish_load_and_stale_rejection(tmp_path: Path) -> None:
+    path = tmp_path / "snapshot.json"
+    connections = [_pat_connection("repository-connection:a")]
+    snapshot = publish_connection_snapshot(connections, path, revision=3)
+    assert load_connection_snapshot(path, minimum_revision=3) == snapshot
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_STALE_SNAPSHOT"):
+        load_connection_snapshot(path, minimum_revision=4)
+    # Digest tampering fails closed (never silently used).
+    raw = path.read_text(encoding="utf-8").replace("team-a", "team-b")
+    path.write_text(raw, encoding="utf-8")
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_STALE_SNAPSHOT"):
+        load_connection_snapshot(path)
+
+
+def test_existing_legacy_persist_load_and_client_checks_still_hold(tmp_path: Path) -> None:
+    from moonmind.workflows.executions.repository_contract import (
+        RepositoryClientEvidence,
+        compile_repository_target,
+    )
+
+    target = compile_repository_target(
+        {
+            "provider": "git",
+            "repository": {"name": "MoonLadderStudios/MoonMind"},
+            "branch": {"name": "main"},
+        }
+    )
+    connection = reconcile_default_git_connection(
+        client_policy=_pat_connection("x").client_policy
+    )
+    path = tmp_path / "legacy.json"
+    persist_repository_connection(connection, path)
+    assert load_repository_connection(path, connection.id) == connection
+    evidence = RepositoryClientEvidence(
+        toolBundleRef="tool-bundle:git-2.46",
+        clientVersion="2.46.0",
+        executableSha256="sha256:git",
+    )
+    validate_connection_and_client(target, connection, evidence, operation="read")

--- a/tests/unit/workflows/executions/test_repository_scoped_routes_4005.py
+++ b/tests/unit/workflows/executions/test_repository_scoped_routes_4005.py
@@ -207,7 +207,6 @@ def test_github_app_is_discriminated_variant() -> None:
 
 
 def test_zero_assignments_grant_nothing_and_legacy_is_refused() -> None:
-    connection = _pat_connection("repository-connection:team-a")
     identity = _identity("repo-id-1")
     with pytest.raises(RepositoryRouteError, match="REPOSITORY_SETUP_REQUIRED"):
         admit_scoped_route(

--- a/tests/unit/workflows/executions/test_repository_scoped_routes_4005.py
+++ b/tests/unit/workflows/executions/test_repository_scoped_routes_4005.py
@@ -26,7 +26,12 @@ from api_service.db.models import (
 from api_service.services.repository_connections import RepositoryConnectionService
 from moonmind.workflows.executions.repository_contract import (
     REPOSITORY_DENIED,
+    REPOSITORY_POLICY_CONFLICT,
+    REPOSITORY_ROUTE_AMBIGUOUS,
+    REPOSITORY_ROUTE_CONFLICT,
+    REPOSITORY_ROUTE_UNSUPPORTED,
     REPOSITORY_SETUP_REQUIRED,
+    REPOSITORY_STALE_SNAPSHOT,
     RepositoryAssignment,
     RepositoryConnection,
     RepositoryIdentity,
@@ -40,12 +45,14 @@ from moonmind.workflows.executions.repository_contract import (
     is_legacy_unrestricted_connection,
     load_connection_snapshot,
     load_repository_connection,
+    normalize_endpoint,
     persist_repository_connection,
     publish_connection_snapshot,
     reconcile_default_git_connection,
     reconcile_verified_rename,
     route_diagnostic,
     route_key_for,
+    scope_key_for,
     validate_connection_and_client,
     validate_endpoint_retarget,
     validate_scoped_connection_for_write,
@@ -361,6 +368,21 @@ def test_denial_diagnostics_do_not_leak_metadata() -> None:
         route_diagnostic(REPOSITORY_SETUP_REQUIRED, authorized_for_details=False)
         == REPOSITORY_DENIED
     )
+    # Every route-state diagnostic maps to the same non-enumerating denial
+    # for unauthorized callers (no connection-count oracle via AMBIGUOUS).
+    for code in (
+        REPOSITORY_ROUTE_AMBIGUOUS,
+        REPOSITORY_ROUTE_CONFLICT,
+        REPOSITORY_ROUTE_UNSUPPORTED,
+        REPOSITORY_POLICY_CONFLICT,
+    ):
+        assert route_diagnostic(code, authorized_for_details=False) == REPOSITORY_DENIED
+        assert route_diagnostic(code, authorized_for_details=True) == code
+    # The local snapshot-file condition is identical for all callers.
+    assert (
+        route_diagnostic(REPOSITORY_STALE_SNAPSHOT, authorized_for_details=False)
+        == REPOSITORY_STALE_SNAPSHOT
+    )
 
 
 def test_audit_record_is_metadata_only() -> None:
@@ -535,7 +557,9 @@ async def test_revision_compare_and_workspace_scope_and_id_reuse(tmp_path: Path)
                 principal_ref="owner:ws", principal_scope=("workspace", "workspace:1"),
             )
             # Stale expected revision fails with a policy conflict.
-            with pytest.raises(RepositoryRouteError, match="REPOSITORY_POLICY_CONFLICT"):
+            with pytest.raises(
+                RepositoryRouteError, match="REPOSITORY_POLICY_CONFLICT"
+            ):
                 await service.update_connection(
                     ws, actor_ref="owner:ws", request_id="req-2",
                     expected_policy_revision=999,
@@ -554,6 +578,7 @@ async def test_revision_compare_and_workspace_scope_and_id_reuse(tmp_path: Path)
                 ws.id, actor_ref="owner:ws", request_id="req-4",
                 principal_ref="owner:ws",
                 principal_scope=("workspace", "workspace:1"),
+                has_active_bindings=lambda _: False,
             )
             with pytest.raises(RepositoryRouteError, match="REPOSITORY_ID_REUSE"):
                 await service.create_connection(
@@ -623,3 +648,506 @@ def test_existing_legacy_persist_load_and_client_checks_still_hold(tmp_path: Pat
         executableSha256="sha256:git",
     )
     validate_connection_and_client(target, connection, evidence, operation="read")
+
+
+# -- impl-9: automated-review remediation -------------------------------------
+
+
+def _lore_connection(connection_id: str) -> RepositoryConnection:
+    return RepositoryConnection.model_validate(
+        {
+            "schemaVersion": "moonmind.repository-connection.v1",
+            "id": connection_id,
+            "provider": "lore",
+            "displayName": f"Lore {connection_id}",
+            "endpointRef": "lore://tactics",
+            "allowedOperations": ["read", "merge_request"],
+            "clientPolicy": _policy(),
+            "projection": {
+                "provider": "github",
+                "repository": "acme/app",
+                "authority": "review_only",
+                "statusSourceRef": "status:1",
+            },
+            "mergeCoordinator": {
+                "endpointRef": "lore://tactics",
+                "policyRef": "policy:1",
+                "supportedProtocolVersion": "1",
+            },
+            "credential": {
+                "source": "secret_ref",
+                "credentialRef": {"provider": "managed", "key": "LORE_KEY"},
+            },
+            "lifecycle": "active",
+            "policyRevision": 1,
+            "credentialRevision": 1,
+            "ownership": {
+                "ownerRef": "owner:team-a",
+                "scopeType": "system",
+                "allowedPrincipalRefs": ["owner:team-a"],
+            },
+            "hostingService": "lore",
+        }
+    )
+
+
+def test_scheme_aware_default_ports() -> None:
+    assert normalize_endpoint("http://git.example:80") == "http://git.example"
+    assert normalize_endpoint("https://git.example:443") == "https://git.example"
+    # Non-default ports for the scheme are distinct network authorities.
+    assert normalize_endpoint("http://git.example:443") == "http://git.example:443"
+    assert normalize_endpoint("https://git.example:80") == "https://git.example:80"
+
+
+def test_scope_key_for_system_and_workspace() -> None:
+    assert scope_key_for("system", None) == "system"
+    assert scope_key_for("workspace", "workspace:1") == "workspace:workspace:1"
+
+
+def test_mutation_actions_require_owner_or_system() -> None:
+    from moonmind.workflows.executions.repository_contract import (
+        ConnectionOwnershipPolicy,
+    )
+
+    teammate = _pat_connection("repository-connection:shared").model_copy(
+        update={
+            "ownership": ConnectionOwnershipPolicy(
+                ownerRef="owner:team-a",
+                scopeType="system",
+                allowedPrincipalRefs=["owner:team-a", "owner:team-b", "owner:ops"],
+            )
+        }
+    )
+    # Admitted teammate may use but not administer.
+    authorize_connection_use(
+        principal_ref="owner:team-b",
+        principal_scope=("workspace", "workspace:1"),
+        connection=teammate,
+        action="use",
+    )
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        authorize_connection_use(
+            principal_ref="owner:team-b",
+            principal_scope=("workspace", "workspace:1"),
+            connection=teammate,
+            action="edit",
+        )
+    # Owner administers; an admitted system principal administers too.
+    authorize_connection_use(
+        principal_ref="owner:team-a",
+        principal_scope=("workspace", "workspace:1"),
+        connection=teammate,
+        action="delete",
+    )
+    authorize_connection_use(
+        principal_ref="owner:ops",
+        principal_scope=("system", None),
+        connection=teammate,
+        action="disable",
+    )
+    # A system principal outside the admission list administers nothing.
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        authorize_connection_use(
+            principal_ref="owner:stranger",
+            principal_scope=("system", None),
+            connection=teammate,
+            action="disable",
+        )
+
+
+def test_disabled_connection_permits_owner_admin_but_not_use() -> None:
+    connection = _pat_connection("repository-connection:a")
+    disabled = connection.model_copy(update={"lifecycle": "disabled"})
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        authorize_connection_use(
+            principal_ref="owner:team-a",
+            principal_scope=("system", None),
+            connection=disabled,
+            action="use",
+        )
+    # Owner cleanup/reactivation paths stay available while disabled.
+    for action in ("edit", "detach", "delete", "disable"):
+        authorize_connection_use(
+            principal_ref="owner:team-a",
+            principal_scope=("system", None),
+            connection=disabled,
+            action=action,
+        )
+    deleted = connection.model_copy(update={"lifecycle": "deleted"})
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        authorize_connection_use(
+            principal_ref="owner:team-a",
+            principal_scope=("system", None),
+            connection=deleted,
+            action="delete",
+        )
+
+
+def test_legacy_resolver_and_matrix_rejected_on_write() -> None:
+    from moonmind.workflows.executions.repository_contract import (
+        GitHubAppCredential,
+        GitHubResolverCredential,
+    )
+
+    connection = _pat_connection("repository-connection:a")
+    legacy = connection.model_copy(
+        update={"credential": GitHubResolverCredential(source="github_resolver")}
+    )
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        validate_scoped_connection_for_write(legacy)
+    # Complete provider x hosting x credential matrix.
+    bad_host = connection.model_copy(update={"hosting_service": "lore"})
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        validate_scoped_connection_for_write(bad_host)
+    app_on_generic = connection.model_copy(
+        update={
+            "hosting_service": "generic_git",
+            "credential": GitHubAppCredential(
+                source="github_app",
+                appRef="github-app:moonmind",
+                installationRef="installation:123",
+            ),
+        }
+    )
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        validate_scoped_connection_for_write(app_on_generic)
+    lore_on_generic = _lore_connection("repository-connection:lore").model_copy(
+        update={"hosting_service": "generic_git"}
+    )
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        validate_scoped_connection_for_write(lore_on_generic)
+    # Compatible combinations still validate.
+    validate_scoped_connection_for_write(
+        connection.model_copy(update={"hosting_service": "generic_git"})
+    )
+    validate_scoped_connection_for_write(_lore_connection("repository-connection:lore"))
+
+
+def test_secret_extra_payload_rejected_regardless_of_key() -> None:
+    from api_service.services.repository_connections import _credential_config
+
+    connection = _pat_connection("repository-connection:a")
+    smuggled = RepositoryConnection.model_validate(
+        {
+            **connection.model_dump(by_alias=True, mode="json"),
+            "credential": {
+                "source": "secret_ref",
+                "credentialRef": {
+                    "provider": "managed",
+                    "key": "TEAM_A_PAT",
+                    "extra": {"accessToken": "x" * 30},
+                },
+            },
+        }
+    )
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+        _credential_config(smuggled)
+
+
+def test_snapshot_revision_and_producer_tamper_fail_closed(tmp_path: Path) -> None:
+    import json
+
+    path = tmp_path / "snapshot.json"
+    publish_connection_snapshot(
+        [_pat_connection("repository-connection:a")], path, revision=3
+    )
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["revision"] = 4
+    path.write_text(json.dumps(raw, sort_keys=True), encoding="utf-8")
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_STALE_SNAPSHOT"):
+        load_connection_snapshot(path)
+    raw["revision"] = 3
+    raw["producer"] = "someone-else.v1"
+    path.write_text(json.dumps(raw, sort_keys=True), encoding="utf-8")
+    with pytest.raises(RepositoryRouteError, match="REPOSITORY_STALE_SNAPSHOT"):
+        load_connection_snapshot(path)
+
+
+@pytest.mark.asyncio
+async def test_credential_rotation_requires_revision_advance(tmp_path: Path) -> None:
+    from moonmind.workflows.executions.repository_contract import SecretRefCredential
+
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            # Ordinary policy edit must not move the credential revision.
+            bumped = conn.model_copy(
+                update={"display_name": "Renamed", "credential_revision": 2}
+            )
+            with pytest.raises(
+                RepositoryRouteError, match="REPOSITORY_POLICY_CONFLICT"
+            ):
+                await service.update_connection(
+                    bumped, actor_ref="owner:team-a", request_id="req-2",
+                    expected_policy_revision=1,
+                    principal_ref="owner:team-a", principal_scope=("system", None),
+                )
+            # Credential change without an advance is refused.
+            rotated = conn.model_copy(
+                update={
+                    "credential": SecretRefCredential(
+                        source="secret_ref",
+                        credentialRef={"provider": "managed", "key": "TEAM_B_PAT"},
+                    )
+                }
+            )
+            with pytest.raises(
+                RepositoryRouteError, match="REPOSITORY_POLICY_CONFLICT"
+            ):
+                await service.update_connection(
+                    rotated, actor_ref="owner:team-a", request_id="req-3",
+                    expected_policy_revision=1,
+                    principal_ref="owner:team-a", principal_scope=("system", None),
+                )
+            # Rotation with exactly one advance succeeds.
+            rotated_once = rotated.model_copy(update={"credential_revision": 2})
+            out = await service.update_connection(
+                rotated_once, actor_ref="owner:team-a", request_id="req-4",
+                expected_policy_revision=1,
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            assert out.policy_revision == 2
+            assert out.credential_revision == 2
+            assert out.credential.credential_ref.key == "TEAM_B_PAT"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_retarget_invalidates_routes(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            await service.set_assignment(
+                _assignment(conn.id, "repo-id-1"), actor_ref="owner:team-a",
+                request_id="req-2", principal_ref="owner:team-a",
+                principal_scope=("system", None),
+            )
+            await service.set_route_default(
+                scope_type="system", scope_ref=None, identity=_identity("repo-id-1"),
+                capability_bundle=["read"], connection_id=conn.id,
+                actor_ref="owner:team-a", request_id="req-3",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            retargeted = conn.model_copy(
+                update={
+                    "endpoint_ref": "https://ghe.example.com",
+                    "credential_revision": 2,
+                }
+            )
+            await service.update_connection(
+                retargeted, actor_ref="owner:team-a", request_id="req-4",
+                expected_policy_revision=1,
+                principal_ref="owner:team-a", principal_scope=("system", None),
+                explicit_endpoint_revision=True,
+            )
+            assignments = (
+                await session.execute(select(RepositoryConnectionAssignment))
+            ).scalars().all()
+            assert assignments == []
+            defaults = (
+                await session.execute(select(RepositoryRouteDefault))
+            ).scalars().all()
+            assert defaults == []
+
+
+@pytest.mark.asyncio
+async def test_system_scope_creation_requires_system_principal(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:sys", owner="owner:ws")
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+                await service.create_connection(
+                    conn, actor_ref="owner:ws", request_id="req-1",
+                    principal_ref="owner:ws",
+                    principal_scope=("workspace", "workspace:1"),
+                )
+
+
+@pytest.mark.asyncio
+async def test_route_default_scope_must_match_principal(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection(
+                "repository-connection:a", owner="owner:a",
+                scope="workspace", scope_ref="workspace:a",
+            )
+            await service.create_connection(
+                conn, actor_ref="owner:a", request_id="req-1",
+                principal_ref="owner:a",
+                principal_scope=("workspace", "workspace:a"),
+            )
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+                await service.set_route_default(
+                    scope_type="workspace", scope_ref="workspace:b",
+                    identity=_identity("repo-id-1"),
+                    capability_bundle=["read"], connection_id=conn.id,
+                    actor_ref="owner:a", request_id="req-2",
+                    principal_ref="owner:a",
+                    principal_scope=("workspace", "workspace:a"),
+                )
+
+
+@pytest.mark.asyncio
+async def test_assignment_revision_conflict_and_replay_returns_stored(
+    tmp_path: Path,
+) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            first = await service.set_assignment(
+                _assignment(conn.id, "repo-id-1"), actor_ref="owner:team-a",
+                request_id="req-2", principal_ref="owner:team-a",
+                principal_scope=("system", None),
+            )
+            assert first.revision == 1
+            # Replaying the same request identity for a different payload
+            # returns the persisted assignment instead of granting the new one.
+            replayed = await service.set_assignment(
+                _assignment(conn.id, "repo-id-1", operations=("read",)),
+                actor_ref="owner:team-a", request_id="req-2",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            assert tuple(replayed.operations) == ("read", "write")
+            assert replayed.revision == 1
+            # Concurrent editors conflict instead of losing permission edits.
+            second = await service.set_assignment(
+                _assignment(conn.id, "repo-id-1", operations=("read",)),
+                actor_ref="owner:team-a", request_id="req-3",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            assert second.revision == 2
+            assert tuple(second.operations) == ("read",)
+            with pytest.raises(
+                RepositoryRouteError, match="REPOSITORY_POLICY_CONFLICT"
+            ):
+                await service.set_assignment(
+                    _assignment(conn.id, "repo-id-1", operations=("read", "write")),
+                    actor_ref="owner:team-a", request_id="req-4",
+                    principal_ref="owner:team-a", principal_scope=("system", None),
+                )
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_binding_authority(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_ROUTE_CONFLICT"):
+                await service.delete_connection(
+                    conn.id, actor_ref="owner:team-a", request_id="req-2",
+                    principal_ref="owner:team-a", principal_scope=("system", None),
+                    has_active_bindings=lambda _: True,
+                )
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_SETUP_REQUIRED"):
+                await service.delete_connection(
+                    conn.id, actor_ref="owner:team-a", request_id="req-3",
+                    principal_ref="owner:team-a", principal_scope=("system", None),
+                    has_active_bindings=None,  # type: ignore[arg-type]
+                )
+            await service.delete_connection(
+                conn.id, actor_ref="owner:team-a", request_id="req-4",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+                has_active_bindings=lambda _: False,
+            )
+
+
+@pytest.mark.asyncio
+async def test_replay_is_reauthorized(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            # Guessing a prior request identity discloses nothing to an
+            # unadmitted principal.
+            with pytest.raises(RepositoryRouteError, match="REPOSITORY_DENIED"):
+                await service.create_connection(
+                    conn, actor_ref="owner:intruder", request_id="req-1",
+                    principal_ref="owner:intruder",
+                    principal_scope=("workspace", "workspace:intruder"),
+                )
+
+
+@pytest.mark.asyncio
+async def test_lore_projection_survives_round_trip(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _lore_connection("repository-connection:lore")
+            created = await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            assert created.projection is not None
+            assert created.merge_coordinator is not None
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            visible = await service.export_snapshot_connections(
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            (reloaded,) = [c for c in visible if c.id == conn.id]
+            assert reloaded.projection is not None
+            assert reloaded.projection.repository == "acme/app"
+            assert reloaded.merge_coordinator is not None
+            renamed = reloaded.model_copy(update={"display_name": "Lore renamed"})
+            updated = await service.update_connection(
+                renamed, actor_ref="owner:team-a", request_id="req-2",
+                expected_policy_revision=1,
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            assert updated.projection is not None
+            assert updated.merge_coordinator is not None
+
+
+@pytest.mark.asyncio
+async def test_system_default_uniqueness_single_row(tmp_path: Path) -> None:
+    async with route_db(tmp_path) as sessions:
+        async with sessions() as session:
+            service = RepositoryConnectionService(session)
+            conn = _pat_connection("repository-connection:a")
+            await service.create_connection(
+                conn, actor_ref="owner:team-a", request_id="req-1",
+                principal_ref="owner:team-a", principal_scope=("system", None),
+            )
+            await service.set_assignment(
+                _assignment(conn.id, "repo-id-1"), actor_ref="owner:team-a",
+                request_id="req-2", principal_ref="owner:team-a",
+                principal_scope=("system", None),
+            )
+            for request_id in ("req-3", "req-4"):
+                await service.set_route_default(
+                    scope_type="system", scope_ref=None,
+                    identity=_identity("repo-id-1"),
+                    capability_bundle=["read"], connection_id=conn.id,
+                    actor_ref="owner:team-a", request_id=request_id,
+                    principal_ref="owner:team-a", principal_scope=("system", None),
+                )
+            defaults = (
+                await session.execute(select(RepositoryRouteDefault))
+            ).scalars().all()
+            assert len(defaults) == 1
+            assert defaults[0].scope_key == "system"


### PR DESCRIPTION
Resolves MoonLadderStudios/MoonMind#4005 — establishes one database/service writer for scoped RepositoryConnections, assignments, and routes; deployment files become versioned read-only snapshots.

## Summary
- Extends `moonmind/workflows/executions/repository_contract.py` (typed SecretRef PATs, discriminated GitHub App variant, lifecycle/policy/credential revisions, endpoint-scoped repository identity, whole-bundle route key/default scope, transactional admission, rename/transfer/retarget rules, metadata-only audit, safe diagnostics).
- Adds `api_service/services/repository_connections.py` single writer (revision compare, uniqueness constraints, normalized system/workspace scope, no stale-filesystem fallback, stable request identity, tombstones blocking ID reuse).
- Adds Alembic migration `377_repository_connections_4005` (4 tables: connections, assignments, route defaults, audit) and ORM models in `api_service/db/models.py`.
- Legacy unrestricted-empty semantic confined to historical loader/validator; new scoped admission requires verified assignments.
- Files changed: api_service/db/models.py, api_service/migrations/versions/377_repository_connections_4005.py, api_service/services/repository_connections.py, moonmind/workflows/executions/repository_contract.py, tests/unit/workflows/executions/test_repository_scoped_routes_4005.py (5 files, +2577/-4).

## Verification outcome
- Controlling post-remediation moonspec-verify verdict: FULLY_IMPLEMENTED (confidence HIGH, candidate 157b920091a54696b79807981b15ccbfece2b4bc, assessment base 06ab51913472b06ff05d208c31af54a98cdb73f0, assessment verdict NOT_IMPLEMENTED).
- All 8 requirements VERIFIED, 7 acceptance boxes VERIFIED, gaps empty, remaining work empty, recommended next action: advance.

## Tests run
- Unit (new acceptance, #4005): `moonmind container python-tests tests/unit/workflows/executions/test_repository_scoped_routes_4005.py` — PASS (17/17, incl. sqlite restart-survival, independent-transaction disable/default/assignment, revision/workspace/ID-reuse, auth, snapshot tests).
- Unit (regression): `moonmind container python-tests tests/unit/workflows/executions/test_repository_contract.py tests/unit/docs/test_repository_access_slice0_reconciliation.py tests/unit/api_service/test_api_service_conftest_boundaries.py` — PASS (46/46; legacy persist/load/client checks and slice-0 reconciliation hold).
- Integration (advisory): NOT RUN — no integration_ci boundary touched beyond the linear Alembic chain; hermetic sqlite coverage exercises transactional paths.

## Remaining risks
- Alembic linear chain (376_merge -> 376_drop_manifest -> 377) needs standard migration rehearsal in deployment pipeline.
- HTTP exposure is a consumer-slice concern (#4007/#2615); this slice defines versioned schemas/diagnostics only.
- Coordinated legacy cutover owned by #4023; deployment snapshots must be published atomically until then.

Closes MoonLadderStudios/MoonMind#4005