### PR TITLE
[Workflows] Allow search-and-implement canonical no-commit outcome

### DIFF
--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -665,6 +665,12 @@ RUN_WORKFLOW_PUBLISH_OUTCOME_PATCH = "run-workflow-publish-outcome-v1"
 # has eliminated those histories.
 RUN_WORKFLOW_NESTED_PROPOSE_TASKS_PATCH = "run-workflow-nested-propose-tasks"
 RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH = "run-canonical-no-commit-outcome-v1"
+# Search-and-implement shares the implement no-commit outcome only for
+# histories that record this marker. Older search histories without it keep
+# their recorded skipped/failed publication path during replay.
+RUN_CANONICAL_NO_COMMIT_SEARCH_PRESET_PATCH = (
+    "run-canonical-no-commit-search-preset-v1"
+)
 RUN_UNGATED_CONTINUATION_DISPOSITION_PATCH = "run-ungated-continuation-disposition-v1"
 RUN_GATED_STEP_CONTINUATION_PATCH = "run-gated-step-continuation-v1"
 # Expose the workflow-owned continuation capability to the portable Skill at
@@ -1612,6 +1618,7 @@ class MoonMindRunWorkflow:
         self._publish_context: dict[str, Any] = {}
         self._canonical_git_repository_projection_enabled: bool = False
         self._canonical_no_commit_outcome_enabled: bool = False
+        self._canonical_no_commit_search_preset_enabled: bool = False
         self._authoritative_publish_outcome_enabled: bool = False
         self._publish_repair_attempts: int = 0
         self._operator_summary: Optional[str] = None
@@ -11066,6 +11073,9 @@ class MoonMindRunWorkflow:
         self._canonical_no_commit_outcome_enabled = workflow.patched(
             RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH
         )
+        self._canonical_no_commit_search_preset_enabled = workflow.patched(
+            RUN_CANONICAL_NO_COMMIT_SEARCH_PRESET_PATCH
+        )
         self._authoritative_publish_outcome_enabled = workflow.patched(
             RUN_AUTHORITATIVE_PUBLISH_OUTCOME_PATCH
         )
@@ -18059,10 +18069,14 @@ class MoonMindRunWorkflow:
         task_payload = self._mapping_value(parameters, "workflow")
         if not task_payload:
             task_payload = self._mapping_value(parameters, "task")
