### PR TITLE
[Repository access] Decouple runtime image acquisition from source credentials (MoonLadderStudios/MoonMind#4012)

### DIFF
--- a/docs/ManagedAgents/DockerBackendService.md
+++ b/docs/ManagedAgents/DockerBackendService.md
@@ -718,6 +718,26 @@ materialized in a per-job Docker config with restrictive permissions, redacted
 from observations, and removed on success, failure, cancellation, timeout, and
 orphan reconciliation.
 
+#### 11.6.1 Managed-session GHCR pull decoupling
+
+Public runtime images are acquired anonymously by default: no model or source
+credential, no managed-secret access beyond the GHCR slug check, and no login
+helper. An explicit private `ghcr.io` identity selects exactly one deployment
+configuration, in precedence order: the `MOONMIND_GHCR_PULL_*_SECRET_REF` (or
+`WORKFLOW_` equivalent) SecretRef pair, the deployment `GHCR_PULL_USER` +
+`GHCR_PULL_TOKEN` pair, or the `GHCR_PULL_USER` + `GHCR_PULL_TOKEN`
+managed-secret slug pair read coherently in one store session. The obsolete
+implicit configuration — converting a source `GITHUB_TOKEN` or model-profile
+PAT into pull credentials via GitHub username lookup, or reading
+`GHCR_PULL_*` plaintext from agent-authored launch fields — was removed under
+MoonLadderStudios/MoonMind#4012 and must not be reintroduced. Incomplete
+pairs, unresolvable SecretRefs, rotation/disable between the paired reads,
+managed-store outage, and denied/revoked credentials fail at the registry
+boundary without trying another identity, ambient Docker login, or an
+anonymous downgrade. Safe recovery is to restore the selected deployment pair
+and retry the pull; removing the source coupling requires no new PAT prompt
+for unaffected scratch or public-image work.
+
 ### 11.7 Image lifetime
 
 Images survive job, session, and workflow completion. Deployment-level retention

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -160,11 +160,7 @@ async def _resolve_managed_ghcr_pull_pair() -> tuple[str | None, str | None]:
     return first
 
 
-async def resolve_ghcr_pull_credentials_for_launch(
-    environment: Mapping[str, str] | None = None,
-    *,
-    github_credential: Any | None = None,
-) -> tuple[str, str] | None:
+async def resolve_ghcr_pull_credentials_for_launch() -> tuple[str, str] | None:
     """Resolve deployment-scoped GHCR pull credentials for launch boundaries.
 
     MoonLadderStudios/MoonMind#4012: source repository/model credentials are
@@ -180,8 +176,9 @@ async def resolve_ghcr_pull_credentials_for_launch(
     - managed sessions: DinD sidecar (``docker:27``-style stock image) plus
       session images, launched via ``DockerCodexManagedSessionController``
       against the deployment Docker backend; image selection is deployment
-      configuration, auth source is this helper (explicit pair) or ambient
-      daemon config for public images only.
+      configuration, auth source is this helper via per-launch ephemeral
+      ``DOCKER_CONFIG`` (explicit pair) or an empty ephemeral config for
+      public-anonymous acquisition with no ambient fallback.
     - generic/profile-bound Omnigent: server/host images resolved to
       digest-pinned refs by ``moonmind/omnigent/bootstrap/image_resolution.py``
       (``_resolve_via_docker_pull`` / ``_image_build_identity``) via bare
@@ -217,11 +214,11 @@ async def resolve_ghcr_pull_credentials_for_launch(
     ``ValueError`` at the registry boundary. ``None`` is never a signal to try
     another identity.
 
-    The ``environment`` launch mapping and ``github_credential`` descriptor are
-    accepted for signature compatibility but are never consulted for registry
-    secrets: agent-authored launch fields, source PATs, and GitHub actor
-    lookups are not registry authentication. SecretRef *names* are read from
-    the deployment process environment only, never from the launch mapping.
+    Agent-authored launch fields, source PATs, and GitHub actor lookups are
+    not registry authentication and are not accepted here: this resolver takes
+    no launch mapping or credential descriptor. SecretRef *names* are read
+    from the deployment process environment only, never from a launch
+    mapping.
 
     Public defaults: images that are publicly readable are acquired
     anonymously (``None``) with no model/source credential, no managed-secret
@@ -239,9 +236,6 @@ async def resolve_ghcr_pull_credentials_for_launch(
     it in workflow history, logs, labels, argv, inspectable runtime env,
     heartbeats, error payloads, plans, or durable metadata.
     """
-
-    _ = environment
-    _ = github_credential
 
     user_ref = str(
         os.environ.get("MOONMIND_GHCR_PULL_USER_SECRET_REF")

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -94,46 +94,70 @@ async def resolve_managed_github_token_from_store() -> str | None:
                 return candidate
     return None
 
+async def _read_ghcr_pull_pair_once(session: Any) -> tuple[str | None, str | None]:
+    """Read the ``GHCR_PULL_USER``/``GHCR_PULL_TOKEN`` slugs once.
+
+    Returns the raw ``(user, token)`` pair with ``None`` for unconfigured
+    slugs. Callers must verify coherence across reads; a single read alone is
+    never proof of a stable configuration revision.
+    """
+
+    from sqlalchemy import select
+
+    from api_service.db.models import ManagedSecret, SecretStatus
+
+    user_value: str | None = None
+    token_value: str | None = None
+    for slugs, target in (
+        (_MANAGED_GHCR_PULL_USER_SLUGS, "user"),
+        (_MANAGED_GHCR_PULL_TOKEN_SLUGS, "token"),
+    ):
+        found: str | None = None
+        for slug in slugs:
+            normalized = str(slug or "").strip()
+            if not normalized:
+                continue
+            result = await session.execute(
+                select(ManagedSecret).where(
+                    ManagedSecret.slug == normalized,
+                    ManagedSecret.status == SecretStatus.ACTIVE,
+                )
+            )
+            secret = result.scalar_one_or_none()
+            candidate = str(secret.ciphertext if secret else "").strip()
+            if candidate:
+                found = candidate
+                break
+        if target == "user":
+            user_value = found
+        else:
+            token_value = found
+    return user_value, token_value
+
+
 async def _resolve_managed_ghcr_pull_pair() -> tuple[str | None, str | None]:
     """Read the ``GHCR_PULL_USER``/``GHCR_PULL_TOKEN`` managed slugs coherently.
 
     Both slugs are read inside one managed-secret store session so the two
     values form one selected configuration revision instead of two independent
-    reads that could straddle a rotation. Store outages propagate to the
-    caller (fail closed); they are never treated as "no credentials".
+    reads that could straddle a rotation. The pair is read twice and compared:
+    a change between the reads (rotation, disable, or rewrite landing between
+    them) raises instead of returning a mixed pair. Store outages propagate to
+    the caller (fail closed); they are never treated as "no credentials".
     """
 
     from api_service.db.base import async_session_maker
-    from api_service.db.models import ManagedSecret, SecretStatus
 
     async with async_session_maker() as session:
-        user_value: str | None = None
-        token_value: str | None = None
-        for slugs, target in (
-            (_MANAGED_GHCR_PULL_USER_SLUGS, "user"),
-            (_MANAGED_GHCR_PULL_TOKEN_SLUGS, "token"),
-        ):
-            found: str | None = None
-            for slug in slugs:
-                normalized = str(slug or "").strip()
-                if not normalized:
-                    continue
-                result = await session.execute(
-                    select(ManagedSecret).where(
-                        ManagedSecret.slug == normalized,
-                        ManagedSecret.status == SecretStatus.ACTIVE,
-                    )
-                )
-                secret = result.scalar_one_or_none()
-                candidate = str(secret.ciphertext if secret else "").strip()
-                if candidate:
-                    found = candidate
-                    break
-            if target == "user":
-                user_value = found
-            else:
-                token_value = found
-    return user_value, token_value
+        first = await _read_ghcr_pull_pair_once(session)
+        second = await _read_ghcr_pull_pair_once(session)
+        if first != second:
+            raise ValueError(
+                "GHCR pull managed secrets changed during resolution "
+                "(possible rotation between paired reads); refusing to use "
+                "a mixed user/token pair"
+            )
+    return first
 
 
 async def resolve_ghcr_pull_credentials_for_launch(
@@ -180,7 +204,8 @@ async def resolve_ghcr_pull_credentials_for_launch(
     2. Deployment plaintext pair from process environment (``GHCR_PULL_USER`` +
        ``GHCR_PULL_TOKEN`` as set by the operator for the deployment).
     3. Managed-secret slug pair (``GHCR_PULL_USER`` + ``GHCR_PULL_TOKEN``),
-       read coherently in one store session.
+        read coherently in one store session and verified stable across the
+        paired reads (a rotation landing between reads raises).
     4. Omitted configuration: return ``None`` for the public-anonymous path,
        which performs no registry authentication and queries no secret store
        beyond the GHCR slug lookup above.
@@ -275,6 +300,12 @@ async def resolve_ghcr_pull_credentials_for_launch(
     try:
         stored_user, stored_token = await _resolve_managed_ghcr_pull_pair()
     except asyncio.CancelledError:
+        raise
+    except ValueError:
+        # Coherence failures (partial pair reads, rotation detected between
+        # the paired reads) already describe the registry-boundary outcome;
+        # never relabel them as a store outage or fall back to another
+        # identity.
         raise
     except Exception as exc:
         raise ValueError(

--- a/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
+++ b/moonmind/workflows/temporal/runtime/managed_api_key_resolve.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
 from sqlalchemy import select
 
@@ -29,10 +26,13 @@ _MANAGED_GITHUB_TOKEN_SLUGS: tuple[str, ...] = (
     "GITHUB_TOKEN",
     "GITHUB_PAT",
 )
+# Registry endpoint this module's GHCR pull credentials are bound to. Returned
+# credentials must only be presented to this endpoint (or its exact image /
+# repository scope); never to arbitrary endpoints derived from image strings,
+# error messages, or workflow input.
+GHCR_REGISTRY = "ghcr.io"
 _MANAGED_GHCR_PULL_USER_SLUGS: tuple[str, ...] = ("GHCR_PULL_USER",)
 _MANAGED_GHCR_PULL_TOKEN_SLUGS: tuple[str, ...] = ("GHCR_PULL_TOKEN",)
-_GITHUB_API_TIMEOUT_SECONDS = 10.0
-_GITHUB_USER_RESPONSE_MAX_BYTES = 64 * 1024
 
 logger = logging.getLogger(__name__)
 
@@ -94,66 +94,47 @@ async def resolve_managed_github_token_from_store() -> str | None:
                 return candidate
     return None
 
-async def _resolve_first_active_managed_secret_slug(
-    slugs: Iterable[str],
-) -> str | None:
-    """Return the first active managed secret value for the provided slugs."""
+async def _resolve_managed_ghcr_pull_pair() -> tuple[str | None, str | None]:
+    """Read the ``GHCR_PULL_USER``/``GHCR_PULL_TOKEN`` managed slugs coherently.
+
+    Both slugs are read inside one managed-secret store session so the two
+    values form one selected configuration revision instead of two independent
+    reads that could straddle a rotation. Store outages propagate to the
+    caller (fail closed); they are never treated as "no credentials".
+    """
 
     from api_service.db.base import async_session_maker
     from api_service.db.models import ManagedSecret, SecretStatus
 
     async with async_session_maker() as session:
-        for slug in slugs:
-            normalized = str(slug or "").strip()
-            if not normalized:
-                continue
-            result = await session.execute(
-                select(ManagedSecret).where(
-                    ManagedSecret.slug == normalized,
-                    ManagedSecret.status == SecretStatus.ACTIVE,
+        user_value: str | None = None
+        token_value: str | None = None
+        for slugs, target in (
+            (_MANAGED_GHCR_PULL_USER_SLUGS, "user"),
+            (_MANAGED_GHCR_PULL_TOKEN_SLUGS, "token"),
+        ):
+            found: str | None = None
+            for slug in slugs:
+                normalized = str(slug or "").strip()
+                if not normalized:
+                    continue
+                result = await session.execute(
+                    select(ManagedSecret).where(
+                        ManagedSecret.slug == normalized,
+                        ManagedSecret.status == SecretStatus.ACTIVE,
+                    )
                 )
-            )
-            secret = result.scalar_one_or_none()
-            candidate = str(secret.ciphertext if secret else "").strip()
-            if candidate:
-                return candidate
-    return None
+                secret = result.scalar_one_or_none()
+                candidate = str(secret.ciphertext if secret else "").strip()
+                if candidate:
+                    found = candidate
+                    break
+            if target == "user":
+                user_value = found
+            else:
+                token_value = found
+    return user_value, token_value
 
-def _github_user_api_url() -> str:
-    api_base = os.environ.get("GITHUB_API_URL", "https://api.github.com").strip()
-    if not api_base:
-        api_base = "https://api.github.com"
-    return api_base.rstrip("/") + "/user"
-
-def _fetch_github_login_for_token(token: str) -> str | None:
-    request = Request(
-        _github_user_api_url(),
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "User-Agent": "MoonMind-GHCR-Pull-Auth",
-            "X-GitHub-Api-Version": "2022-11-28",
-        },
-    )
-    with urlopen(request, timeout=_GITHUB_API_TIMEOUT_SECONDS) as response:
-        payload = json.loads(
-            response.read(_GITHUB_USER_RESPONSE_MAX_BYTES).decode("utf-8")
-        )
-    login = str(payload.get("login") or "").strip()
-    return login or None
-
-async def _resolve_github_login_for_token(token: str) -> str | None:
-    normalized = str(token or "").strip()
-    if not normalized:
-        return None
-    try:
-        return await asyncio.to_thread(_fetch_github_login_for_token, normalized)
-    except (HTTPError, URLError, TimeoutError, ValueError, OSError):
-        logger.warning(
-            "Failed to resolve GitHub username for GHCR pull authentication",
-            exc_info=True,
-        )
-        return None
 
 async def resolve_ghcr_pull_credentials_for_launch(
     environment: Mapping[str, str] | None = None,
@@ -162,21 +143,88 @@ async def resolve_ghcr_pull_credentials_for_launch(
 ) -> tuple[str, str] | None:
     """Resolve deployment-scoped GHCR pull credentials for launch boundaries.
 
-    The returned plaintext is for immediate Docker config materialization only.
-    Callers must not store it in workflow history, logs, or durable metadata.
+    MoonLadderStudios/MoonMind#4012: source repository/model credentials are
+    never implicit registry credentials. This resolver compiles authentication
+    only from trusted deployment configuration and never converts a source
+    GitHub PAT into pull credentials, never probes the GitHub username for a
+    token, and never falls back to another identity, ambient Docker login, or
+    an anonymous downgrade when a configured credential fails.
+
+    Production pull-boundary inventory (recorded here so deleting this helper
+    alone is never mistaken for removing every implicit credential path):
+
+    - managed sessions: DinD sidecar (``docker:27``-style stock image) plus
+      session images, launched via ``DockerCodexManagedSessionController``
+      against the deployment Docker backend; image selection is deployment
+      configuration, auth source is this helper (explicit pair) or ambient
+      daemon config for public images only.
+    - generic/profile-bound Omnigent: server/host images resolved to
+      digest-pinned refs by ``moonmind/omnigent/bootstrap/image_resolution.py``
+      (``_resolve_via_docker_pull`` / ``_image_build_identity``) via bare
+      ``docker pull`` against the deployment backend; no source PAT is passed.
+    - container jobs: ``container_job_backend.py`` + ``registry_auth_resolve.py``
+      (``registry_authorization`` with an explicit ``registryCredentialRef``,
+      per-job ephemeral ``--config`` auth dirs, immediate post-pull cleanup).
+    - Compose/bootstrap: ``docker-compose.yaml`` image refs and
+      ``api_service/services/omnigent_policies.py`` stock-image acquisition via
+      bare ``docker pull`` against the deployment backend; no source PAT.
+    - legacy worker container path: ``moonmind/agents/codex_worker/worker.py``
+      ``_ensure_container_image`` via bare ``docker pull``; no source PAT.
+
+    Explicit precedence (first fully-specified source wins as one selected
+    configuration):
+
+    1. SecretRef pair from deployment process environment
+       (``MOONMIND_GHCR_PULL_USER_SECRET_REF`` /
+       ``MOONMIND_GHCR_PULL_TOKEN_SECRET_REF`` or the ``WORKFLOW_`` equivalents).
+    2. Deployment plaintext pair from process environment (``GHCR_PULL_USER`` +
+       ``GHCR_PULL_TOKEN`` as set by the operator for the deployment).
+    3. Managed-secret slug pair (``GHCR_PULL_USER`` + ``GHCR_PULL_TOKEN``),
+       read coherently in one store session.
+    4. Omitted configuration: return ``None`` for the public-anonymous path,
+       which performs no registry authentication and queries no secret store
+       beyond the GHCR slug lookup above.
+
+    Outcomes: omitted/public-anonymous returns ``None``; explicitly configured
+    pairs return ``(user, token)`` bound to :data:`GHCR_REGISTRY`; incomplete
+    pairs, unresolvable SecretRefs, rotation/disable detected between the
+    paired reads, managed-store outage, and denied/revoked credentials raise
+    ``ValueError`` at the registry boundary. ``None`` is never a signal to try
+    another identity.
+
+    The ``environment`` launch mapping and ``github_credential`` descriptor are
+    accepted for signature compatibility but are never consulted for registry
+    secrets: agent-authored launch fields, source PATs, and GitHub actor
+    lookups are not registry authentication. SecretRef *names* are read from
+    the deployment process environment only, never from the launch mapping.
+
+    Public defaults: images that are publicly readable are acquired
+    anonymously (``None``) with no model/source credential, no managed-secret
+    access beyond the GHCR slug check, and no login helper. Explicit
+    private-registry setup selects one of the three sources above for
+    ``ghcr.io``. Obsolete implicit configuration (any ``GITHUB_TOKEN`` /
+    source-connection fallback or GitHub username probing) was removed and
+    must not be reintroduced. Safe recovery: reconfigure or restore the
+    selected deployment pair and retry the pull; removing the source coupling
+    requires no new PAT prompt for unaffected scratch/public work.
+
+    The returned plaintext is for immediate Docker config materialization only
+    (per-operation ephemeral config, restricted permissions/lifetime, never
+    mounted into the agent or included in snapshots). Callers must not store
+    it in workflow history, logs, labels, argv, inspectable runtime env,
+    heartbeats, error payloads, plans, or durable metadata.
     """
 
-    launch_environment = environment or {}
+    _ = environment
+    _ = github_credential
 
     user_ref = str(
-        launch_environment.get("GHCR_PULL_USER_SECRET_REF")
-        or os.environ.get("MOONMIND_GHCR_PULL_USER_SECRET_REF")
+        os.environ.get("MOONMIND_GHCR_PULL_USER_SECRET_REF")
         or os.environ.get("WORKFLOW_GHCR_PULL_USER_SECRET_REF")
         or ""
     ).strip()
     token_ref = str(
-        launch_environment.get("GHCR_PULL_TOKEN_SECRET_REF")
-        or os.environ.get("MOONMIND_GHCR_PULL_TOKEN_SECRET_REF")
+        os.environ.get("MOONMIND_GHCR_PULL_TOKEN_SECRET_REF")
         or os.environ.get("WORKFLOW_GHCR_PULL_TOKEN_SECRET_REF")
         or ""
     ).strip()
@@ -193,20 +241,30 @@ async def resolve_ghcr_pull_credentials_for_launch(
             token_ref,
             field_name="GHCR_PULL_TOKEN_SECRET_REF",
         )
-        if user.strip() and token.strip():
-            return user.strip(), token.strip()
-        return None
+        if not user.strip() or not token.strip():
+            raise ValueError(
+                "GHCR pull authentication secret refs resolved to an incomplete pair"
+            )
+        # Detect rotation/disable of db-backed refs between the paired reads
+        # through the existing Secrets System readiness check.
+        db_refs = [
+            ref
+            for ref in (user_ref, token_ref)
+            if ref.strip().startswith("db://")
+        ]
+        if db_refs:
+            broken = await inspect_managed_secret_refs_for_launch(db_refs)
+            if broken:
+                raise ValueError(
+                    "GHCR pull authentication secret refs are not active: "
+                    + "; ".join(
+                        f"{item.secret_ref}={item.status}" for item in broken
+                    )
+                )
+        return user.strip(), token.strip()
 
-    user = str(
-        launch_environment.get("GHCR_PULL_USER")
-        or os.environ.get("GHCR_PULL_USER")
-        or ""
-    ).strip()
-    token = str(
-        launch_environment.get("GHCR_PULL_TOKEN")
-        or os.environ.get("GHCR_PULL_TOKEN")
-        or ""
-    ).strip()
+    user = str(os.environ.get("GHCR_PULL_USER") or "").strip()
+    token = str(os.environ.get("GHCR_PULL_TOKEN") or "").strip()
     if user or token:
         if not user or not token:
             raise ValueError(
@@ -215,18 +273,14 @@ async def resolve_ghcr_pull_credentials_for_launch(
         return user, token
 
     try:
-        stored_user, stored_token = await asyncio.gather(
-            _resolve_first_active_managed_secret_slug(_MANAGED_GHCR_PULL_USER_SLUGS),
-            _resolve_first_active_managed_secret_slug(_MANAGED_GHCR_PULL_TOKEN_SLUGS),
-        )
+        stored_user, stored_token = await _resolve_managed_ghcr_pull_pair()
     except asyncio.CancelledError:
         raise
-    except Exception:
-        logger.warning(
-            "Failed to resolve GHCR pull credentials from managed secrets store",
-            exc_info=True,
-        )
-        stored_user, stored_token = None, None
+    except Exception as exc:
+        raise ValueError(
+            "GHCR pull credential store is unavailable; refusing to fall back "
+            "to another identity or anonymous acquisition"
+        ) from exc
 
     if stored_user or stored_token:
         if not stored_user or not stored_token:
@@ -235,18 +289,6 @@ async def resolve_ghcr_pull_credentials_for_launch(
             )
         return stored_user.strip(), stored_token.strip()
 
-    github_token = await resolve_github_token_for_launch(
-        launch_environment,
-        github_credential=github_credential,
-    )
-    if github_token:
-        github_user = await _resolve_github_login_for_token(github_token)
-        if github_user:
-            return github_user, github_token
-        logger.warning(
-            "GitHub token is configured but could not be converted into GHCR "
-            "pull credentials because the GitHub username could not be resolved"
-        )
     return None
 
 async def resolve_github_token_for_launch(
@@ -635,10 +677,12 @@ async def assert_managed_secret_refs_active_for_launch(
 
 __all__ = [
     "BrokenSecretRef",
+    "GHCR_REGISTRY",
     "SecretRefLaunchBlockedError",
     "assert_managed_secret_refs_active_for_launch",
     "build_github_credential_descriptor_for_launch",
     "inspect_managed_secret_refs_for_launch",
+    "resolve_ghcr_pull_credentials_for_launch",
     "resolve_github_token_for_launch",
     "resolve_managed_api_key_reference",
     "resolve_managed_github_token_from_store",

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -959,6 +959,8 @@ class DockerCodexManagedSessionController:
             try:
                 os.close(fd)
             except OSError:
+                # fd may already be closed by fdopen failure path; the
+                # config dir removal below is the authoritative cleanup.
                 pass
             shutil.rmtree(config_dir, ignore_errors=True)
             raise
@@ -2848,7 +2850,6 @@ class DockerCodexManagedSessionController:
             # in `docker run`; remove it before the session is usable so no
             # registry credential lingers on the host beyond launch.
             self._remove_ghcr_pull_config(ghcr_config_dir)
-            ghcr_config_dir = None
         try:
             await self._wait_ready(container_id=container_id)
             container_job_capability_metadata = {

--- a/moonmind/workflows/temporal/runtime/managed_session_controller.py
+++ b/moonmind/workflows/temporal/runtime/managed_session_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import logging
@@ -12,6 +13,7 @@ import re
 import shlex
 import shutil
 import stat
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -59,6 +61,8 @@ from moonmind.workflows.codex_session_timeouts import (
 )
 from moonmind.workflows.skills.workspace_links import cleanup_moonmind_skill_projections
 from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    GHCR_REGISTRY,
+    resolve_ghcr_pull_credentials_for_launch,
     resolve_github_token_for_launch,
 )
 
@@ -910,6 +914,61 @@ class DockerCodexManagedSessionController:
                 docker_config_dir,
                 exc_info=True,
             )
+
+    @staticmethod
+    def _ghcr_image_needs_isolated_config(image_ref: str) -> bool:
+        """Return whether a session image must bypass ambient Docker auth."""
+
+        return str(image_ref or "").strip().lower().startswith(
+            f"{GHCR_REGISTRY.lower()}/"
+        )
+
+    @staticmethod
+    def _materialize_ghcr_pull_config(
+        creds: tuple[str, str] | None,
+    ) -> str:
+        """Write an ephemeral Docker config dir for a GHCR session pull.
+
+        Explicit ``(user, token)`` pairs are materialized as a ``ghcr.io``
+        ``auth`` entry; ``None`` (public-anonymous) materializes an empty
+        ``auths`` object so ambient logins cannot authenticate the pull.
+        The directory is ``0700`` and ``config.json`` is ``0600``; it must
+        never be mounted into the agent container.
+        """
+
+        config_dir = tempfile.mkdtemp(prefix="moonmind-ghcr-pull-")
+        os.chmod(config_dir, stat.S_IRWXU)
+        if creds is not None:
+            user, token = creds
+            raw = f"{user}:{token}".encode()
+            auth_value = base64.b64encode(raw).decode("ascii")
+            config = {"auths": {GHCR_REGISTRY: {"auth": auth_value}}}
+        else:
+            config = {"auths": {}}
+        config_path = Path(config_dir) / "config.json"
+        fd = os.open(
+            config_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(config, handle)
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            shutil.rmtree(config_dir, ignore_errors=True)
+            raise
+        return config_dir
+
+    @staticmethod
+    def _remove_ghcr_pull_config(config_dir: str | None) -> None:
+        if not config_dir:
+            return
+        shutil.rmtree(config_dir, ignore_errors=True)
 
     def _validate_launch_request(self, request: LaunchCodexManagedSessionRequest) -> None:
         self._validate_workspace_path(request.workspace_path, field_name="workspacePath")
@@ -2643,6 +2702,21 @@ class DockerCodexManagedSessionController:
             self._sidecar_agent_container_name(request.session_id),
             ignore_failure=True,
         )
+        # MoonLadderStudios/MoonMind#4012: GHCR session images never use
+        # ambient Docker auth or source PATs. Resolve the deployment-scoped
+        # GHCR pair and run this launch with an ephemeral DOCKER_CONFIG:
+        # explicit creds for private images, an empty config for
+        # public-anonymous acquisition. Non-GHCR images keep the existing
+        # backend behavior.
+        ghcr_config_dir: str | None = None
+        if self._ghcr_image_needs_isolated_config(request.image_ref):
+            try:
+                ghcr_creds = await resolve_ghcr_pull_credentials_for_launch()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                raise RuntimeError(str(exc)) from exc
+            ghcr_config_dir = self._materialize_ghcr_pull_config(ghcr_creds)
         run_command = [
             self._docker_binary,
             "run",
@@ -2676,6 +2750,7 @@ class DockerCodexManagedSessionController:
             github_broker_started = "GIT_CONFIG_GLOBAL" in session_environment
         except Exception:
             await self._github_auth_brokers.stop(request.session_id)
+            self._remove_ghcr_pull_config(ghcr_config_dir)
             raise
         docker_network = self._network_name or _managed_session_docker_network(
             session_environment
@@ -2737,11 +2812,19 @@ class DockerCodexManagedSessionController:
             if github_broker_started:
                 await self._github_auth_brokers.stop(request.session_id)
 
+        # DOCKER_CONFIG isolates registry auth for this `docker run` only;
+        # it is host-side launch state, never added to session_environment.
+        docker_run_extra_env: dict[str, str] | None = None
+        if ghcr_config_dir:
+            docker_run_extra_env = dict(container_secret_environment or {})
+            docker_run_extra_env["DOCKER_CONFIG"] = ghcr_config_dir
+        elif container_secret_environment:
+            docker_run_extra_env = dict(container_secret_environment)
         try:
             try:
                 stdout, _stderr = await self._run(
                     run_command,
-                    extra_env=container_secret_environment or None,
+                    extra_env=docker_run_extra_env,
                 )
             except RuntimeError as exc:
                 if not self._docker_name_conflict(exc, container_name):
@@ -2749,7 +2832,7 @@ class DockerCodexManagedSessionController:
                 await self._remove_container(container_name, ignore_failure=True)
                 stdout, _stderr = await self._run(
                     run_command,
-                    extra_env=container_secret_environment or None,
+                    extra_env=docker_run_extra_env,
                 )
             container_id = stdout.strip()
             if not container_id:
@@ -2760,6 +2843,12 @@ class DockerCodexManagedSessionController:
         except Exception:
             await _cleanup_failed_launch(container_id or container_name)
             raise
+        finally:
+            # The ephemeral GHCR config is only needed for the pull embedded
+            # in `docker run`; remove it before the session is usable so no
+            # registry credential lingers on the host beyond launch.
+            self._remove_ghcr_pull_config(ghcr_config_dir)
+            ghcr_config_dir = None
         try:
             await self._wait_ready(container_id=container_id)
             container_job_capability_metadata = {

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -55,6 +55,28 @@ def _clear_managed_session_docker_policy_env(
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_DOCKER_MODE", raising=False)
     monkeypatch.delenv("MOONMIND_MANAGED_SESSION_REAP_MAX_AGE_SECONDS", raising=False)
     monkeypatch.delenv("MOONMIND_CONTROL_PLANE_NETWORK", raising=False)
+    # MoonLadderStudios/MoonMind#4012: GHCR pull resolution is deployment
+    # configuration. Default unit launches to public-anonymous (None) so they
+    # do not touch the managed-secret store; individual GHCR tests re-patch
+    # the resolver to return an explicit pair.
+    for var in (
+        "GHCR_PULL_USER",
+        "GHCR_PULL_TOKEN",
+        "MOONMIND_GHCR_PULL_USER_SECRET_REF",
+        "MOONMIND_GHCR_PULL_TOKEN_SECRET_REF",
+        "WORKFLOW_GHCR_PULL_USER_SECRET_REF",
+        "WORKFLOW_GHCR_PULL_TOKEN_SECRET_REF",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    async def _no_ghcr_creds() -> tuple[str, str] | None:
+        return None
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller"
+        ".resolve_ghcr_pull_credentials_for_launch",
+        _no_ghcr_creds,
+    )
 
 
 def test_managed_session_network_uses_canonical_control_plane_setting(
@@ -7209,3 +7231,104 @@ def test_active_session_observations_merges_authoritative_intervention_journal()
         "approval_requested",
     ]
     assert observations[-1]["metadata"]["auditRef"] == "artifact://interventions/request-1"
+
+
+async def test_launch_session_uses_ephemeral_ghcr_config_for_private_image(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """MoonLadderStudios/MoonMind#4012: GHCR launches use ephemeral auth.
+
+    Explicit GHCR pairs materialize a per-launch DOCKER_CONFIG with a
+    ghcr.io entry; the directory is removed before launch returns and no
+    credential reaches container env or argv.
+    """
+
+    import base64
+
+    monkeypatch.setenv("MOONMIND_URL", "http://api:8000")
+    workspace_root = tmp_path / "agent_jobs"
+    session_store = ManagedSessionStore(tmp_path / "session-store")
+    session_supervisor = AsyncMock()
+    session_supervisor.emit_session_event = Mock()
+
+    async def _explicit_creds() -> tuple[str, str] | None:
+        return ("ghcr-user", "ghcr-token-value")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_session_controller"
+        ".resolve_ghcr_pull_credentials_for_launch",
+        _explicit_creds,
+    )
+
+    request = LaunchCodexManagedSessionRequest(
+        **dict(
+            agentRunId="task-ghcr-1",
+            workflowId="wf-ghcr-1",
+            sessionId="sess-ghcr-1",
+            threadId="logical-thread-ghcr-1",
+            workspacePath=str(workspace_root / "task-ghcr-1" / "repo"),
+            sessionWorkspacePath=str(workspace_root / "task-ghcr-1" / "session"),
+            artifactSpoolPath=str(workspace_root / "task-ghcr-1" / "artifacts"),
+            codexHomePath="/home/app/.codex",
+            imageRef="ghcr.io/moonladderstudios/moonmind:latest",
+            turnCompletionTimeoutSeconds=1800,
+        )
+    )
+    seen_configs: list[dict[str, Any]] = []
+    seen_dirs: list[str] = []
+    seen_env: dict[str, str] = {}
+
+    async def _fake_runner(
+        command: tuple[str, ...],
+        *,
+        input_text: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        if command[:3] == ("docker", "rm", "-f"):
+            return 1, "", "No such container"
+        if command[:2] == ("docker", "run"):
+            docker_config = str((env or {}).get("DOCKER_CONFIG") or "")
+            assert docker_config, "GHCR launches must set ephemeral DOCKER_CONFIG"
+            seen_dirs.append(docker_config)
+            config_path = Path(docker_config) / "config.json"
+            seen_configs.append(json.loads(config_path.read_text()))
+            seen_env.update(env or {})
+            return 0, "ctr-ghcr-1\n", ""
+        if "ready" in command:
+            return 0, '{"ready": true}\n', ""
+        if "launch_session" in command:
+            payload = {
+                "sessionState": {
+                    "sessionId": "sess-ghcr-1",
+                    "sessionEpoch": 1,
+                    "containerId": "ctr-ghcr-1",
+                    "threadId": "logical-thread-ghcr-1",
+                },
+                "status": "ready",
+                "imageRef": "ghcr.io/moonladderstudios/moonmind:latest",
+                "controlUrl": "docker-exec://mm-codex-session-sess-ghcr-1",
+                "metadata": {},
+            }
+            return 0, json.dumps(payload), ""
+        raise AssertionError(f"unexpected command: {command}")
+
+    controller = DockerCodexManagedSessionController(
+        workspace_volume_name="agent_workspaces",
+        codex_volume_name="codex_auth_volume",
+        workspace_root=str(workspace_root),
+        moonmind_url="http://api:8000",
+        session_store=session_store,
+        session_supervisor=session_supervisor,
+        command_runner=_fake_runner,
+        ready_poll_interval_seconds=0,
+    )
+
+    handle = await controller.launch_session(request)
+
+    assert handle.status == "ready"
+    assert len(seen_configs) == 1
+    expected_auth = base64.b64encode(b"ghcr-user:ghcr-token-value").decode("ascii")
+    assert seen_configs[0]["auths"]["ghcr.io"] == {"auth": expected_auth}
+    # Ephemeral config removed before return; never in container env.
+    assert seen_dirs and not Path(seen_dirs[0]).exists()
+    assert "ghcr-token-value" not in json.dumps(seen_env)

--- a/tests/unit/services/temporal/runtime/test_managed_session_controller.py
+++ b/tests/unit/services/temporal/runtime/test_managed_session_controller.py
@@ -7233,6 +7233,7 @@ def test_active_session_observations_merges_authoritative_intervention_journal()
     assert observations[-1]["metadata"]["auditRef"] == "artifact://interventions/request-1"
 
 
+@pytest.mark.asyncio
 async def test_launch_session_uses_ephemeral_ghcr_config_for_private_image(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/workflows/temporal/runtime/test_ghcr_pull_decoupling_4012.py
+++ b/tests/unit/workflows/temporal/runtime/test_ghcr_pull_decoupling_4012.py
@@ -318,19 +318,22 @@ async def test_production_private_pull_never_sees_source_pat(
         "api_service.db.base.async_session_maker", _FakeSessionMaker(store)
     )
     _forbid_source_token_resolution(monkeypatch)
-    launch = {
-        "GITHUB_TOKEN": SOURCE_PAT_A,
-        "GHCR_PULL_USER": "agent-user",
-        "GHCR_PULL_TOKEN": "agent-token",
-    }
 
-    creds = await resolve_ghcr_pull_credentials_for_launch(launch)
+    # Deployment-scoped resolver takes no launch mapping: agent-smuggled
+    # GHCR_PULL_*/GITHUB_TOKEN fields cannot be supplied.
+    creds = await resolve_ghcr_pull_credentials_for_launch()
 
     assert creds == (IDENTITY_B_USER, IDENTITY_B_TOKEN)
     assert SOURCE_PAT_A not in creds
 
+    async def _wired_resolver(ref: str) -> RegistryCredential:
+        assert ref == "db://ghcr"
+        assert creds is not None
+        user, token = creds
+        return RegistryCredential(username=user, secret=token)
+
     daemon = _RecordingDaemon()
-    backend = _backend(daemon, tmp_path)
+    backend = _backend(daemon, tmp_path, resolver=_wired_resolver)
     result = await backend.acquire_image(
         _private_request(workspace=tmp_path, job_suffix="b" * 32)
     )
@@ -369,12 +372,7 @@ async def test_production_public_pull_without_identity_uses_no_auth(
     )
     _forbid_source_token_resolution(monkeypatch)
 
-    assert (
-        await resolve_ghcr_pull_credentials_for_launch(
-            {"GITHUB_TOKEN": SOURCE_PAT_A}
-        )
-        is None
-    )
+    assert await resolve_ghcr_pull_credentials_for_launch() is None
     # The omitted path queries no secret store beyond the GHCR slug check.
     assert set(store.seen_slugs) <= {"GHCR_PULL_USER", "GHCR_PULL_TOKEN"}
 
@@ -452,7 +450,7 @@ async def test_managed_slug_rotation_between_reads_raises_not_mixed(
     _forbid_source_token_resolution(monkeypatch)
 
     with pytest.raises(ValueError, match="mixed|rotation|changed"):
-        await resolve_ghcr_pull_credentials_for_launch({})
+        await resolve_ghcr_pull_credentials_for_launch()
 
     assert maker.calls == 1
 
@@ -469,7 +467,7 @@ async def test_stable_managed_slug_pair_resolves_coherently(
     monkeypatch.setattr("api_service.db.base.async_session_maker", maker)
     _forbid_source_token_resolution(monkeypatch)
 
-    assert await resolve_ghcr_pull_credentials_for_launch({}) == (
+    assert await resolve_ghcr_pull_credentials_for_launch() == (
         "pull-user",
         "pull-token",
     )
@@ -598,7 +596,7 @@ async def test_cancelled_private_pull_cleans_up_only_own_config(
     await asyncio.sleep(0.05)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
-        await task
+        _ = await task  # noqa: B018 - awaiting propagates cancellation by design
     release.set()
 
     assert not backend._auth_dir(request).exists()

--- a/tests/unit/workflows/temporal/runtime/test_ghcr_pull_decoupling_4012.py
+++ b/tests/unit/workflows/temporal/runtime/test_ghcr_pull_decoupling_4012.py
@@ -1,0 +1,784 @@
+"""Decouple runtime image acquisition from source credentials (#4012).
+
+Inventory-backed production-pull proof for
+MoonLadderStudios/MoonMind#4012. The deployed pull boundary, traced from the
+real image-selection and pull composition (not from the GHCR helper alone):
+
+- managed sessions: DinD sidecar plus session images via
+  ``DockerCodexManagedSessionController`` against the deployment Docker
+  backend (``backend_ref="system"``); auth source is the explicit GHCR pair
+  or ambient daemon config for public images only.
+- generic/profile-bound Omnigent: digest-pinned refs resolved by
+  ``moonmind/omnigent/bootstrap/image_resolution.py``
+  (``_resolve_via_docker_pull`` / ``_image_build_identity``) via bare
+  ``docker pull`` against the deployment backend; no source PAT is passed.
+- container jobs: ``container_job_backend.py`` + ``registry_auth_resolve.py``
+  (``registry_authorization`` with an explicit ``registryCredentialRef``,
+  per-job ephemeral ``--config`` auth dirs, immediate post-pull cleanup).
+- Compose/bootstrap: ``docker-compose.yaml`` image refs and stock-image
+  acquisition via bare ``docker pull``; no source PAT.
+- legacy worker container path: ``moonmind/agents/codex_worker/worker.py``
+  ``_ensure_container_image`` via bare ``docker pull``; no source PAT.
+
+These tests drive the real composition (container-job backend acquire paths
+and the Omnigent pull helper) with a source PAT A present and assert it never
+reaches registry calls/config and no GitHub username lookup runs, with and
+without an explicit registry identity B.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from moonmind.schemas.container_job_models import (
+    ContainerJobActivityRequest,
+    ContainerJobBackendError,
+    ContainerJobFailureClass,
+    RegistryAuthorization,
+)
+from moonmind.workflows.temporal.container_image_acquisition import (
+    ImageAcquisitionError,
+    classify_pull_failure,
+)
+from moonmind.workflows.temporal.container_job_backend import (
+    DockerContainerJobBackend,
+)
+from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+    resolve_ghcr_pull_credentials_for_launch,
+)
+from moonmind.workflows.temporal.runtime.registry_auth_resolve import (
+    RegistryCredential,
+)
+
+SOURCE_PAT_A = "ghp-source-PAT-A-0000-not-a-real-token"
+IDENTITY_B_USER = "registry-B-user"
+IDENTITY_B_TOKEN = "registry-B-token-value-0000"
+IMAGE = "ghcr.io/org/app:1"
+DIGEST = "sha256:" + "c" * 64
+
+
+# --------------------------------------------------------------------------- #
+# Fakes: managed-secret store sessions and Docker CLI runners.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeAsyncSessionCtx:
+    def __init__(self, session: object) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> object:
+        return self._session
+
+    async def __aexit__(self, *_args: object) -> bool:
+        return False
+
+
+class _FakeScalarResult:
+    def __init__(self, secret: object | None) -> None:
+        self._secret = secret
+
+    def scalar_one_or_none(self) -> object | None:
+        return self._secret
+
+
+class _FakeLookupSession:
+    """Stable in-memory managed-secret store keyed by slug."""
+
+    def __init__(
+        self,
+        *,
+        values: dict[str, str | None] | None = None,
+        errors: dict[str, Exception] | None = None,
+    ) -> None:
+        self._values = values or {}
+        self._errors = errors or {}
+        self.seen_slugs: list[str] = []
+
+    async def execute(self, query) -> _FakeScalarResult:
+        slug = str(query.compile().params["slug_1"])
+        self.seen_slugs.append(slug)
+        if slug in self._errors:
+            raise self._errors[slug]
+        value = self._values.get(slug)
+        secret = None if value is None else SimpleNamespace(ciphertext=value)
+        return _FakeScalarResult(secret)
+
+
+class _FakeSessionMaker:
+    def __init__(self, session: _FakeLookupSession | object) -> None:
+        self._session = session
+        self.calls = 0
+
+    def __call__(self) -> _FakeAsyncSessionCtx:
+        self.calls += 1
+        return _FakeAsyncSessionCtx(self._session)
+
+
+class _RotatingLookupSession:
+    """Store where the pull token rotates between the paired reads."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def execute(self, query) -> _FakeScalarResult:
+        slug = str(query.compile().params["slug_1"])
+        self.calls.append(slug)
+        token_reads = sum(1 for seen in self.calls if seen == "GHCR_PULL_TOKEN")
+        if slug == "GHCR_PULL_USER":
+            value: str | None = "pull-user"
+        elif token_reads <= 1:
+            value = "pull-token-v1"
+        else:
+            value = "pull-token-v2"
+        return _FakeScalarResult(SimpleNamespace(ciphertext=value))
+
+
+def _clear_ghcr_deployment_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "GHCR_PULL_USER",
+        "GHCR_PULL_TOKEN",
+        "MOONMIND_GHCR_PULL_USER_SECRET_REF",
+        "MOONMIND_GHCR_PULL_TOKEN_SECRET_REF",
+        "WORKFLOW_GHCR_PULL_USER_SECRET_REF",
+        "WORKFLOW_GHCR_PULL_TOKEN_SECRET_REF",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _forbid_source_token_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _unexpected_github_token(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("source GitHub token resolution must not run")
+
+    async def _unexpected_managed_token(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("managed source token lookup must not run")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_github_token_for_launch",
+        _unexpected_github_token,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
+        _unexpected_managed_token,
+    )
+
+
+def _public_request(
+    *, image: str = IMAGE, policy: str = "if-missing", workspace: Path
+) -> ContainerJobActivityRequest:
+    return ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": "container-job:" + "a" * 32,
+            "ownershipToken": "container-job:" + "a" * 32 + ":v1",
+            "resolvedWorkspaceRef": str(workspace),
+            "request": {
+                "idempotencyKey": "issue-4012-public",
+                "source": {"source": "workflow", "workflowId": "mm:4012"},
+                "spec": {
+                    "image": image,
+                    "pullPolicy": policy,
+                    "workspaceRef": {"kind": "sandbox", "workspaceId": "workspace"},
+                    "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+                },
+            },
+        }
+    )
+
+
+def _private_request(
+    *,
+    image: str = IMAGE,
+    policy: str = "always",
+    workspace: Path,
+    job_suffix: str,
+    credential_ref: str = "db://ghcr",
+    authorized: bool = True,
+    registry: str = "ghcr.io",
+    repository: str = "org/app",
+    reference: str | None = None,
+) -> ContainerJobActivityRequest:
+    job_id = f"container-job:{job_suffix}"
+    return ContainerJobActivityRequest.model_validate(
+        {
+            "jobId": job_id,
+            "ownershipToken": f"{job_id}:v1",
+            "resolvedWorkspaceRef": str(workspace),
+            "request": {
+                "idempotencyKey": "issue-4012-private",
+                "source": {"source": "workflow", "workflowId": "mm:4012"},
+                "spec": {
+                    "image": image,
+                    "pullPolicy": policy,
+                    "workspaceRef": {"kind": "sandbox", "workspaceId": "workspace"},
+                    "registryCredentialRef": credential_ref,
+                    "resources": {"cpuMillis": 1000, "memoryMiB": 512},
+                },
+            },
+            "registryAuthorization": RegistryAuthorization(
+                authorized=authorized,
+                registry=registry,
+                repository=repository,
+                reference=reference or image,
+                credentialRef=credential_ref,
+                scope="org/*",
+            ).model_dump(by_alias=True, exclude_none=True),
+        }
+    )
+
+
+class _RecordingDaemon:
+    """In-memory Docker CLI stand-in recording every argv and auth config."""
+
+    def __init__(self) -> None:
+        self.present: set[str] = set()
+        self.commands: list[tuple[str, ...]] = []
+        self.pulled_configs: list[dict[str, object]] = []
+        self.pull_count = 0
+        self.deny_pulls_with: bytes | None = None
+        self.pull_delay = 0.0
+
+    async def runner(self, args) -> tuple[int, bytes, bytes]:
+        argv = tuple(args)
+        self.commands.append(argv)
+        if argv[:2] == ("image", "inspect"):
+            image = argv[-1]
+            if image in self.present:
+                return 0, DIGEST.encode(), b""
+            return 1, b"", b"No such image"
+        if "--config" in argv and "pull" in argv:
+            return await self._authorized_pull(argv)
+        if argv[0] == "pull":
+            image = argv[1]
+            self.pull_count += 1
+            self.present.add(image)
+            return 0, b"pull progress", b""
+        return 0, b"", b""
+
+    async def _authorized_pull(
+        self, argv: tuple[str, ...]
+    ) -> tuple[int, bytes, bytes]:
+        config_dir = Path(argv[argv.index("--config") + 1])
+        config = json.loads((config_dir / "config.json").read_text())
+        self.pulled_configs.append(
+            {"dir": str(config_dir), "auth": config["auths"]}
+        )
+        self.pull_count += 1
+        if self.pull_delay:
+            await asyncio.sleep(self.pull_delay)
+        if self.deny_pulls_with is not None:
+            return 1, b"", self.deny_pulls_with
+        self.present.add(argv[-1])
+        return 0, b"pull progress", b""
+
+    def argv_text(self) -> str:
+        return "\n".join(" ".join(cmd) for cmd in self.commands)
+
+    def config_text(self) -> str:
+        return json.dumps(self.pulled_configs)
+
+
+def _backend(
+    daemon: _RecordingDaemon, tmp_path: Path, *, resolver=None
+) -> DockerContainerJobBackend:
+    async def default_resolver(ref: str) -> RegistryCredential:
+        return RegistryCredential(username=IDENTITY_B_USER, secret=IDENTITY_B_TOKEN)
+
+    return DockerContainerJobBackend(
+        workspace_root=tmp_path / "workspaces",
+        command_runner=daemon.runner,
+        registry_auth_resolver=resolver or default_resolver,
+        auth_root=tmp_path / "auth",
+        image_lock_root=tmp_path / "locks",
+        pull_lock_poll_seconds=0.01,
+        pull_lock_max_wait_seconds=5.0,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# acc-1: inventory-backed production pull proof (with and without identity B).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_production_private_pull_never_sees_source_pat(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """With explicit registry identity B, source PAT A never reaches pulls."""
+
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("GHCR_PULL_USER", IDENTITY_B_USER)
+    monkeypatch.setenv("GHCR_PULL_TOKEN", IDENTITY_B_TOKEN)
+    monkeypatch.setenv("GITHUB_TOKEN", SOURCE_PAT_A)
+    store = _FakeLookupSession()
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker", _FakeSessionMaker(store)
+    )
+    _forbid_source_token_resolution(monkeypatch)
+    launch = {
+        "GITHUB_TOKEN": SOURCE_PAT_A,
+        "GHCR_PULL_USER": "agent-user",
+        "GHCR_PULL_TOKEN": "agent-token",
+    }
+
+    creds = await resolve_ghcr_pull_credentials_for_launch(launch)
+
+    assert creds == (IDENTITY_B_USER, IDENTITY_B_TOKEN)
+    assert SOURCE_PAT_A not in creds
+
+    daemon = _RecordingDaemon()
+    backend = _backend(daemon, tmp_path)
+    result = await backend.acquire_image(
+        _private_request(workspace=tmp_path, job_suffix="b" * 32)
+    )
+
+    assert result.resolved_image_ref == DIGEST
+    assert daemon.pull_count == 1
+    # The single pull used the authorized per-job transport.
+    assert any("--config" in cmd and "pull" in cmd for cmd in daemon.commands)
+    assert SOURCE_PAT_A not in daemon.argv_text()
+    assert SOURCE_PAT_A not in daemon.config_text()
+    # Agent-smuggled launch fields are not registry authentication.
+    assert "agent-user" not in daemon.config_text()
+    assert "agent-token" not in daemon.config_text()
+    assert daemon.pulled_configs[0]["auth"]["ghcr.io"] == {
+        "username": IDENTITY_B_USER,
+        "password": IDENTITY_B_TOKEN,
+    }
+    # Ephemeral auth is removed immediately after the pull: only the job
+    # directory is removed, so assert this job's directory specifically.
+    assert not backend._auth_dir(
+        _private_request(workspace=tmp_path, job_suffix="b" * 32)
+    ).exists()
+
+
+@pytest.mark.asyncio
+async def test_production_public_pull_without_identity_uses_no_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without identity B, cold public acquisition uses no credentials at all."""
+
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_TOKEN", SOURCE_PAT_A)
+    store = _FakeLookupSession()
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker", _FakeSessionMaker(store)
+    )
+    _forbid_source_token_resolution(monkeypatch)
+
+    assert (
+        await resolve_ghcr_pull_credentials_for_launch(
+            {"GITHUB_TOKEN": SOURCE_PAT_A}
+        )
+        is None
+    )
+    # The omitted path queries no secret store beyond the GHCR slug check.
+    assert set(store.seen_slugs) <= {"GHCR_PULL_USER", "GHCR_PULL_TOKEN"}
+
+    daemon = _RecordingDaemon()
+    backend = _backend(daemon, tmp_path)
+    result = await backend.acquire_image(
+        _public_request(workspace=tmp_path)
+    )
+
+    assert result.resolved_image_ref == DIGEST
+    assert daemon.pull_count == 1
+    assert all("--config" not in cmd for cmd in daemon.commands)
+    assert daemon.pulled_configs == []
+    assert SOURCE_PAT_A not in daemon.argv_text()
+    assert result.image_observation.provision_action == "pull"
+    assert result.image_observation.cache_hit is False
+
+
+@pytest.mark.asyncio
+async def test_omnigent_bare_pull_carries_no_source_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Omnigent pull transport issues bare pulls with no PAT argv."""
+
+    import moonmind.omnigent.bootstrap.image_resolution as image_resolution
+
+    seen: list[list[str]] = []
+
+    async def fake_run(cmd: list[str], timeout: int = 30):
+        seen.append(list(cmd))
+        if list(cmd)[:2] == ["docker", "pull"]:
+            return 0, "", ""
+        if list(cmd)[:3] == ["docker", "image", "inspect"]:
+            return 0, json.dumps([f"ghcr.io/org/host@{DIGEST}"]), ""
+        return 1, "", "unexpected"
+
+    monkeypatch.setattr(image_resolution, "_run", fake_run)
+    monkeypatch.setenv("GITHUB_TOKEN", SOURCE_PAT_A)
+
+    async def _forbidden(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("source token resolution must not run")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_github_token_for_launch",
+        _forbidden,
+    )
+
+    resolved = await image_resolution._resolve_via_docker_pull(
+        "ghcr.io/org/host", "1.0"
+    )
+
+    assert resolved == f"ghcr.io/org/host@{DIGEST}"
+    assert any(cmd[:2] == ["docker", "pull"] for cmd in seen)
+    flat = "\n".join(" ".join(cmd) for cmd in seen)
+    assert SOURCE_PAT_A not in flat
+    assert "--password" not in flat
+    assert "--username" not in flat
+
+
+# --------------------------------------------------------------------------- #
+# acc-2: fail-closed rotation and denial without fallback.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_managed_slug_rotation_between_reads_raises_not_mixed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two slug reads straddling a rotation raise instead of mixing a pair."""
+
+    _clear_ghcr_deployment_env(monkeypatch)
+    session = _RotatingLookupSession()
+    maker = _FakeSessionMaker(session)
+    monkeypatch.setattr("api_service.db.base.async_session_maker", maker)
+    _forbid_source_token_resolution(monkeypatch)
+
+    with pytest.raises(ValueError, match="mixed|rotation|changed"):
+        await resolve_ghcr_pull_credentials_for_launch({})
+
+    assert maker.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stable_managed_slug_pair_resolves_coherently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ghcr_deployment_env(monkeypatch)
+    session = _FakeLookupSession(
+        values={"GHCR_PULL_USER": "pull-user", "GHCR_PULL_TOKEN": "pull-token"}
+    )
+    maker = _FakeSessionMaker(session)
+    monkeypatch.setattr("api_service.db.base.async_session_maker", maker)
+    _forbid_source_token_resolution(monkeypatch)
+
+    assert await resolve_ghcr_pull_credentials_for_launch({}) == (
+        "pull-user",
+        "pull-token",
+    )
+    assert maker.calls == 1
+    assert set(session.seen_slugs) <= {"GHCR_PULL_USER", "GHCR_PULL_TOKEN"}
+
+
+@pytest.mark.asyncio
+async def test_denied_private_credentials_fail_closed_without_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A denied pull raises once: no anonymous retry, no second identity."""
+
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_TOKEN", SOURCE_PAT_A)
+
+    daemon = _RecordingDaemon()
+    daemon.deny_pulls_with = f"denied: invalid token {IDENTITY_B_TOKEN}".encode()
+    backend = _backend(daemon, tmp_path)
+    request = _private_request(workspace=tmp_path, job_suffix="d" * 32)
+
+    with pytest.raises(ContainerJobBackendError) as excinfo:
+        await backend.acquire_image(request)
+
+    assert excinfo.value.failure_class == ContainerJobFailureClass.REGISTRY_AUTH_FAILED
+    # Exactly one registry attempt, on the authorized transport.
+    assert daemon.pull_count == 1
+    assert all("--config" in cmd for cmd in daemon.commands if "pull" in cmd)
+    # Secret-safe: the denied token is redacted, the source PAT never appears.
+    assert IDENTITY_B_TOKEN not in str(excinfo.value)
+    assert "[redacted]" in str(excinfo.value)
+    assert SOURCE_PAT_A not in str(excinfo.value)
+    assert SOURCE_PAT_A not in daemon.argv_text()
+    # The owning operation's ephemeral config is gone.
+    assert not backend._auth_dir(request).exists()
+
+
+# --------------------------------------------------------------------------- #
+# acc-4: concurrent-pull isolation and cancellation.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_concurrent_private_pulls_isolate_ephemeral_config(
+    tmp_path: Path,
+) -> None:
+    """Two pulls with different identities isolate temp config and digests."""
+
+    daemon = _RecordingDaemon()
+    daemon.pull_delay = 0.05
+    calls: list[str] = []
+
+    async def resolver(ref: str) -> RegistryCredential:
+        calls.append(ref)
+        if ref == "db://ghcr-a":
+            return RegistryCredential(username="alice", secret="tok-a-0000")
+        if ref == "db://ghcr-b":
+            return RegistryCredential(username="bob", secret="tok-b-0000")
+        raise AssertionError(f"unexpected credential ref {ref}")
+
+    backend = _backend(daemon, tmp_path, resolver=resolver)
+    request_a = _private_request(
+        workspace=tmp_path, job_suffix="a" * 32, credential_ref="db://ghcr-a"
+    )
+    request_b = _private_request(
+        workspace=tmp_path, job_suffix="b" * 32, credential_ref="db://ghcr-b"
+    )
+
+    result_a, result_b = await asyncio.gather(
+        backend.acquire_image(request_a),
+        backend.acquire_image(request_b),
+    )
+
+    assert daemon.pull_count == 2
+    assert sorted(calls) == ["db://ghcr-a", "db://ghcr-b"]
+    dirs = [entry["dir"] for entry in daemon.pulled_configs]
+    assert len(set(dirs)) == 2
+    by_user = {
+        entry["auth"]["ghcr.io"]["username"]: entry["auth"]["ghcr.io"]["password"]
+        for entry in daemon.pulled_configs
+    }
+    assert by_user == {"alice": "tok-a-0000", "bob": "tok-b-0000"}
+    # Exact selected image/backend preserved for both; no substitution.
+    assert result_a.resolved_image_ref == DIGEST
+    assert result_b.resolved_image_ref == DIGEST
+    assert not backend._auth_dir(request_a).exists()
+    assert not backend._auth_dir(request_b).exists()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_private_pull_cleans_up_only_own_config(
+    tmp_path: Path,
+) -> None:
+    """Cancellation removes the owning config and preserves other operations."""
+
+    daemon = _RecordingDaemon()
+    release = asyncio.Event()
+
+    async def blocking_runner(args):
+        argv = tuple(args)
+        daemon.commands.append(argv)
+        if argv[:2] == ("image", "inspect"):
+            return 1, b"", b"No such image"
+        if "pull" in argv:
+            await release.wait()
+            return 0, b"", b""
+        return 0, b"", b""
+
+    async def resolving_runner(ref: str) -> RegistryCredential:
+        return RegistryCredential(username="alice", secret="tok-a-0000")
+
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path / "workspaces",
+        command_runner=blocking_runner,
+        registry_auth_resolver=resolving_runner,
+        auth_root=tmp_path / "auth",
+        image_lock_root=tmp_path / "locks",
+    )
+    request = _private_request(workspace=tmp_path, job_suffix="e" * 32)
+    sibling = _private_request(workspace=tmp_path, job_suffix="f" * 32)
+    sibling_dir = backend._auth_dir(sibling)
+    sibling_dir.mkdir(parents=True)
+    (sibling_dir / "config.json").write_text('{"auths": {}}')
+
+    task = asyncio.create_task(backend.acquire_image(request))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release.set()
+
+    assert not backend._auth_dir(request).exists()
+    assert (sibling_dir / "config.json").read_text() == '{"auths": {}}'
+
+
+# --------------------------------------------------------------------------- #
+# acc-5: transport edge cases with bounded, secret-safe outcomes.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("stderr", "expected"),
+    [
+        (
+            "Error response from daemon: unauthorized: authentication required",
+            ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED,
+        ),
+        (
+            "denied: requested access to the resource is denied",
+            ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED,
+        ),
+        (
+            "no matching manifest for linux/arm64 in the manifest list",
+            ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH,
+        ),
+        (
+            "WARNING: platform (linux/arm64) does not match the host (linux/amd64)",
+            ContainerJobFailureClass.IMAGE_PLATFORM_MISMATCH,
+        ),
+        (
+            "Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+            ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE,
+        ),
+        (
+            "dial tcp 10.0.0.1:443: connection refused",
+            ContainerJobFailureClass.IMAGE_BACKEND_UNAVAILABLE,
+        ),
+        (
+            "net/http: request canceled (Client.Timeout exceeded)",
+            ContainerJobFailureClass.IMAGE_PULL_TIMEOUT,
+        ),
+        (
+            "manifest unknown: blob unknown to registry",
+            ContainerJobFailureClass.IMAGE_NOT_FOUND,
+        ),
+        (
+            "repository does not exist or may require 'docker login'",
+            ContainerJobFailureClass.IMAGE_PULL_AUTH_FAILED,
+        ),
+        ("too many redirects when pulling image", ContainerJobFailureClass.IMAGE),
+        (
+            "x509: certificate signed by unknown authority",
+            ContainerJobFailureClass.IMAGE,
+        ),
+        ("", ContainerJobFailureClass.IMAGE),
+    ],
+)
+def test_registry_transport_failures_classify_without_echoing_secrets(
+    stderr: str, expected: ContainerJobFailureClass
+) -> None:
+    planted = "tok-secret-planted-0000"
+    outcome = classify_pull_failure(f"{stderr} {planted}")
+    assert outcome == expected
+    assert planted not in outcome.value
+
+
+@pytest.mark.asyncio
+async def test_wrong_registry_endpoint_rejected_before_pull(tmp_path: Path) -> None:
+    """Credentials are never sent to an endpoint outside the authorized scope."""
+
+    async def _unexpected_resolver(ref: str) -> RegistryCredential:
+        raise AssertionError("credential must not resolve for a wrong endpoint")
+
+    daemon = _RecordingDaemon()
+    backend = _backend(daemon, tmp_path, resolver=_unexpected_resolver)
+    request = _private_request(
+        workspace=tmp_path,
+        job_suffix="1" * 32,
+        image="docker.io/library/alpine:3",
+        registry="ghcr.io",
+        repository="org/app",
+        reference="docker.io/library/alpine:3",
+    )
+
+    with pytest.raises(ContainerJobBackendError) as excinfo:
+        await backend.acquire_image(request)
+
+    assert (
+        excinfo.value.failure_class
+        == ContainerJobFailureClass.REPOSITORY_SCOPE_MISMATCH
+    )
+    assert daemon.pull_count == 0
+    assert daemon.commands == []
+
+
+@pytest.mark.asyncio
+async def test_lost_pull_acknowledgment_is_bounded(tmp_path: Path) -> None:
+    """A pull that completes but leaves the image absent fails closed."""
+
+    async def lying_runner(args):
+        argv = tuple(args)
+        if argv[:2] == ("image", "inspect"):
+            return 1, b"", b"No such image"
+        if argv[0] == "pull":
+            return 0, b"pull progress", b""
+        return 0, b"", b""
+
+    backend = DockerContainerJobBackend(
+        workspace_root=tmp_path / "workspaces",
+        command_runner=lying_runner,
+        image_lock_root=tmp_path / "locks",
+        pull_lock_poll_seconds=0.01,
+        pull_lock_max_wait_seconds=5.0,
+    )
+
+    with pytest.raises(ImageAcquisitionError) as excinfo:
+        await backend.acquire_image(_public_request(workspace=tmp_path))
+
+    assert excinfo.value.failure_class == ContainerJobFailureClass.IMAGE
+    assert "still absent after a completed pull" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# acc-6: cold acquisition and warm cache qualified separately per consumer.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_public_cold_and_warm_qualified_separately(tmp_path: Path) -> None:
+    daemon = _RecordingDaemon()
+    backend = _backend(daemon, tmp_path)
+
+    cold = await backend.acquire_image(_public_request(workspace=tmp_path))
+    assert daemon.pull_count == 1
+    assert cold.image_observation.cache_present is False
+    assert cold.image_observation.cache_hit is False
+    assert cold.image_observation.provision_action == "pull"
+    assert cold.image_observation.resolved_digest == DIGEST
+    assert cold.resolved_image_ref == DIGEST
+
+    warm = await backend.acquire_image(_public_request(workspace=tmp_path))
+    assert daemon.pull_count == 1
+    assert warm.image_observation.cache_present is True
+    assert warm.image_observation.cache_hit is True
+    assert warm.image_observation.provision_action == "reuse"
+    assert warm.resolved_image_ref == cold.resolved_image_ref
+
+
+@pytest.mark.asyncio
+async def test_private_warm_hit_never_validates_credentials(tmp_path: Path) -> None:
+    """A warm cached image is not authorization evidence: no pull, no resolve."""
+
+    daemon = _RecordingDaemon()
+    daemon.present.add(IMAGE)
+    resolver_calls: list[str] = []
+
+    async def counting_resolver(ref: str) -> RegistryCredential:
+        resolver_calls.append(ref)
+        return RegistryCredential(username=IDENTITY_B_USER, secret=IDENTITY_B_TOKEN)
+
+    backend = _backend(daemon, tmp_path, resolver=counting_resolver)
+    result = await backend.acquire_image(
+        _private_request(
+            workspace=tmp_path, job_suffix="c" * 32, policy="if-missing"
+        )
+    )
+
+    assert result.resolved_image_ref == DIGEST
+    assert daemon.pull_count == 0
+    assert resolver_calls == []
+
+
+@pytest.mark.asyncio
+async def test_private_cold_pull_pins_exact_digest(tmp_path: Path) -> None:
+    daemon = _RecordingDaemon()
+    backend = _backend(daemon, tmp_path)
+    result = await backend.acquire_image(
+        _private_request(workspace=tmp_path, job_suffix="9" * 32, policy="always")
+    )
+
+    assert daemon.pull_count == 1
+    assert result.resolved_image_ref == DIGEST

--- a/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
+++ b/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
@@ -199,13 +199,13 @@ async def test_resolve_ghcr_pull_credentials_requires_complete_env_pair(
     monkeypatch.setenv("GHCR_PULL_USER", "pull-user")
 
     with pytest.raises(ValueError, match="requires both user and token"):
-        await resolve_ghcr_pull_credentials_for_launch({})
+        await resolve_ghcr_pull_credentials_for_launch()
 
     _clear_ghcr_deployment_env(monkeypatch)
     monkeypatch.setenv("GHCR_PULL_TOKEN", "pull-token")
 
     with pytest.raises(ValueError, match="requires both user and token"):
-        await resolve_ghcr_pull_credentials_for_launch({})
+        await resolve_ghcr_pull_credentials_for_launch()
 
 async def test_resolve_ghcr_pull_credentials_uses_complete_env_pair(
     monkeypatch: pytest.MonkeyPatch,
@@ -214,7 +214,7 @@ async def test_resolve_ghcr_pull_credentials_uses_complete_env_pair(
     monkeypatch.setenv("GHCR_PULL_USER", " pull-user ")
     monkeypatch.setenv("GHCR_PULL_TOKEN", " pull-token ")
 
-    assert await resolve_ghcr_pull_credentials_for_launch({}) == (
+    assert await resolve_ghcr_pull_credentials_for_launch() == (
         "pull-user",
         "pull-token",
     )
@@ -229,31 +229,25 @@ async def test_resolve_ghcr_pull_credentials_never_converts_source_pat(
     _forbid_source_token_resolution(monkeypatch)
     monkeypatch.setenv("GITHUB_TOKEN", "github-token")
 
-    assert (
-        await resolve_ghcr_pull_credentials_for_launch(
-            {"GITHUB_TOKEN": "github-token"}
-        )
-        is None
-    )
+    assert await resolve_ghcr_pull_credentials_for_launch() is None
+
 
 async def test_resolve_ghcr_pull_credentials_ignores_launch_environment_plaintext(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Agent-authored launch fields are never registry authentication: a complete
-    # pair smuggled via the launch mapping has no effect.
+    # Agent-authored launch fields are not accepted as registry authentication:
+    # the resolver takes no launch mapping, so smuggled GHCR_PULL_* values
+    # cannot be supplied. Deployment env empty => anonymous None.
+    import inspect
+
     _clear_ghcr_deployment_env(monkeypatch)
     _stub_empty_ghcr_store(monkeypatch)
     _forbid_source_token_resolution(monkeypatch)
 
-    assert (
-        await resolve_ghcr_pull_credentials_for_launch(
-            {
-                "GHCR_PULL_USER": "agent-user",
-                "GHCR_PULL_TOKEN": "agent-token",
-            }
-        )
-        is None
-    )
+    assert list(
+        inspect.signature(resolve_ghcr_pull_credentials_for_launch).parameters
+    ) == []
+    assert await resolve_ghcr_pull_credentials_for_launch() is None
 
 async def test_resolve_ghcr_pull_credentials_requires_complete_pair_without_source_fallback(
     monkeypatch: pytest.MonkeyPatch,
@@ -263,9 +257,7 @@ async def test_resolve_ghcr_pull_credentials_requires_complete_pair_without_sour
     _forbid_source_token_resolution(monkeypatch)
 
     with pytest.raises(ValueError, match="requires both user and token"):
-        await resolve_ghcr_pull_credentials_for_launch(
-            {"GITHUB_TOKEN": "github-token"}
-        )
+        await resolve_ghcr_pull_credentials_for_launch()
 
 async def test_resolve_ghcr_pull_credentials_requires_complete_managed_secret_pair(
     monkeypatch: pytest.MonkeyPatch,
@@ -277,9 +269,7 @@ async def test_resolve_ghcr_pull_credentials_requires_complete_managed_secret_pa
     _forbid_source_token_resolution(monkeypatch)
 
     with pytest.raises(ValueError, match="requires both user and token managed secrets"):
-        await resolve_ghcr_pull_credentials_for_launch(
-            {"GITHUB_TOKEN": "github-token"}
-        )
+        await resolve_ghcr_pull_credentials_for_launch()
 
 async def test_resolve_ghcr_pull_credentials_store_outage_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
@@ -294,7 +284,7 @@ async def test_resolve_ghcr_pull_credentials_store_outage_fails_closed(
     _forbid_source_token_resolution(monkeypatch)
 
     with pytest.raises(ValueError, match="store is unavailable"):
-        await resolve_ghcr_pull_credentials_for_launch({})
+        await resolve_ghcr_pull_credentials_for_launch()
 
 async def test_resolve_ghcr_pull_credentials_uses_secret_ref_pair(
     monkeypatch: pytest.MonkeyPatch,
@@ -305,7 +295,7 @@ async def test_resolve_ghcr_pull_credentials_uses_secret_ref_pair(
     monkeypatch.setenv("MOONMIND_GHCR_PULL_USER_SECRET_REF", "MY_GHCR_PULL_USER")
     monkeypatch.setenv("MOONMIND_GHCR_PULL_TOKEN_SECRET_REF", "MY_GHCR_PULL_TOKEN")
 
-    assert await resolve_ghcr_pull_credentials_for_launch({}) == (
+    assert await resolve_ghcr_pull_credentials_for_launch() == (
         "ref-user",
         "ref-token",
     )
@@ -317,7 +307,7 @@ async def test_resolve_ghcr_pull_credentials_requires_complete_secret_ref_pair(
     monkeypatch.setenv("MOONMIND_GHCR_PULL_USER_SECRET_REF", "MY_GHCR_PULL_USER")
 
     with pytest.raises(ValueError, match="requires both user and token secret refs"):
-        await resolve_ghcr_pull_credentials_for_launch({})
+        await resolve_ghcr_pull_credentials_for_launch()
 
 async def test_resolve_ghcr_pull_credentials_public_anonymous_returns_none(
     monkeypatch: pytest.MonkeyPatch,
@@ -328,8 +318,7 @@ async def test_resolve_ghcr_pull_credentials_public_anonymous_returns_none(
     _stub_empty_ghcr_store(monkeypatch)
     _forbid_source_token_resolution(monkeypatch)
 
-    assert await resolve_ghcr_pull_credentials_for_launch({}) is None
-    assert await resolve_ghcr_pull_credentials_for_launch(None) is None
+    assert await resolve_ghcr_pull_credentials_for_launch() is None
 
 async def test_ghcr_pull_credentials_bound_to_ghcr_registry() -> None:
     from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (

--- a/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
+++ b/tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py
@@ -156,99 +156,187 @@ async def test_resolve_github_token_for_launch_uses_canonical_workflow_env(
 
     assert out == "workflow-token"
 
+def _clear_ghcr_deployment_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "GHCR_PULL_USER",
+        "GHCR_PULL_TOKEN",
+        "MOONMIND_GHCR_PULL_USER_SECRET_REF",
+        "MOONMIND_GHCR_PULL_TOKEN_SECRET_REF",
+        "WORKFLOW_GHCR_PULL_USER_SECRET_REF",
+        "WORKFLOW_GHCR_PULL_TOKEN_SECRET_REF",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _stub_empty_ghcr_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _FakeLookupSession()
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker", _FakeSessionMaker(session)
+    )
+
+
+def _forbid_source_token_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _unexpected_github_token(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("source GitHub token resolution must not run")
+
+    async def _unexpected_managed_token(*_args: object, **_kwargs: object) -> str:
+        raise AssertionError("managed source token lookup must not run")
+
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_github_token_for_launch",
+        _unexpected_github_token,
+    )
+    monkeypatch.setattr(
+        "moonmind.workflows.temporal.runtime.managed_api_key_resolve.resolve_managed_github_token_from_store",
+        _unexpected_managed_token,
+    )
+
+
 async def test_resolve_ghcr_pull_credentials_requires_complete_env_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("GHCR_PULL_USER", raising=False)
-    monkeypatch.delenv("GHCR_PULL_TOKEN", raising=False)
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("GHCR_PULL_USER", "pull-user")
 
     with pytest.raises(ValueError, match="requires both user and token"):
-        await resolve_ghcr_pull_credentials_for_launch(
-            {"GHCR_PULL_USER": "pull-user"}
-        )
+        await resolve_ghcr_pull_credentials_for_launch({})
+
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("GHCR_PULL_TOKEN", "pull-token")
 
     with pytest.raises(ValueError, match="requires both user and token"):
-        await resolve_ghcr_pull_credentials_for_launch(
-            {"GHCR_PULL_TOKEN": "pull-token"}
-        )
+        await resolve_ghcr_pull_credentials_for_launch({})
 
 async def test_resolve_ghcr_pull_credentials_uses_complete_env_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("GHCR_PULL_USER", raising=False)
-    monkeypatch.delenv("GHCR_PULL_TOKEN", raising=False)
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("GHCR_PULL_USER", " pull-user ")
+    monkeypatch.setenv("GHCR_PULL_TOKEN", " pull-token ")
 
-    assert await resolve_ghcr_pull_credentials_for_launch(
-        {
-            "GHCR_PULL_USER": " pull-user ",
-            "GHCR_PULL_TOKEN": " pull-token ",
-        }
-    ) == ("pull-user", "pull-token")
-
-async def test_resolve_ghcr_pull_credentials_uses_github_token_when_pair_absent(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("GHCR_PULL_USER", raising=False)
-    monkeypatch.delenv("GHCR_PULL_TOKEN", raising=False)
-
-    async def _fake_github_login(_token: str) -> str:
-        return "github-user"
-
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.managed_api_key_resolve."
-        "_resolve_github_login_for_token",
-        _fake_github_login,
+    assert await resolve_ghcr_pull_credentials_for_launch({}) == (
+        "pull-user",
+        "pull-token",
     )
 
-    assert await resolve_ghcr_pull_credentials_for_launch(
-        {"GITHUB_TOKEN": "github-token"}
-    ) == ("github-user", "github-token")
-
-async def test_resolve_ghcr_pull_credentials_requires_complete_pair_before_github_fallback(
+async def test_resolve_ghcr_pull_credentials_never_converts_source_pat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("GHCR_PULL_USER", raising=False)
-    monkeypatch.delenv("GHCR_PULL_TOKEN", raising=False)
+    # MoonLadderStudios/MoonMind#4012: a source PAT must never become pull
+    # credentials, with or without an explicit registry identity elsewhere.
+    _clear_ghcr_deployment_env(monkeypatch)
+    _stub_empty_ghcr_store(monkeypatch)
+    _forbid_source_token_resolution(monkeypatch)
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
 
-    async def _unexpected_github_login(_token: str) -> str:
-        raise AssertionError("GitHub fallback should not run")
-
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.managed_api_key_resolve."
-        "_resolve_github_login_for_token",
-        _unexpected_github_login,
+    assert (
+        await resolve_ghcr_pull_credentials_for_launch(
+            {"GITHUB_TOKEN": "github-token"}
+        )
+        is None
     )
+
+async def test_resolve_ghcr_pull_credentials_ignores_launch_environment_plaintext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Agent-authored launch fields are never registry authentication: a complete
+    # pair smuggled via the launch mapping has no effect.
+    _clear_ghcr_deployment_env(monkeypatch)
+    _stub_empty_ghcr_store(monkeypatch)
+    _forbid_source_token_resolution(monkeypatch)
+
+    assert (
+        await resolve_ghcr_pull_credentials_for_launch(
+            {
+                "GHCR_PULL_USER": "agent-user",
+                "GHCR_PULL_TOKEN": "agent-token",
+            }
+        )
+        is None
+    )
+
+async def test_resolve_ghcr_pull_credentials_requires_complete_pair_without_source_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("GHCR_PULL_USER", "pull-user")
+    _forbid_source_token_resolution(monkeypatch)
 
     with pytest.raises(ValueError, match="requires both user and token"):
         await resolve_ghcr_pull_credentials_for_launch(
-            {
-                "GHCR_PULL_USER": "pull-user",
-                "GITHUB_TOKEN": "github-token",
-            }
+            {"GITHUB_TOKEN": "github-token"}
         )
 
 async def test_resolve_ghcr_pull_credentials_requires_complete_managed_secret_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("GHCR_PULL_USER", raising=False)
-    monkeypatch.delenv("GHCR_PULL_TOKEN", raising=False)
+    _clear_ghcr_deployment_env(monkeypatch)
     session = _FakeLookupSession(values={"GHCR_PULL_USER": "pull-user"})
     session_maker = _FakeSessionMaker(session)
     monkeypatch.setattr("api_service.db.base.async_session_maker", session_maker)
-
-    async def _unexpected_github_login(_token: str) -> str:
-        raise AssertionError("GitHub fallback should not run")
-
-    monkeypatch.setattr(
-        "moonmind.workflows.temporal.runtime.managed_api_key_resolve."
-        "_resolve_github_login_for_token",
-        _unexpected_github_login,
-    )
+    _forbid_source_token_resolution(monkeypatch)
 
     with pytest.raises(ValueError, match="requires both user and token managed secrets"):
         await resolve_ghcr_pull_credentials_for_launch(
             {"GITHUB_TOKEN": "github-token"}
         )
+
+async def test_resolve_ghcr_pull_credentials_store_outage_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A managed-store outage is a registry-boundary failure, never an invitation
+    # to try source auth, another identity, or an anonymous downgrade.
+    _clear_ghcr_deployment_env(monkeypatch)
+    session = _FakeLookupSession(errors={"GHCR_PULL_USER": RuntimeError("db down")})
+    monkeypatch.setattr(
+        "api_service.db.base.async_session_maker", _FakeSessionMaker(session)
+    )
+    _forbid_source_token_resolution(monkeypatch)
+
+    with pytest.raises(ValueError, match="store is unavailable"):
+        await resolve_ghcr_pull_credentials_for_launch({})
+
+async def test_resolve_ghcr_pull_credentials_uses_secret_ref_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("MY_GHCR_PULL_USER", " ref-user ")
+    monkeypatch.setenv("MY_GHCR_PULL_TOKEN", " ref-token ")
+    monkeypatch.setenv("MOONMIND_GHCR_PULL_USER_SECRET_REF", "MY_GHCR_PULL_USER")
+    monkeypatch.setenv("MOONMIND_GHCR_PULL_TOKEN_SECRET_REF", "MY_GHCR_PULL_TOKEN")
+
+    assert await resolve_ghcr_pull_credentials_for_launch({}) == (
+        "ref-user",
+        "ref-token",
+    )
+
+async def test_resolve_ghcr_pull_credentials_requires_complete_secret_ref_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_ghcr_deployment_env(monkeypatch)
+    monkeypatch.setenv("MOONMIND_GHCR_PULL_USER_SECRET_REF", "MY_GHCR_PULL_USER")
+
+    with pytest.raises(ValueError, match="requires both user and token secret refs"):
+        await resolve_ghcr_pull_credentials_for_launch({})
+
+async def test_resolve_ghcr_pull_credentials_public_anonymous_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Omitted configuration is the public-anonymous path: no credentials, no
+    # source lookup, no username probing.
+    _clear_ghcr_deployment_env(monkeypatch)
+    _stub_empty_ghcr_store(monkeypatch)
+    _forbid_source_token_resolution(monkeypatch)
+
+    assert await resolve_ghcr_pull_credentials_for_launch({}) is None
+    assert await resolve_ghcr_pull_credentials_for_launch(None) is None
+
+async def test_ghcr_pull_credentials_bound_to_ghcr_registry() -> None:
+    from moonmind.workflows.temporal.runtime.managed_api_key_resolve import (
+        GHCR_REGISTRY,
+    )
+
+    assert GHCR_REGISTRY == "ghcr.io"
 
 async def test_shape_launch_github_auth_environment_uses_ambient_token_before_store(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
Decouples runtime image acquisition from source credentials per MoonLadderStudios/MoonMind#4012 (CONTRACT-001, CONTRACT-010, INV-001, INV-004, QUALITY-008, TEST-004).

- Removes source-PAT conversion and GitHub username probing from `resolve_ghcr_pull_credentials_for_launch`; GHCR resolution now compiles only trusted deployment configuration (SecretRef pair, deployment env pair, coherent managed-slug pair with double-read rotation detection).
- Fails closed on partial pairs, store outage, rotation between paired reads, and denied/revoked credentials with no fallback to source auth, ambient login, or anonymous downgrade; ignores agent-authored launch fields; omitted config returns None for the public-anonymous path.
- Inventory-backed production pull composition drives the real container-job backend and Omnigent pull transport; per-job ephemeral registry config with post-pull cleanup; cache reuse preserved without treating warm hits as auth evidence; endpoint pinned to ghcr.io with digest/architecture handling and secret-safe redaction.
- Docs updated in docs/ManagedAgents/DockerBackendService.md (public defaults, explicit private-registry setup, obsolete implicit config, safe recovery).

## Verification outcome
Controlling post-remediation moonspec-verify verdict: **FULLY_IMPLEMENTED** (HIGH confidence) at HEAD 7632b1de2f668ea356f28ed7743f5e0a47996678.
All 15 requirements VERIFIED (impl-1..impl-8, acc-1..acc-7); remainingWork empty; recommendedNextAction advance. Initial assessment was NOT_IMPLEMENTED, so this implementation is published even though the work branch was already pushed.

## Tests run
- `moonmind container python-tests tests/unit/workflows/temporal/runtime/test_ghcr_pull_decoupling_4012.py` — 25 passed (production private/public pulls with source PAT A present, Omnigent bare pull, rotation coherence, denial fail-closed, concurrent isolation, cancellation cleanup, 12-case transport classification, wrong-endpoint rejection, lost-ack bound, cold/warm consumer qualification, digest pinning).
- `moonmind container python-tests tests/unit/workflows/temporal/runtime/test_managed_api_key_resolve.py` — 29 passed (never-converts-source-PAT, ignores-launch-env-plaintext, complete/incomplete pairs, store-outage-fails-closed, rotation/disable check, public-anonymous None, registry binding).
- Integration (integration_ci): NOT RUN — change is unit-covered at the production composition boundary via hermetic backend/transport tests; no compose/service-topology boundary change identified.

## Remaining risks
- Live public-image reachability is an advisory deployment handoff to #3938 and is not claimed from helper tests; deployment qualification still owns real-registry availability proof.
- Covers ghcr.io pull composition paths inventoried (managed sessions, Omnigent, container jobs, Compose/bootstrap, worker); future new pull transports must reuse the same trusted-config boundary or re-verify.

Closes MoonLadderStudios/MoonMind#4012