### PR TITLE
[GitHub issue lifecycle] Resilient assessment-verdict normalization with intelligence fallback (MoonLadderStudios/MoonMind#4175)

### DIFF
--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8813,9 +8813,6 @@ class TemporalAgentRuntimeActivities:
                     "with keys issue_provider, issue_ref, issue_url, verdict, branch, "
                     "base_ref, mode, summary, and requirements."
                 )
-            verdict_value = ""
-            verdict_provenance = "declared"
-            verdict_evidence = "payload.verdict"
             normalized_payload = dict(payload)
             try:
                 from moonmind.workflows.temporal.assessment_verdict import (
@@ -8881,8 +8878,9 @@ class TemporalAgentRuntimeActivities:
                     f"verdict: {assessment_path}. The assessment step must write "
                     "verdict as exactly one of FULLY_IMPLEMENTED, "
                     "PARTIALLY_IMPLEMENTED, NOT_IMPLEMENTED, or BLOCKED, or "
-                    "provide unanimous requirements / assistant verdict text so "
-                    "the normalizer can recover it."
+                    "provide an explicit verdict statement (for example "
+                    "'## Verdict: FULLY_IMPLEMENTED') so the normalizer can "
+                    "recover it. Requirement statuses alone never imply completion."
                 )
             verdict_ref = await _write_json_artifact(
                 self._artifact_service,

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -8777,22 +8777,117 @@ class TemporalAgentRuntimeActivities:
             try:
                 payload = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, json.JSONDecodeError):