-        return bool(
-            self._task_applied_template_slugs(parameters, task_payload)
-            & _CANONICAL_NO_COMMIT_TASK_PRESETS
-        )
+        slugs = self._task_applied_template_slugs(parameters, task_payload)
+        if "github-issue-implement" in slugs:
+            return True
+        if "github-issue-search-and-implement" in slugs:
+            # Replay gate: histories that started before this preset was
+            # admitted keep their recorded skipped/failed path.
+            return bool(self._canonical_no_commit_search_preset_enabled)
+        return bool(slugs & _CANONICAL_NO_COMMIT_TASK_PRESETS)
 
     def _task_skill_names(
         self,

--- a/moonmind/workflows/temporal/workflows/run.py
+++ b/moonmind/workflows/temporal/workflows/run.py
@@ -379,7 +379,9 @@ def bounded_story_loop_scope_guard(
 
 _PR_OPTIONAL_AGENT_SKILLS = JIRA_AGENT_SKILLS
 _PR_OPTIONAL_TASK_SKILLS = frozenset({"jira-implement", *_PR_OPTIONAL_AGENT_SKILLS})
-_CANONICAL_NO_COMMIT_TASK_PRESETS = frozenset({"github-issue-implement"})
+_CANONICAL_NO_COMMIT_TASK_PRESETS = frozenset(
+    {"github-issue-implement", "github-issue-search-and-implement"}
+)
 _EXTERNAL_INTEGRATION_MONITOR_IDS = frozenset({"codex_cloud", "jules"})
 _PUBLISH_NOT_REQUIRED_STATUSES = frozenset(
     {

--- a/tests/unit/workflows/temporal/test_run_replayer.py
+++ b/tests/unit/workflows/temporal/test_run_replayer.py
@@ -26,6 +26,7 @@ from moonmind.workflows.temporal.workflows.run import (
     RUN_BOUNDED_STORY_LOOP_PROGRESS_BUDGET_PATCH,
     RUN_CANONICAL_GIT_REPOSITORY_PROJECTION_PATCH,
     RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH,
+    RUN_CANONICAL_NO_COMMIT_SEARCH_PRESET_PATCH,
     RUN_LATE_REMEDIATION_HEAD_ATTEMPT_ORDINAL_PATCH,
     RUN_MANAGED_SESSION_CHECKPOINT_LOCATOR_PATCH,
     RUN_MOONSPEC_TITLE_REMEDIATION_DETECTION_PATCH,
@@ -897,6 +898,17 @@ def test_canonical_no_commit_patch_is_snapshotted_at_workflow_start() -> None:
     patch_name = "RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH"
 
     assert RUN_CANONICAL_NO_COMMIT_OUTCOME_PATCH.endswith("-v1")
+    assert source.count(patch_name) == 1
+    assert source.index(patch_name) < source.index(
+        "Starting MoonMind.UserWorkflow workflow"
+    )
+
+
+def test_canonical_no_commit_search_preset_patch_is_snapshotted_at_workflow_start() -> None:
+    source = inspect.getsource(MoonMindRunWorkflow.run)
+    patch_name = "RUN_CANONICAL_NO_COMMIT_SEARCH_PRESET_PATCH"
+
+    assert RUN_CANONICAL_NO_COMMIT_SEARCH_PRESET_PATCH.endswith("-v1")
     assert source.count(patch_name) == 1
     assert source.index(patch_name) < source.index(
         "Starting MoonMind.UserWorkflow workflow"

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2176,6 +2176,7 @@ def test_github_issue_search_and_implement_no_commit_finalizes_as_no_commit(
     """
 
     mock_run_workflow._canonical_no_commit_outcome_enabled = True
+    mock_run_workflow._canonical_no_commit_search_preset_enabled = True
     parameters = {
         "publishMode": "pr",
         "workflow": {
@@ -2213,6 +2214,41 @@ def test_github_issue_search_and_implement_no_commit_finalizes_as_no_commit(
     assert "No pull request was required" in message
     assert "no publishable diff was produced" not in message
     assert publish_failure is False
+
+
+def test_github_issue_search_and_implement_no_commit_keeps_legacy_failed_path(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    """Pre-patch search histories replay to their recorded failure.
+
+    Old `github-issue-search-and-implement` runs without
+    `run-canonical-no-commit-search-preset-v1` keep `skipped`/failed for
+    `push_status=no_commits` so replay stays deterministic.
+    """
+
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
+    mock_run_workflow._canonical_no_commit_search_preset_enabled = False
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {
+            "appliedStepTemplates": [
+                {"slug": "github-issue-search-and-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+
+    mock_run_workflow._record_publish_result(
+        parameters=parameters,
+        execution_result={"outputs": {"push_status": "no_commits"}},
+    )
+
+    assert mock_run_workflow._publish_status == "skipped"
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters=parameters
+    )
+    assert status == "failed"
+    assert "no publishable diff was produced" in message
+    assert publish_failure is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/temporal/workflows/test_run_integration.py
+++ b/tests/unit/workflows/temporal/workflows/test_run_integration.py
@@ -2163,6 +2163,58 @@ async def test_github_issue_implement_no_commit_closure_finalizes_as_no_commit(
     ]
 
 
+def test_github_issue_search_and_implement_no_commit_finalizes_as_no_commit(
+    mock_run_workflow: MoonMindRunWorkflow,
+) -> None:
+    """Search-and-implement shares the implement no-commit outcome.
+
+    Regression for mm:2898e272-c0ac-4eba-b546-056e3f4a4986-2026-09-11T16:25:00Z:
+    a FULLY_IMPLEMENTED assessment with no repository changes correctly
+    produces ``push_status=no_commits`` on branch ``main``. The run must
+    finalize as ``no_commit`` (issue already implemented, Done side effect
+    preserved), not fail with "no publishable diff was produced".
+    """
+
+    mock_run_workflow._canonical_no_commit_outcome_enabled = True
+    parameters = {
+        "publishMode": "pr",
+        "workflow": {
+            "tool": {"type": "skill", "name": "auto"},
+            "skill": {"name": "auto"},
+            "appliedStepTemplates": [
+                {"slug": "github-issue-search-and-implement", "version": "1.0.0"},
+            ],
+        },
+    }
+    no_commit_result = {
+        "outputs": {
+            "push_status": "no_commits",
+            "push_branch": "main",
+            "push_base_ref": "main",
+            "push_commit_count": 0,
+            "operator_summary": "GitHub issue #4175 was already implemented.",
+        }
+    }
+    mock_run_workflow._record_execution_context(
+        node_id="create-pull-request",
+        execution_result=no_commit_result,
+    )
+    mock_run_workflow._record_publish_result(
+        parameters=parameters,
+        execution_result=no_commit_result,
+    )
+
+    assert mock_run_workflow._publish_status == "not_required"
+    status, message, publish_failure = mock_run_workflow._determine_publish_completion(
+        parameters=parameters
+    )
+
+    assert status == "no_commit"
+    assert "No pull request was required" in message
+    assert "no publishable diff was produced" not in message
+    assert publish_failure is False
+
+
 @pytest.mark.asyncio
 async def test_already_implemented_no_commit_pr_handoff_completes_jira_done(
     mock_run_workflow: MoonMindRunWorkflow,


### PR DESCRIPTION
Fixes recurring failure mm:2898e272-c0ac-4eba-b546-056e3f4a4986-2026-09-11T16:25:00Z (and 10:25Z same definition): publishMode pr with push_status no_commits on branch main failed with no publishable diff, even though assessment was FULLY_IMPLEMENTED and finalize closed the issue as Done successfully.

Root cause: _CANONICAL_NO_COMMIT_TASK_PRESETS only contained github-issue-implement, so github-issue-search-and-implement (which declares implementsPreset: github-issue-implement) fell through to skipped/failed instead of not_required/no_commit.

Change: add github-issue-search-and-implement to the canonical no-commit preset set. PARTIALLY/NOT_IMPLEMENTED still requires a PR via the existing _issue_implement_pr_required guard.

Verification: new regression test test_github_issue_search_and_implement_no_commit_finalizes_as_no_commit plus existing no-commit suites (14 tests) and publication head handoff suite (18 tests) pass via docker-compose test runner.