-                logger.warning(
-                    "Assessment verdict artifact could not be read as JSON: %s",
-                    assessment_path,
-                    exc_info=True,
+                failure_class = str(
+                    result_dict.get("failureClass")
+                    or result_dict.get("failure_class")
+                    or ""
+                ).strip()
+                if failure_class:
+                    logger.warning(
+                        "Assessment verdict artifact could not be read as JSON: %s",
+                        assessment_path,
+                        exc_info=True,
+                    )
+                    return {}
+                raise TemporalActivityRuntimeError(
+                    "Declared assessment verdict artifact could not be read as JSON: "
+                    f"{assessment_path}. The assessment step must write a JSON object "
+                    "with keys issue_provider, issue_ref, issue_url, verdict, branch, "
+                    "base_ref, mode, summary, and requirements."
                 )
-                return {}
             if not isinstance(payload, Mapping):
-                logger.warning(
-                    "Assessment verdict artifact payload must be a JSON object: %s",
-                    assessment_path,
+                failure_class = str(
+                    result_dict.get("failureClass")
+                    or result_dict.get("failure_class")
+                    or ""
+                ).strip()
+                if failure_class:
+                    logger.warning(
+                        "Assessment verdict artifact payload must be a JSON object: %s",
+                        assessment_path,
+                    )
+                    return {}
+                raise TemporalActivityRuntimeError(
+                    "Assessment verdict artifact payload must be a JSON object: "
+                    f"{assessment_path}. The assessment step must write a JSON object "
+                    "with keys issue_provider, issue_ref, issue_url, verdict, branch, "
+                    "base_ref, mode, summary, and requirements."
                 )
-                return {}
+            verdict_value = ""
+            verdict_provenance = "declared"
+            verdict_evidence = "payload.verdict"
+            normalized_payload = dict(payload)
+            try:
+                from moonmind.workflows.temporal.assessment_verdict import (
+                    normalize_assessment_payload,
+                )
+            except Exception:  # pragma: no cover - import guard
+                normalize_assessment_payload = None  # type: ignore[assignment]
+            if normalize_assessment_payload is not None:
+                assistant_hint = ""
+                if isinstance(metadata, Mapping):
+                    for _key in (
+                        "assistantText",
+                        "lastAssistantText",
+                        "assistant_text",
+                    ):
+                        _val = metadata.get(_key)
+                        if isinstance(_val, str) and _val.strip():
+                            assistant_hint = _val
+                            break
+                verdict_value, verdict_provenance, verdict_evidence = (
+                    normalize_assessment_payload(
+                        payload,
+                        assistant_text=assistant_hint,
+                    )
+                )
+                if verdict_value and verdict_provenance != "declared":
+                    normalized_payload = dict(payload)
+                    normalized_payload["verdict"] = verdict_value
+                    normalized_payload["verdictProvenance"] = verdict_provenance
+                    normalized_payload["verdictEvidence"] = verdict_evidence
+                    logger.warning(
+                        "Assessment verdict artifact %s missing declared verdict; "
+                        "normalized via %s (%s)",
+                        assessment_path,
+                        verdict_provenance,
+                        verdict_evidence,
+                    )
+            else:
+                verdict_value = str(payload.get("verdict") or "").strip().upper()
+                if verdict_value not in {
+                    "FULLY_IMPLEMENTED",
+                    "PARTIALLY_IMPLEMENTED",
+                    "NOT_IMPLEMENTED",
+                    "BLOCKED",
+                }:
+                    verdict_value = ""
+            if not verdict_value:
+                failure_class = str(
+                    result_dict.get("failureClass")
+                    or result_dict.get("failure_class")
+                    or ""
+                ).strip()
+                if failure_class:
+                    logger.warning(
+                        "Assessment verdict artifact has no recoverable verdict %s; "
+                        "preserving original agent failure (%s)",
+                        assessment_path,
+                        failure_class,
+                    )
+                    return {}
+                raise TemporalActivityRuntimeError(
+                    "Declared assessment verdict artifact has no recoverable "
+                    f"verdict: {assessment_path}. The assessment step must write "
+                    "verdict as exactly one of FULLY_IMPLEMENTED, "
+                    "PARTIALLY_IMPLEMENTED, NOT_IMPLEMENTED, or BLOCKED, or "
+                    "provide unanimous requirements / assistant verdict text so "
+                    "the normalizer can recover it."
+                )
             verdict_ref = await _write_json_artifact(
                 self._artifact_service,
                 principal="system:agent_runtime",
-                payload=dict(payload),
+                payload=dict(normalized_payload),
                 execution_ref=_execution_ref("output.assessment_verdict"),
                 metadata_json={
                     "name": "assessment-verdict.json",
@@ -8826,14 +8921,8 @@ class TemporalAgentRuntimeActivities:
             }
             # Compact structured verdict rides previousOutputs as a fast path for
             # adjacent steps; the ref is the durable, bridge-compatible channel.
-            verdict = str(payload.get("verdict") or "").strip().upper()
-            if verdict in {
-                "FULLY_IMPLEMENTED",
-                "PARTIALLY_IMPLEMENTED",
-                "NOT_IMPLEMENTED",
-                "BLOCKED",
-            }:
-                published["assessmentVerdict"] = verdict
+            # verdict_value was validated above, so it is always present here.
+            published["assessmentVerdict"] = verdict_value
             return published
 
         async def _publish_issue_brief_artifact() -> dict[str, Any]:

--- a/moonmind/workflows/temporal/assessment_verdict.py
+++ b/moonmind/workflows/temporal/assessment_verdict.py
@@ -1,0 +1,252 @@
+"""Canonical assessment-verdict normalization.
+
+One capability-derived recovery policy for issue-implement assessments.
+
+Deterministic workflows and activities share this module so GitHub and Jira
+stay on one verdict path. It trusts the assessment agent's semantic intent over
+strict syntactic field presence:
+
+- ``declared``: explicit ``verdict`` field valid.
+- ``text_recovered``: verdict found in free text (assistant ``## Verdict: X``,
+  ``verdict: X``, ``assessment complete ... X``).
+- ``requirements_inferred``: no explicit verdict anywhere, but the agent's own
+  requirements list is unanimous. All ``met`` implies the agent believed the
+  work complete; mixed implies partial work remains.
+
+Only truly ambiguous payloads (no verdict, no text, empty/mixed-unknown
+requirements) return ``unavailable``. Callers preserve the original artifact
+and record ``verdictProvenance`` so inference is observable, never silent.
+
+Safe bias: never infer ``BLOCKED`` from requirements alone (BLOCKED needs
+explicit missing evidence). Mixed ``partially_met``/``not_met`` infers
+``PARTIALLY_IMPLEMENTED`` (do bounded work) rather than skipping work.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+
+ASSESSMENT_VERDICTS = frozenset(
+    {"FULLY_IMPLEMENTED", "PARTIALLY_IMPLEMENTED", "NOT_IMPLEMENTED", "BLOCKED"}
+)
+
+_MAPPING_VERDICT_KEYS = (
+    "assessmentVerdict",
+    "assessment_verdict",
+    "jiraAssessmentVerdict",
+    "jira_assessment_verdict",
+    "initialAssessmentVerdict",
+    "initial_assessment_verdict",
+    "verdict",
+)
+
+_MAPPING_NESTED_KEYS = (
+    "assessment",
+    "jiraAssessment",
+    "jira_assessment",
+    "jiraImplementAssessment",
+    "jira_implement_assessment",
+)
+
+_TEXT_KEYS = ("lastAssistantText", "assistantText", "summary", "operator_summary")
+
+_VERDICT_PATTERN = r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)"
+_VERDICT_PREFIX = r"[\s:`*_\"']*"
+_VERDICT_SUFFIX = r"(?:_+(?!\w)|(?![-\w]))"
+_ASSESSMENT_SEP = r"[\s:.,;!?\-\u2010-\u2015`*_\"'\[\]\(\)]*"
+_ISSUE_REF_PATTERN = r"`?[A-Z][A-Z0-9]+-\d+`?"
+
+_TEXT_PATTERNS = (
+    r"(?im)^\s*#{1,6}\s*verdict\s*[:\-]\s*"
+    rf"{_VERDICT_PREFIX}{_VERDICT_PATTERN}{_VERDICT_SUFFIX}",
+    r"(?im)^\s*verdict\s*[:\-]\s*"
+    rf"{_VERDICT_PREFIX}{_VERDICT_PATTERN}{_VERDICT_SUFFIX}",
+    r"(?is)\bassessment\s+complete\b"
+    rf"{_ASSESSMENT_SEP}"
+    rf"(?:(?:for|on)\b{_ASSESSMENT_SEP}"
+    rf"{_ISSUE_REF_PATTERN}{_ASSESSMENT_SEP})?"
+    rf"(?:{_ISSUE_REF_PATTERN}{_ASSESSMENT_SEP})?"
+    rf"(?:(?:is|was|has|verdict|status)\b{_ASSESSMENT_SEP})?"
+    rf"{_VERDICT_PATTERN}{_VERDICT_SUFFIX}",
+    r"(?is)\brecorded\s+verdict\b[^.\n:]*[:\s`]+"
+    rf"{_VERDICT_PREFIX}{_VERDICT_PATTERN}{_VERDICT_SUFFIX}",
+    r"(?is)['\"]verdict['\"]\s*:\s*['\"]"
+    rf"{_VERDICT_PATTERN}['\"]",
+)
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def normalize_verdict(value: Any) -> str:
+    """Return canonical verdict or empty when invalid."""
+    verdict = _string(value).strip().upper()
+    return verdict if verdict in ASSESSMENT_VERDICTS else ""
+
+
+def verdict_from_text(value: Any) -> str:
+    """Extract verdict from free text using bounded patterns."""
+    text = _string(value)
+    if not text:
+        return ""
+    for pattern in _TEXT_PATTERNS:
+        try:
+            match = re.search(pattern, text)
+        except re.error:
+            continue
+        if match:
+            return normalize_verdict(match.group(1))
+    return ""
+
+
+def verdict_from_mapping(payload: Mapping[str, Any]) -> str:
+    """Extract verdict from compact mapping keys (including nested)."""
+    for key in _MAPPING_VERDICT_KEYS:
+        verdict = normalize_verdict(payload.get(key))
+        if verdict:
+            return verdict
+    for key in _MAPPING_NESTED_KEYS:
+        nested = _mapping(payload.get(key))
+        if nested:
+            verdict = verdict_from_mapping(nested)
+            if verdict:
+                return verdict
+    return ""
+
+
+def _requirement_status(value: Any) -> str:
+    status = _string(value).strip().lower().replace("-", "_").replace(" ", "_")
+    # Normalize common agent variants to canonical preset vocabulary.
+    aliases = {
+        "fully_met": "met",
+        "fully_implemented": "met",
+        "satisfied": "met",
+        "passed": "met",
+        "done": "met",
+        "partial": "partially_met",
+        "partial_met": "partially_met",
+        "incomplete": "partially_met",
+        "unmet": "not_met",
+        "missing": "not_met",
+        "failed": "not_met",
+        "todo": "not_met",
+    }
+    return aliases.get(status, status)
+
+
+def infer_verdict_from_requirements(
+    requirements: Any,
+    *,
+    summary: Any = "",
+    assistant_text: Any = "",
+) -> tuple[str, str]:
+    """Infer verdict from the agent's own requirements list.
+
+    Returns ``(verdict, evidence)``. Empty verdict means cannot safely infer.
+
+    Rules (safe bias, no BLOCKED inference):
+    - empty/non-list requirements -> unavailable.
+    - all ``met`` -> FULLY_IMPLEMENTED (agent believed all done).
+    - all ``not_met`` -> NOT_IMPLEMENTED.
+    - any ``partially_met``/``not_met`` mixed with ``met`` -> PARTIALLY_IMPLEMENTED.
+    - any ``unverifiable`` with rest ``met`` -> PARTIALLY_IMPLEMENTED (preserve
+      prerequisites, do bounded work, don't skip).
+    - unknown statuses only -> unavailable.
+    """
+    if not isinstance(requirements, (list, tuple)) or not requirements:
+        return "", ""
+    statuses: list[str] = []
+    for item in requirements:
+        if isinstance(item, Mapping):
+            raw = (
+                item.get("status")
+                or item.get("state")
+                or item.get("verdict")
+                or item.get("result")
+            )
+            statuses.append(_requirement_status(raw))
+        elif isinstance(item, str):
+            statuses.append(_requirement_status(item))
+        else:
+            statuses.append("")
+    known = [s for s in statuses if s]
+    if not known:
+        return "", ""
+    # If any status is outside known vocabulary, don't infer.
+    allowed = {"met", "partially_met", "not_met", "unverifiable"}
+    if any(s not in allowed for s in known):
+        # Still allow inference if the unknown looks like a met-variant already
+        # normalized above; otherwise treat as ambiguous.
+        return "", ""
+    if all(s == "met" for s in known):
+        evidence = f"{len(known)} requirements all met"
+        summary_text = _string(summary)
+        if summary_text:
+            evidence += f"; summary: {summary_text[:160]}"
+        assistant = _string(assistant_text)
+        if assistant:
+            # Corroborating text verdict strengthens evidence but mapping/text
+            # recovery is handled by callers; here we just note it.
+            text_verdict = verdict_from_text(assistant)
+            if text_verdict:
+                evidence += f"; assistant text verdict {text_verdict}"
+        return "FULLY_IMPLEMENTED", evidence
+    if all(s == "not_met" for s in known):
+        return "NOT_IMPLEMENTED", f"{len(known)} requirements all not_met"
+    if any(s in {"partially_met", "not_met", "unverifiable"} for s in known):
+        return (
+            "PARTIALLY_IMPLEMENTED",
+            f"{len(known)} requirements mixed: {sorted(set(known))}",
+        )
+    return "", ""
+
+
+def normalize_assessment_payload(
+    payload: Mapping[str, Any],
+    *,
+    assistant_text: Any = "",
+) -> tuple[str, str, str]:
+    """Normalize one assessment artifact payload.
+
+    Returns ``(verdict, provenance, evidence)`` where provenance is one of
+    ``declared``, ``mapping``, ``text_recovered``, ``requirements_inferred``,
+    or ``unavailable``.
+
+    Order preserves authority: explicit field first, then compact mapping
+    variants, then free text, then unanimous requirements. Requirements
+    inference is last because it is the weakest signal, but it rescues the
+    common minor-difference case (verdict key omitted while every requirement
+    is marked met and summary/text agree).
+    """
+    if not isinstance(payload, Mapping):
+        return "", "unavailable", "payload is not a JSON object"
+    verdict = normalize_verdict(payload.get("verdict"))
+    if verdict:
+        return verdict, "declared", "payload.verdict"
+    verdict = verdict_from_mapping(payload)
+    if verdict:
+        return verdict, "mapping", "compact mapping key"
+    for key in _TEXT_KEYS:
+        verdict = verdict_from_text(payload.get(key))
+        if verdict:
+            return verdict, "text_recovered", f"payload.{key}"
+    verdict = verdict_from_text(assistant_text)
+    if verdict:
+        return verdict, "text_recovered", "assistant text"
+    requirements = payload.get("requirements")
+    summary = payload.get("summary", "")
+    verdict, evidence = infer_verdict_from_requirements(
+        requirements,
+        summary=summary,
+        assistant_text=assistant_text,
+    )
+    if verdict:
+        return verdict, "requirements_inferred", evidence
+    return "", "unavailable", "no usable verdict signal"

--- a/moonmind/workflows/temporal/assessment_verdict.py
+++ b/moonmind/workflows/temporal/assessment_verdict.py
@@ -1,25 +1,22 @@
 """Canonical assessment-verdict normalization.
 
-One capability-derived recovery policy for issue-implement assessments.
+Syntactic normalization only. Completion decisions stay in the assessment Skill.
 
 Deterministic workflows and activities share this module so GitHub and Jira
-stay on one verdict path. It trusts the assessment agent's semantic intent over
-strict syntactic field presence:
+stay on one verdict path. It recovers explicit verdict statements when the
+``verdict`` key is omitted, but it never manufactures completion decisions
+from requirement statuses:
 
 - ``declared``: explicit ``verdict`` field valid.
-- ``text_recovered``: verdict found in free text (assistant ``## Verdict: X``,
-  ``verdict: X``, ``assessment complete ... X``).
-- ``requirements_inferred``: no explicit verdict anywhere, but the agent's own
-  requirements list is unanimous. All ``met`` implies the agent believed the
-  work complete; mixed implies partial work remains.
+- ``mapping``: compact alias (``assessmentVerdict`` etc., including nested).
+- ``text_recovered``: explicit verdict in free text (assistant
+  ``## Verdict: X``, ``verdict: X``, ``assessment complete ... X``).
 
-Only truly ambiguous payloads (no verdict, no text, empty/mixed-unknown
-requirements) return ``unavailable``. Callers preserve the original artifact
-and record ``verdictProvenance`` so inference is observable, never silent.
-
-Safe bias: never infer ``BLOCKED`` from requirements alone (BLOCKED needs
-explicit missing evidence). Mixed ``partially_met``/``not_met`` infers
-``PARTIALLY_IMPLEMENTED`` (do bounded work) rather than skipping work.
+Requirement lists (all ``met`` etc.) do NOT imply a verdict here. Inferring
+``FULLY_IMPLEMENTED`` from unanimous requirements is a completion decision
+owned by the portable assessment Skill, not the native boundary. When no
+explicit verdict exists, callers must reject with repair guidance or execute
+the portable Skill entrypoint — never synthesize completion natively.
 """
 
 from __future__ import annotations
@@ -56,7 +53,9 @@ _VERDICT_PATTERN = r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BL
 _VERDICT_PREFIX = r"[\s:`*_\"']*"
 _VERDICT_SUFFIX = r"(?:_+(?!\w)|(?![-\w]))"
 _ASSESSMENT_SEP = r"[\s:.,;!?\-\u2010-\u2015`*_\"'\[\]\(\)]*"
-_ISSUE_REF_PATTERN = r"`?[A-Z][A-Z0-9]+-\d+`?"
+# Issue refs for text recovery: Jira (MM-123), GitHub qualified
+# (Owner/Repo#123), and short (#123). Backticks optional.
+_ISSUE_REF_PATTERN = r"(?:`?[A-Z][A-Z0-9]+-\d+`?|`?[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+`?|`?#\d+`?)"
 
 _TEXT_PATTERNS = (
     r"(?im)^\s*#{1,6}\s*verdict\s*[:\-]\s*"
@@ -121,109 +120,20 @@ def verdict_from_mapping(payload: Mapping[str, Any]) -> str:
     return ""
 
 
-def _requirement_status(value: Any) -> str:
-    status = _string(value).strip().lower().replace("-", "_").replace(" ", "_")
-    # Normalize common agent variants to canonical preset vocabulary.
-    aliases = {
-        "fully_met": "met",
-        "fully_implemented": "met",
-        "satisfied": "met",
-        "passed": "met",
-        "done": "met",
-        "partial": "partially_met",
-        "partial_met": "partially_met",
-        "incomplete": "partially_met",
-        "unmet": "not_met",
-        "missing": "not_met",
-        "failed": "not_met",
-        "todo": "not_met",
-    }
-    return aliases.get(status, status)
-
-
-def infer_verdict_from_requirements(
-    requirements: Any,
-    *,
-    summary: Any = "",
-    assistant_text: Any = "",
-) -> tuple[str, str]:
-    """Infer verdict from the agent's own requirements list.
-
-    Returns ``(verdict, evidence)``. Empty verdict means cannot safely infer.
-
-    Rules (safe bias, no BLOCKED inference):
-    - empty/non-list requirements -> unavailable.
-    - all ``met`` -> FULLY_IMPLEMENTED (agent believed all done).
-    - all ``not_met`` -> NOT_IMPLEMENTED.
-    - any ``partially_met``/``not_met`` mixed with ``met`` -> PARTIALLY_IMPLEMENTED.
-    - any ``unverifiable`` with rest ``met`` -> PARTIALLY_IMPLEMENTED (preserve
-      prerequisites, do bounded work, don't skip).
-    - unknown statuses only -> unavailable.
-    """
-    if not isinstance(requirements, (list, tuple)) or not requirements:
-        return "", ""
-    statuses: list[str] = []
-    for item in requirements:
-        if isinstance(item, Mapping):
-            raw = (
-                item.get("status")
-                or item.get("state")
-                or item.get("verdict")
-                or item.get("result")
-            )
-            statuses.append(_requirement_status(raw))
-        elif isinstance(item, str):
-            statuses.append(_requirement_status(item))
-        else:
-            statuses.append("")
-    known = [s for s in statuses if s]
-    if not known:
-        return "", ""
-    # If any status is outside known vocabulary, don't infer.
-    allowed = {"met", "partially_met", "not_met", "unverifiable"}
-    if any(s not in allowed for s in known):
-        # Still allow inference if the unknown looks like a met-variant already
-        # normalized above; otherwise treat as ambiguous.
-        return "", ""
-    if all(s == "met" for s in known):
-        evidence = f"{len(known)} requirements all met"
-        summary_text = _string(summary)
-        if summary_text:
-            evidence += f"; summary: {summary_text[:160]}"
-        assistant = _string(assistant_text)
-        if assistant:
-            # Corroborating text verdict strengthens evidence but mapping/text
-            # recovery is handled by callers; here we just note it.
-            text_verdict = verdict_from_text(assistant)
-            if text_verdict:
-                evidence += f"; assistant text verdict {text_verdict}"
-        return "FULLY_IMPLEMENTED", evidence
-    if all(s == "not_met" for s in known):
-        return "NOT_IMPLEMENTED", f"{len(known)} requirements all not_met"
-    if any(s in {"partially_met", "not_met", "unverifiable"} for s in known):
-        return (
-            "PARTIALLY_IMPLEMENTED",
-            f"{len(known)} requirements mixed: {sorted(set(known))}",
-        )
-    return "", ""
-
-
 def normalize_assessment_payload(
     payload: Mapping[str, Any],
     *,
     assistant_text: Any = "",
 ) -> tuple[str, str, str]:
-    """Normalize one assessment artifact payload.
+    """Normalize one assessment artifact payload (syntactic only).
 
     Returns ``(verdict, provenance, evidence)`` where provenance is one of
-    ``declared``, ``mapping``, ``text_recovered``, ``requirements_inferred``,
-    or ``unavailable``.
+    ``declared``, ``mapping``, ``text_recovered``, or ``unavailable``.
 
     Order preserves authority: explicit field first, then compact mapping
-    variants, then free text, then unanimous requirements. Requirements
-    inference is last because it is the weakest signal, but it rescues the
-    common minor-difference case (verdict key omitted while every requirement
-    is marked met and summary/text agree).
+    variants, then explicit free-text verdict statements. Requirement statuses
+    are never mapped to verdicts here; that completion decision belongs to the
+    portable assessment Skill.
     """
     if not isinstance(payload, Mapping):
         return "", "unavailable", "payload is not a JSON object"
@@ -240,13 +150,4 @@ def normalize_assessment_payload(
     verdict = verdict_from_text(assistant_text)
     if verdict:
         return verdict, "text_recovered", "assistant text"
-    requirements = payload.get("requirements")
-    summary = payload.get("summary", "")
-    verdict, evidence = infer_verdict_from_requirements(
-        requirements,
-        summary=summary,
-        assistant_text=assistant_text,
-    )
-    if verdict:
-        return verdict, "requirements_inferred", evidence
-    return "", "unavailable", "no usable verdict signal"
+    return "", "unavailable", "no explicit verdict signal"

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -4960,9 +4960,10 @@ async def check_github_issue_blockers(
     issue_ref = f"{repository}#{issue_number}"
     # Carry the assessment verdict + durable ref forward so the In Progress step
     # (which sits after this blocker step) can resolve the verdict by ref without
-    # sharing the assessment agent's filesystem.
-    assessment_verdict, _ = await _augment_assessment_verdict_with_ref(
-        _assessment_verdict_from_artifact(inputs, _context),
+    # sharing the assessment agent's filesystem. Use the shared assessment
+    # resolver (compact previousOutputs, local handoff file, free text, then
+    # durable ref) so GitHub and Jira stay on one canonical verdict path.
+    assessment_verdict, _ = await _resolve_jira_assessment_verdict(
         inputs,
         _context,
     )
@@ -5493,6 +5494,11 @@ async def _augment_assessment_verdict_with_ref(
     identical for in-flight runs that carry no ref. This is the bridge-compatible
     channel: it resolves via the artifact store, so it works even when the
     assessment ran on an Omnigent host whose workspace the tool cannot mount.
+
+    Resilience: when the ref payload omits the declared ``verdict`` key but
+    carries the agent's unanimous requirements / assistant text, normalize via
+    the shared assessment-verdict module instead of returning unavailable for a
+    minor schema difference.
     """
 
     verdict, available = base
@@ -5507,6 +5513,42 @@ async def _augment_assessment_verdict_with_ref(
             ref_verdict = _normalize_assessment_verdict(payload.get("verdict"))
             if ref_verdict:
                 return ref_verdict, True
+            try:
+                from moonmind.workflows.temporal.assessment_verdict import (
+                    normalize_assessment_payload,
+                )
+            except Exception:  # pragma: no cover - import guard
+                normalize_assessment_payload = None  # type: ignore[assignment]
+            if normalize_assessment_payload is not None:
+                # Collect assistant text hints from compact previousOutputs so
+                # text-recovered verdicts work without mounting the producer FS.
+                assistant_hint = ""
+                for source in (
+                    _mapping(inputs.get("previousOutputs")),
+                    _mapping(inputs.get("previous_outputs")),
+                    _mapping((context or {}).get("previousOutputs")),
+                    _mapping((context or {}).get("previous_outputs")),
+                    inputs,
+                    (context or {}),
+                ):
+                    for _k in (
+                        "lastAssistantText",
+                        "assistantText",
+                        "summary",
+                        "operator_summary",
+                    ):
+                        _v = source.get(_k)
+                        if isinstance(_v, str) and _v.strip():
+                            assistant_hint = _v
+                            break
+                    if assistant_hint:
+                        break
+                norm_verdict, _prov, _ev = normalize_assessment_payload(
+                    payload,
+                    assistant_text=assistant_hint,
+                )
+                if norm_verdict:
+                    return norm_verdict, True
     return verdict, available
 
 
@@ -5514,11 +5556,12 @@ async def _resolve_jira_assessment_verdict(
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
 ) -> tuple[str, bool]:
-    """Resolve the Jira assessment verdict, preferring durable in-payload sources.
+    """Resolve the issue-implement assessment verdict, preferring durable sources.
 
-    Tries the synchronous sources first (compact ``assessmentVerdict`` in
-    ``previousOutputs``, a locally resolvable handoff file, then free text), then
-    the published artifact ref.
+    Shared by Jira and GitHub flows: tries the synchronous sources first
+    (compact ``assessmentVerdict`` in ``previousOutputs``, a locally resolvable
+    handoff file, then free text), then the published artifact ref. The ref is
+    the bridge-compatible channel when the assessment ran on an Omnigent host.
     """
 
     return await _augment_assessment_verdict_with_ref(
@@ -7027,12 +7070,14 @@ async def update_github_issue_status(
     mode = _github_status_mode(inputs)
     requested_mode = mode
     was_finalize_after_pr = requested_mode == "finalize_after_pr_or_done"
-    assessment_verdict, assessment_available = (
-        await _augment_assessment_verdict_with_ref(
-            _assessment_verdict_from_artifact(inputs, _context),
-            inputs,
-            _context,
-        )
+    # Use the shared assessment resolver (compact previousOutputs, local handoff
+    # file, free text, then durable ref) so GitHub start/in-progress gating stays
+    # on one canonical verdict path with the Jira assessment flow. The ref is the
+    # bridge-compatible channel when the assessment ran on an Omnigent host whose
+    # workspace this tool cannot mount.
+    assessment_verdict, assessment_available = await _resolve_jira_assessment_verdict(
+        inputs,
+        _context,
     )
     issue_ref = f"{repository}#{issue_number}"
     require_verification = _github_status_requires_verification(inputs)
@@ -7041,12 +7086,28 @@ async def update_github_issue_status(
         or _assessment_artifact_ref(inputs, _context)
     ):
         if not assessment_available:
+            assessment_ref = _assessment_artifact_ref(inputs, _context)
+            assessment_path = _string(
+                inputs.get("assessmentArtifactPath")
+                or inputs.get("assessment_artifact_path")
+            )
+            detail = (
+                f" assessment ref {assessment_ref}" if assessment_ref else ""
+            )
+            if assessment_path:
+                detail += f" (path {assessment_path})"
             return ToolResult(
                 status="FAILED",
                 outputs={
                     "issueRef": issue_ref,
                     "decision": "blocked",
-                    "summary": "GitHub issue status update requires an assessment artifact, but it was unavailable.",
+                    "summary": (
+                        "GitHub issue status update requires an assessment artifact, "
+                        f"but it was unavailable{detail}. Re-run the assessment step "
+                        "so it writes a JSON object with verdict as exactly one of "
+                        "FULLY_IMPLEMENTED, PARTIALLY_IMPLEMENTED, NOT_IMPLEMENTED, "
+                        "or BLOCKED."
+                    ),
                 },
             )
         if assessment_verdict == "FULLY_IMPLEMENTED":

--- a/moonmind/workflows/temporal/story_output_tools.py
+++ b/moonmind/workflows/temporal/story_output_tools.py
@@ -5305,70 +5305,29 @@ _ASSESSMENT_VERDICTS = frozenset(
 
 
 def _normalize_assessment_verdict(value: Any) -> str:
-    verdict = _string(value).upper()
-    return verdict if verdict in _ASSESSMENT_VERDICTS else ""
+    # Canonical implementation lives in assessment_verdict.py; this wrapper
+    # keeps one verdict path for GitHub/Jira callers in this module.
+    from moonmind.workflows.temporal.assessment_verdict import (
+        normalize_verdict as _canonical_normalize,
+    )
+
+    return _canonical_normalize(value)
 
 
 def _assessment_verdict_from_mapping(payload: Mapping[str, Any]) -> str:
-    for key in (
-        "assessmentVerdict",
-        "assessment_verdict",
-        "jiraAssessmentVerdict",
-        "jira_assessment_verdict",
-        "initialAssessmentVerdict",
-        "initial_assessment_verdict",
-        "verdict",
-    ):
-        verdict = _normalize_assessment_verdict(payload.get(key))
-        if verdict:
-            return verdict
-    for key in (
-        "assessment",
-        "jiraAssessment",
-        "jira_assessment",
-        "jiraImplementAssessment",
-        "jira_implement_assessment",
-    ):
-        nested = _mapping(payload.get(key))
-        verdict = _assessment_verdict_from_mapping(nested) if nested else ""
-        if verdict:
-            return verdict
-    return ""
+    from moonmind.workflows.temporal.assessment_verdict import (
+        verdict_from_mapping as _canonical_from_mapping,
+    )
+
+    return _canonical_from_mapping(payload)
 
 
 def _assessment_verdict_from_text(value: Any) -> str:
-    text = _string(value)
-    if not text:
-        return ""
-    verdict_pattern = (
-        r"(FULLY_IMPLEMENTED|PARTIALLY_IMPLEMENTED|NOT_IMPLEMENTED|BLOCKED)"
+    from moonmind.workflows.temporal.assessment_verdict import (
+        verdict_from_text as _canonical_from_text,
     )
-    verdict_prefix = r"[\s:`*_\"']*"
-    verdict_suffix = r"(?:_+(?!\w)|(?![-\w]))"
-    assessment_separator = r"[\s:.,;!?\-\u2010-\u2015`*_\"'\[\]\(\)]*"
-    issue_ref_pattern = r"`?[A-Z][A-Z0-9]+-\d+`?"
-    patterns = (
-        r"(?im)^\s*#{1,6}\s*verdict\s*[:\-]\s*"
-        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
-        r"(?im)^\s*verdict\s*[:\-]\s*"
-        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
-        r"(?is)\bassessment\s+complete\b"
-        rf"{assessment_separator}"
-        rf"(?:(?:for|on)\b{assessment_separator}"
-        rf"{issue_ref_pattern}{assessment_separator})?"
-        rf"(?:{issue_ref_pattern}{assessment_separator})?"
-        rf"(?:(?:is|was|has|verdict|status)\b{assessment_separator})?"
-        rf"{verdict_pattern}{verdict_suffix}",
-        r"(?is)\brecorded\s+verdict\b[^.\n:]*[:\s`]+"
-        rf"{verdict_prefix}{verdict_pattern}{verdict_suffix}",
-        r"(?is)['\"]verdict['\"]\s*:\s*['\"]"
-        rf"{verdict_pattern}['\"]",
-    )
-    for pattern in patterns:
-        match = re.search(pattern, text)
-        if match:
-            return _normalize_assessment_verdict(match.group(1))
-    return ""
+
+    return _canonical_from_text(value)
 
 
 def _jira_assessment_verdict(
@@ -5556,14 +5515,62 @@ async def _resolve_jira_assessment_verdict(
     inputs: Mapping[str, Any],
     context: Mapping[str, Any] | None,
 ) -> tuple[str, bool]:
-    """Resolve the issue-implement assessment verdict, preferring durable sources.
+    """Resolve the issue-implement assessment verdict, preferring durable ref.
 
-    Shared by Jira and GitHub flows: tries the synchronous sources first
-    (compact ``assessmentVerdict`` in ``previousOutputs``, a locally resolvable
-    handoff file, then free text), then the published artifact ref. The ref is
-    the bridge-compatible channel when the assessment ran on an Omnigent host.
+    Shared by Jira and GitHub flows. When ``assessmentArtifactRef`` is present,
+    the durable artifact is read and preferred over compact
+    ``previousOutputs.assessmentVerdict`` projections, which can go stale across
+    replay / context restoration. Only when no usable durable verdict exists
+    does resolution fall back to synchronous sources (local handoff file,
+    compact mapping, free text). Histories carrying no ref behave identically
+    to before.
     """
 
+    ref = _assessment_artifact_ref(inputs, context)
+    if ref:
+        payload = await _read_json_artifact_by_ref(ref, context)
+        if payload is not None:
+            try:
+                from moonmind.workflows.temporal.assessment_verdict import (
+                    normalize_assessment_payload as _normalize_payload,
+                )
+            except Exception:  # pragma: no cover - import guard
+                _normalize_payload = None  # type: ignore[assignment]
+            if _normalize_payload is not None:
+                assistant_hint = ""
+                for source in (
+                    _mapping(inputs.get("previousOutputs")),
+                    _mapping(inputs.get("previous_outputs")),
+                    _mapping((context or {}).get("previousOutputs")),
+                    _mapping((context or {}).get("previous_outputs")),
+                ):
+                    for _k in (
+                        "lastAssistantText",
+                        "assistantText",
+                        "summary",
+                        "operator_summary",
+                    ):
+                        _v = source.get(_k)
+                        if isinstance(_v, str) and _v.strip():
+                            assistant_hint = _v
+                            break
+                    if assistant_hint:
+                        break
+                ref_verdict, _prov, _ev = _normalize_payload(
+                    payload,
+                    assistant_text=assistant_hint,
+                )
+                if ref_verdict:
+                    return ref_verdict, True
+            else:
+                ref_verdict = _normalize_assessment_verdict(
+                    payload.get("verdict") if isinstance(payload, Mapping) else ""
+                )
+                if ref_verdict:
+                    return ref_verdict, True
+        # Ref present but unreadable/unusable: fall through to sync sources so
+        # a valid compact verdict can still proceed; ultimate unavailable is
+        # decided by the sync path (which returns False when artifact path set).
     return await _augment_assessment_verdict_with_ref(
         _jira_assessment_verdict(inputs, context), inputs, context
     )

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -3923,6 +3923,200 @@ async def test_agent_runtime_publish_artifacts_resolves_omnigent_sandbox_workspa
             assert persisted["issue_ref"] == "MoonLadderStudios/MoonMind#3620"
 
 
+async def test_agent_runtime_publish_artifacts_rejects_missing_verdict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for mm:12352fc2: assessment JSON without verdict must fail fast.
+
+    The Omnigent assessment agent wrote requirements + summary but omitted the
+    required verdict key. Publishing must raise at this owning boundary instead
+    of emitting a ref without verdict that later fails In Progress gating with
+    a misleading 'unavailable' error.
+    """
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            workspace_root = tmp_path / "agent_workspaces"
+            workspace_id = "sandbox-assess-missing-verdict"
+            workflow_id = "parent-wf"
+            step_execution_id = "parent-wf:run-1:step-2:execution:1"
+            workspace = (
+                workspace_root / "temporal_sandbox" / workspace_id / "repo"
+            )
+            assessment_path = (
+                workspace / "artifacts/github-issue-implement-assessment.json"
+            )
+            assessment_path.parent.mkdir(parents=True)
+            assessment_path.write_text(
+                json.dumps(
+                    {
+                        "issue_provider": "github",
+                        "issue_ref": "MoonLadderStudios/MoonMind#4175",
+                        "mode": "main",
+                        "summary": "Epic fully implemented",
+                        "requirements": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            SandboxWorkspaceRecordStore(workspace_root).ensure(
+                SandboxWorkspaceRecord(
+                    workspace_id=workspace_id,
+                    workflow_id=workflow_id,
+                    step_execution_id=step_execution_id,
+                    relative_path="repo",
+                )
+            )
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                workspace_root=workspace_root,
+            )
+
+            async def _skip_notify(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+                return {"status": "skipped"}
+
+            monkeypatch.setattr(
+                activities, "execution_notify_completion", _skip_notify
+            )
+            monkeypatch.setattr(
+                temporal_activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id="parent-wf:agent:step-2",
+                    workflow_run_id="child-run-assess",
+                ),
+            )
+
+            with pytest.raises(
+                activity_runtime_module.TemporalActivityRuntimeError,
+                match="no recoverable.*verdict",
+            ):
+                await activities.agent_runtime_publish_artifacts(
+                    AgentRunResult(
+                        summary="Omnigent session completed",
+                        metadata={
+                            "correlationId": workflow_id,
+                            "idempotencyKey": f"{step_execution_id}:agent_execute",
+                            "workspaceLocator": {
+                                "kind": "sandbox",
+                                "workspaceId": workspace_id,
+                                "relativePath": "repo",
+                            },
+                            "assessment_artifact_path": (
+                                "artifacts/github-issue-implement-assessment.json"
+                            ),
+                        },
+                    )
+                )
+
+
+async def test_agent_runtime_publish_artifacts_normalizes_missing_verdict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resilient fallback: unanimous met requirements recover missing verdict.
+
+    Mirrors mm:12352fc2 where the agent omitted the verdict key but marked every
+    requirement met. Publisher normalizes to FULLY_IMPLEMENTED with provenance
+    instead of failing the run on a minor schema difference.
+    """
+
+    async with temporal_db(tmp_path) as session_maker:
+        async with session_maker() as session:
+            workspace_root = tmp_path / "agent_workspaces"
+            workspace_id = "sandbox-assess-recoverable"
+            workflow_id = "parent-wf"
+            step_execution_id = "parent-wf:run-1:step-2:execution:1"
+            workspace = (
+                workspace_root / "temporal_sandbox" / workspace_id / "repo"
+            )
+            assessment_path = (
+                workspace / "artifacts/github-issue-implement-assessment.json"
+            )
+            assessment_path.parent.mkdir(parents=True)
+            assessment_path.write_text(
+                json.dumps(
+                    {
+                        "issue_provider": "github",
+                        "issue_ref": "MoonLadderStudios/MoonMind#4175",
+                        "mode": "main",
+                        "summary": "Epic fully implemented on main",
+                        "requirements": [
+                            {"id": "a", "status": "met"},
+                            {"id": "b", "status": "met"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            SandboxWorkspaceRecordStore(workspace_root).ensure(
+                SandboxWorkspaceRecord(
+                    workspace_id=workspace_id,
+                    workflow_id=workflow_id,
+                    step_execution_id=step_execution_id,
+                    relative_path="repo",
+                )
+            )
+            service = TemporalArtifactService(
+                TemporalArtifactRepository(session),
+                store=LocalTemporalArtifactStore(tmp_path / "artifacts"),
+            )
+            activities = TemporalAgentRuntimeActivities(
+                artifact_service=service,
+                workspace_root=workspace_root,
+            )
+
+            async def _skip_notify(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+                return {"status": "skipped"}
+
+            monkeypatch.setattr(
+                activities, "execution_notify_completion", _skip_notify
+            )
+            monkeypatch.setattr(
+                temporal_activity,
+                "info",
+                lambda: SimpleNamespace(
+                    namespace="default",
+                    workflow_id="parent-wf:agent:step-2",
+                    workflow_run_id="child-run-assess",
+                ),
+            )
+
+            result = await activities.agent_runtime_publish_artifacts(
+                AgentRunResult(
+                    summary="Omnigent session completed",
+                    metadata={
+                        "correlationId": workflow_id,
+                        "idempotencyKey": f"{step_execution_id}:agent_execute",
+                        "workspaceLocator": {
+                            "kind": "sandbox",
+                            "workspaceId": workspace_id,
+                            "relativePath": "repo",
+                        },
+                        "assessment_artifact_path": (
+                            "artifacts/github-issue-implement-assessment.json"
+                        ),
+                    },
+                )
+            )
+
+            assert isinstance(result, AgentRunResult)
+            assert result.metadata["assessmentVerdict"] == "FULLY_IMPLEMENTED"
+            _artifact, artifact_path = await service.read_path(
+                artifact_id=result.metadata["assessmentArtifactRef"],
+                principal="system:agent_runtime",
+            )
+            persisted = json.loads(artifact_path.read_text(encoding="utf-8"))
+            assert persisted["verdict"] == "FULLY_IMPLEMENTED"
+            assert persisted["verdictProvenance"] == "requirements_inferred"
+
+
 @pytest.mark.parametrize(
     "runtime",
     ["omnigent", "codex_cli", "claude_code", "jules", "openclaw"],

--- a/tests/unit/workflows/temporal/test_activity_runtime.py
+++ b/tests/unit/workflows/temporal/test_activity_runtime.py
@@ -4020,11 +4020,11 @@ async def test_agent_runtime_publish_artifacts_normalizes_missing_verdict(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Resilient fallback: unanimous met requirements recover missing verdict.
+    """Syntactic recovery: explicit verdict text recovers missing verdict key.
 
-    Mirrors mm:12352fc2 where the agent omitted the verdict key but marked every
-    requirement met. Publisher normalizes to FULLY_IMPLEMENTED with provenance
-    instead of failing the run on a minor schema difference.
+    The portable assessment Skill owns completion decisions, so unanimous
+    requirements alone never imply verdicts natively. Explicit verdict
+    statements (for example ``## Verdict: X``) are syntactic and recoverable.
     """
 
     async with temporal_db(tmp_path) as session_maker:
@@ -4046,7 +4046,7 @@ async def test_agent_runtime_publish_artifacts_normalizes_missing_verdict(
                         "issue_provider": "github",
                         "issue_ref": "MoonLadderStudios/MoonMind#4175",
                         "mode": "main",
-                        "summary": "Epic fully implemented on main",
+                        "summary": "## Verdict: FULLY_IMPLEMENTED",
                         "requirements": [
                             {"id": "a", "status": "met"},
                             {"id": "b", "status": "met"},
@@ -4114,7 +4114,7 @@ async def test_agent_runtime_publish_artifacts_normalizes_missing_verdict(
             )
             persisted = json.loads(artifact_path.read_text(encoding="utf-8"))
             assert persisted["verdict"] == "FULLY_IMPLEMENTED"
-            assert persisted["verdictProvenance"] == "requirements_inferred"
+            assert persisted["verdictProvenance"] == "text_recovered"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/workflows/temporal/test_assessment_verdict.py
+++ b/tests/unit/workflows/temporal/test_assessment_verdict.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from moonmind.workflows.temporal.assessment_verdict import (
-    infer_verdict_from_requirements,
     normalize_assessment_payload,
     normalize_verdict,
     verdict_from_mapping,
@@ -27,6 +26,18 @@ def test_verdict_from_text_recovers_assistant_verdict() -> None:
     assert verdict_from_text("no verdict here") == ""
 
 
+def test_verdict_from_text_recovers_github_refs() -> None:
+    assert (
+        verdict_from_text(
+            "Assessment complete for MoonLadderStudios/MoonMind#4175: FULLY_IMPLEMENTED"
+        )
+        == "FULLY_IMPLEMENTED"
+    )
+    assert verdict_from_text("Assessment complete for #4175: NOT_IMPLEMENTED") == (
+        "NOT_IMPLEMENTED"
+    )
+
+
 def test_verdict_from_mapping_checks_aliases() -> None:
     assert (
         verdict_from_mapping({"assessmentVerdict": "NOT_IMPLEMENTED"})
@@ -36,24 +47,18 @@ def test_verdict_from_mapping_checks_aliases() -> None:
     assert verdict_from_mapping({}) == ""
 
 
-def test_infer_all_met_implies_fully() -> None:
-    verdict, _ = infer_verdict_from_requirements(
-        [{"status": "met"}, {"status": "met"}],
-        summary="Epic fully implemented",
+def test_requirements_alone_never_imply_completion() -> None:
+    # Skill authority: unanimous met requirements without an explicit verdict
+    # must NOT manufacture FULLY_IMPLEMENTED natively. The portable assessment
+    # Skill owns completion decisions; native only recovers explicit statements.
+    verdict, provenance, _ = normalize_assessment_payload(
+        {
+            "summary": "Epic fully implemented",
+            "requirements": [{"status": "met"}, {"status": "met"}],
+        }
     )
-    assert verdict == "FULLY_IMPLEMENTED"
-
-
-def test_infer_mixed_implies_partially_safe_bias() -> None:
-    verdict, _ = infer_verdict_from_requirements(
-        [{"status": "met"}, {"status": "not_met"}]
-    )
-    assert verdict == "PARTIALLY_IMPLEMENTED"
-
-
-def test_infer_empty_unavailable() -> None:
-    assert infer_verdict_from_requirements([])[0] == ""
-    assert infer_verdict_from_requirements(None)[0] == ""  # type: ignore[arg-type]
+    assert verdict == ""
+    assert provenance == "unavailable"
 
 
 def test_normalize_payload_prefers_declared() -> None:
@@ -63,16 +68,13 @@ def test_normalize_payload_prefers_declared() -> None:
     assert (verdict, provenance) == ("BLOCKED", "declared")
 
 
-def test_normalize_payload_recovers_requirements() -> None:
+def test_normalize_payload_recovers_explicit_text() -> None:
     verdict, provenance, _ = normalize_assessment_payload(
-        {
-            "summary": "Epic fully implemented",
-            "requirements": [{"status": "met"}, {"status": "met"}],
-        }
+        {"summary": "## Verdict: PARTIALLY_IMPLEMENTED"},
     )
     assert (verdict, provenance) == (
-        "FULLY_IMPLEMENTED",
-        "requirements_inferred",
+        "PARTIALLY_IMPLEMENTED",
+        "text_recovered",
     )
 
 

--- a/tests/unit/workflows/temporal/test_assessment_verdict.py
+++ b/tests/unit/workflows/temporal/test_assessment_verdict.py
@@ -1,0 +1,80 @@
+"""Unit tests for canonical assessment-verdict normalization."""
+
+from __future__ import annotations
+
+from moonmind.workflows.temporal.assessment_verdict import (
+    infer_verdict_from_requirements,
+    normalize_assessment_payload,
+    normalize_verdict,
+    verdict_from_mapping,
+    verdict_from_text,
+)
+
+
+def test_normalize_verdict_accepts_canonical() -> None:
+    assert normalize_verdict("fully_implemented") == "FULLY_IMPLEMENTED"
+    assert normalize_verdict("BLOCKED") == "BLOCKED"
+    assert normalize_verdict("bogus") == ""
+
+
+def test_verdict_from_text_recovers_assistant_verdict() -> None:
+    assert (
+        verdict_from_text("## Verdict: FULLY_IMPLEMENTED") == "FULLY_IMPLEMENTED"
+    )
+    assert verdict_from_text("verdict: partially_implemented") == (
+        "PARTIALLY_IMPLEMENTED"
+    )
+    assert verdict_from_text("no verdict here") == ""
+
+
+def test_verdict_from_mapping_checks_aliases() -> None:
+    assert (
+        verdict_from_mapping({"assessmentVerdict": "NOT_IMPLEMENTED"})
+        == "NOT_IMPLEMENTED"
+    )
+    assert verdict_from_mapping({"verdict": "blocked"}) == "BLOCKED"
+    assert verdict_from_mapping({}) == ""
+
+
+def test_infer_all_met_implies_fully() -> None:
+    verdict, _ = infer_verdict_from_requirements(
+        [{"status": "met"}, {"status": "met"}],
+        summary="Epic fully implemented",
+    )
+    assert verdict == "FULLY_IMPLEMENTED"
+
+
+def test_infer_mixed_implies_partially_safe_bias() -> None:
+    verdict, _ = infer_verdict_from_requirements(
+        [{"status": "met"}, {"status": "not_met"}]
+    )
+    assert verdict == "PARTIALLY_IMPLEMENTED"
+
+
+def test_infer_empty_unavailable() -> None:
+    assert infer_verdict_from_requirements([])[0] == ""
+    assert infer_verdict_from_requirements(None)[0] == ""  # type: ignore[arg-type]
+
+
+def test_normalize_payload_prefers_declared() -> None:
+    verdict, provenance, _ = normalize_assessment_payload(
+        {"verdict": "BLOCKED", "requirements": [{"status": "met"}]}
+    )
+    assert (verdict, provenance) == ("BLOCKED", "declared")
+
+
+def test_normalize_payload_recovers_requirements() -> None:
+    verdict, provenance, _ = normalize_assessment_payload(
+        {
+            "summary": "Epic fully implemented",
+            "requirements": [{"status": "met"}, {"status": "met"}],
+        }
+    )
+    assert (verdict, provenance) == (
+        "FULLY_IMPLEMENTED",
+        "requirements_inferred",
+    )
+
+
+def test_normalize_payload_unavailable_when_no_signal() -> None:
+    assert normalize_assessment_payload({"summary": "no verdict here"})[0] == ""

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -5571,3 +5571,99 @@ async def test_check_github_issue_blockers_forwards_artifact_ref() -> None:
 
     assert result.outputs["assessmentVerdict"] == "NOT_IMPLEMENTED"
     assert result.outputs["assessmentArtifactRef"] == "art_gh_assessment_2"
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_resolves_compact_mapping_verdict() -> None:
+    # Regression for mm:12352fc2 workflow: when the assessment ran on an Omnigent
+    # host, the compact assessmentVerdict in previousOutputs is the fast path.
+    # GitHub start gating must honor it like the Jira flow does, without
+    # requiring a locally mountable handoff file.
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "mode": "start",
+            "assessmentArtifactPath": "artifacts/missing-assessment.json",
+            "previousOutputs": {
+                "assessmentVerdict": "FULLY_IMPLEMENTED",
+                "assessmentArtifactRef": "art_compact_verdict",
+            },
+        },
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "skipped"
+    assert result.outputs["assessmentVerdict"] == "FULLY_IMPLEMENTED"
+    assert service.token_requests == []
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_unavailable_names_ref_for_remediation() -> None:
+    # When the artifact resolves but carries no usable verdict (e.g. assessment
+    # JSON missing the required verdict key), the failure must name the ref and
+    # tell the operator to re-run the assessment step.
+    artifact_service = _FakeAssessmentArtifactService(
+        {"art_missing_verdict": {"summary": "no verdict here"}}
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "mode": "start",
+            "assessmentArtifactPath": "artifacts/github-issue-implement-assessment.json",
+            "assessmentArtifactRef": "art_missing_verdict",
+        },
+        {"temporal_artifact_service": artifact_service},
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert "art_missing_verdict" in result.outputs["summary"]
+    assert "verdict" in result.outputs["summary"].lower()
+    assert service.token_requests == []
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_recovers_missing_verdict_from_requirements() -> None:
+    # Resilient fallback for mm:12352fc2: verdict key omitted but agent's own
+    # requirements are unanimously met. Trust semantic intent over syntactic
+    # field presence instead of failing the run.
+    artifact_service = _FakeAssessmentArtifactService(
+        {
+            "art_recoverable": {
+                "issue_provider": "github",
+                "issue_ref": "MoonLadderStudios/MoonMind#4175",
+                "mode": "main",
+                "summary": "Epic fully implemented on main",
+                "requirements": [
+                    {"id": "a", "status": "met"},
+                    {"id": "b", "status": "met"},
+                ],
+            }
+        }
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 4175,
+            "mode": "start",
+            "assessmentArtifactPath": "artifacts/github-issue-implement-assessment.json",
+            "assessmentArtifactRef": "art_recoverable",
+        },
+        {"temporal_artifact_service": artifact_service},
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "COMPLETED"
+    assert result.outputs["decision"] == "skipped"
+    assert result.outputs["assessmentVerdict"] == "FULLY_IMPLEMENTED"
+    assert service.token_requests == []

--- a/tests/unit/workflows/temporal/test_story_output_tools.py
+++ b/tests/unit/workflows/temporal/test_story_output_tools.py
@@ -5452,10 +5452,11 @@ async def test_check_jira_blockers_resolves_and_forwards_artifact_ref() -> None:
 
 @pytest.mark.asyncio
 async def test_update_jira_issue_status_prefers_in_payload_verdict_over_ref() -> None:
-    # The compact in-payload verdict is the fast path; the artifact must not be
-    # read when a verdict is already present in previousOutputs.
+    # Durable artifact wins over stale compact projections. When both are
+    # present and conflict, the ref is read and preferred so a stale
+    # FULLY_IMPLEMENTED cannot override durable NOT/BLOCKED and skip work.
     artifact_service = _FakeAssessmentArtifactService(
-        {"art_assessment_5": {"verdict": "NOT_IMPLEMENTED"}}
+        {"art_assessment_5": {"verdict": "BLOCKED"}}
     )
     service = _FakeJiraService()
 
@@ -5473,10 +5474,10 @@ async def test_update_jira_issue_status_prefers_in_payload_verdict_over_ref() ->
         jira_service_factory=lambda: service,
     )
 
-    assert result.status == "COMPLETED"
-    assert result.outputs["decision"] == "skipped"
-    assert result.outputs["assessmentVerdict"] == "FULLY_IMPLEMENTED"
-    assert artifact_service.read_calls == []
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["assessmentVerdict"] == "BLOCKED"
+    assert artifact_service.read_calls == ["art_assessment_5"]
 
 
 @pytest.mark.asyncio
@@ -5632,16 +5633,16 @@ async def test_update_github_issue_status_unavailable_names_ref_for_remediation(
 
 @pytest.mark.asyncio
 async def test_update_github_issue_status_recovers_missing_verdict_from_requirements() -> None:
-    # Resilient fallback for mm:12352fc2: verdict key omitted but agent's own
-    # requirements are unanimously met. Trust semantic intent over syntactic
-    # field presence instead of failing the run.
+    # Native syntactic recovery only: explicit verdict text in the payload is
+    # recovered, but unanimous requirements alone never imply completion
+    # (owned by the portable assessment Skill).
     artifact_service = _FakeAssessmentArtifactService(
         {
             "art_recoverable": {
                 "issue_provider": "github",
                 "issue_ref": "MoonLadderStudios/MoonMind#4175",
                 "mode": "main",
-                "summary": "Epic fully implemented on main",
+                "summary": "## Verdict: FULLY_IMPLEMENTED",
                 "requirements": [
                     {"id": "a", "status": "met"},
                     {"id": "b", "status": "met"},
@@ -5666,4 +5667,34 @@ async def test_update_github_issue_status_recovers_missing_verdict_from_requirem
     assert result.status == "COMPLETED"
     assert result.outputs["decision"] == "skipped"
     assert result.outputs["assessmentVerdict"] == "FULLY_IMPLEMENTED"
+
+
+@pytest.mark.asyncio
+async def test_update_github_issue_status_prefers_durable_ref_over_compact() -> None:
+    # Stale compact projections must not override the durable artifact. When
+    # both are present and conflict, the durable ref wins.
+    artifact_service = _FakeAssessmentArtifactService(
+        {"art_durable": {"verdict": "BLOCKED"}}
+    )
+    service = _FakeGitHubService()
+
+    result = await update_github_issue_status(
+        {
+            "repository": "MoonLadderStudios/MoonMind",
+            "issueNumber": 1067,
+            "mode": "start",
+            "assessmentArtifactPath": "artifacts/missing-assessment.json",
+            "assessmentArtifactRef": "art_durable",
+            "previousOutputs": {
+                "assessmentVerdict": "FULLY_IMPLEMENTED",
+                "assessmentArtifactRef": "art_durable",
+            },
+        },
+        {"temporal_artifact_service": artifact_service},
+        github_service_factory=lambda: service,
+    )
+
+    assert result.status == "FAILED"
+    assert result.outputs["decision"] == "blocked"
+    assert result.outputs["assessmentVerdict"] == "BLOCKED"
     assert service.token_requests == []


### PR DESCRIPTION
Root cause: workflow mm:12352fc2 failed at github.update_issue_status start gate because assessment artifact art_01M28N54WG3P95AWYB45NSS36Z omitted verdict key while requirements all met + summary fully implemented + assistant ## Verdict: FULLY_IMPLEMENTED were unanimous. Strict field-equality failed fragilely.

Resilient fix, one canonical path:
- New moonmind/workflows/temporal/assessment_verdict.py: declared > mapping > text_recovered > requirements_inferred > unavailable, safe bias (never infer BLOCKED, mixed->PARTIALLY).
- activity_runtime publish normalizes missing verdict with provenance verdictProvenance/verdictEvidence instead of failing on minor difference; only truly ambiguous still raises with repair guidance.
- story_output_tools ref augment + start gate use shared resolver, improved error names ref.
- Tests: 9 new normalizer, 1 downstream recovery, 1 publish normalization; existing suites green.