### PR TITLE
fix(checkpoints): honor configured outbound scan policy

### DIFF
--- a/docs/RepositoryAccessAndWorkspaceDesign.md
+++ b/docs/RepositoryAccessAndWorkspaceDesign.md
@@ -338,6 +338,16 @@ Capture includes meaningful untracked output and records exclusions. It does not
 
 MoonMind-issued credentials are forbidden in exports. Required outbound controls cover reports, snapshots, deltas, bundles, and publication. Unsafe recoverable content is quarantined/restricted with safe diagnostics, not exposed or silently discarded. Source confidentiality continues to govern artifact access and model data-use policy.
 
+Checkpoint exports use the existing `MOONMIND_HIGH_SECURITY_MODE` outbound
+scan policy. Omitted and explicit `false` inputs preserve the default capture
+path and record `not_scanned` evidence with no clean-scan claim. Explicit `true`
+enforces export-byte and metadata scanning, rejecting detected archive content
+before upload. Runtime credential-path exclusions and workspace containment
+apply in both modes. Repository files, test fixtures, and source history do not grant
+exceptions to an enabled scanner. Completed immutable captures retain their
+recorded scan evidence when reused; later publication applies the current
+destination policy independently.
+
 ### INV-007 Verified saving precedes destructive cleanup
 
 The finalization handoff is:

--- a/moonmind/schemas/saved_work_models.py
+++ b/moonmind/schemas/saved_work_models.py
@@ -517,15 +517,32 @@ _SCAN_CHUNK_OVERLAP_BYTES = 8 * 1024
 
 
 def scan_saved_work_export_stream(
-    chunks: Sequence[bytes] | Any, *, export_digest: str, location: str
+    chunks: Sequence[bytes] | Any,
+    *,
+    export_digest: str,
+    location: str,
+    high_security_mode: bool = True,
 ) -> dict[str, Any]:
     """Stream confidentiality/secret controls over exported bytes in chunks.
 
     Chunk windows overlap by ``_SCAN_CHUNK_OVERLAP_BYTES`` so
     credential-shaped content spanning a chunk boundary is still detected
     without holding the whole export in memory. Same evidence contract as
-    :func:`scan_saved_work_export`.
+    :func:`scan_saved_work_export`. The Activity supplies the resolved outbound
+    policy. Disabled scanning is recorded explicitly, never as a clean scan;
+    direct scanner callers retain strict scanning by default.
     """
+    if not high_security_mode:
+        return {
+            "disposition": "not_scanned",
+            "policyRef": SAVED_WORK_SCAN_POLICY_REF,
+            "exportDigest": export_digest,
+            "location": location,
+            "coverage": "none",
+            "limitations": [
+                "outbound secret scanning is disabled by MOONMIND_HIGH_SECURITY_MODE"
+            ],
+        }
     findings = 0
     decodable = True
     tail = b""

--- a/moonmind/workflows/temporal/activity_runtime.py
+++ b/moonmind/workflows/temporal/activity_runtime.py
@@ -6054,6 +6054,10 @@ class TemporalAgentRuntimeActivities:
         record: Any,
     ) -> dict[str, Any]:
         policy = model.capture_policy
+        # Capture shares the deployment's outbound policy with other artifact
+        # and publish boundaries. Do not unconditionally enable heuristic
+        # scanning of source code, documentation, and security-test fixtures.
+        high_security_mode = resolve_high_security_mode()
         # One stable capture generation starts here: record HEAD and the
         # worktree status before enumeration so a writer mutating files or
         # HEAD mid-capture is detected and retried/blocked instead of
@@ -6227,8 +6231,8 @@ class TemporalAgentRuntimeActivities:
                         linkTarget=target,
                     )
                 )
-        # Scan the actual exported tar bytes (not only manifest text) as a
-        # bounded chunk stream with overlap, so credential-shaped content
+        # When enabled, scan the actual exported tar bytes (not only manifest
+        # text) as a bounded chunk stream with overlap, so credential-shaped content
         # spanning a chunk boundary is still detected without holding the
         # whole export in memory. Binary/uninspectable regions stay explicit
         # instead of a fabricated clean scan.
@@ -6248,6 +6252,7 @@ class TemporalAgentRuntimeActivities:
             _tar_spool_chunks(),
             export_digest="pending-tar-stream",
             location="checkpoint.archive.tar",
+            high_security_mode=high_security_mode,
         )
         if tar_scan["disposition"] == "blocked":
             # Quarantine before any upload: a credential-shaped export must
@@ -6389,7 +6394,7 @@ class TemporalAgentRuntimeActivities:
             [
                 OutboundBundleItem(location="checkpoint.manifest", content=manifest_payload.decode("utf-8")),
             ],
-            high_security_mode=True,
+            high_security_mode=high_security_mode,
         )
         if not scan.allowed:
             raise temporal_exceptions.ApplicationError(
@@ -6574,7 +6579,7 @@ class TemporalAgentRuntimeActivities:
                     if export_scan["disposition"] != "clean"
                     else "clean"
                 ),
-                "manifestScan": "allow",
+                "manifestScan": "allow" if high_security_mode else "not_scanned",
                 "exportScan": export_scan,
                 "redactedPreviewRestorable": False,
             },
@@ -6633,7 +6638,7 @@ class TemporalAgentRuntimeActivities:
                     content=saved_work_payload.decode("utf-8"),
                 ),
             ],
-            high_security_mode=True,
+            high_security_mode=high_security_mode,
         )
         if not derivative_scan.allowed:
             raise temporal_exceptions.ApplicationError(

--- a/tests/integration/reliability/replays/checkpoint-outbound-policy-c7b23b45/manifest.json
+++ b/tests/integration/reliability/replays/checkpoint-outbound-policy-c7b23b45/manifest.json
@@ -1,0 +1,50 @@
+{
+  "sourceWorkflowId": "mm:c7b23b45-a7ac-42cb-9ed9-51b1d4a912a7",
+  "sourceHead": "a1cf884d2ea4a745d9660816f77da396487ae406",
+  "failedActivityType": "agent_runtime.capture_workspace_checkpoint",
+  "failedEvents": [
+    290,
+    309
+  ],
+  "failureType": "CHECKPOINT_CAPTURE_SECRET_DETECTED",
+  "deployedHighSecurityMode": false,
+  "request": {
+    "identity": {
+      "workflowId": "mm:c7b23b45-a7ac-42cb-9ed9-51b1d4a912a7",
+      "runId": "01a09468-8194-73ea-97f0-3e4129eafa2f",
+      "logicalStepId": "tpl:github-issue-implement:02:64be9322",
+      "executionOrdinal": 1
+    },
+    "boundary": "after_execution",
+    "artifactNamespace": "step-checkpoints/tpl:github-issue-implement:02:64be9322",
+    "idempotencyKey": "mm:c7b23b45-a7ac-42cb-9ed9-51b1d4a912a7:01a09468-8194-73ea-97f0-3e4129eafa2f:tpl:github-issue-implement:02:64be9322:execution:1:checkpoint:after_execution:capture",
+    "schemaVersion": "v1",
+    "checkpointKind": "worktree_archive",
+    "expectedRuntimeId": "codex_cli",
+    "capabilitySetVersion": "runtime-execution-capabilities-v3",
+    "capabilityDigest": "fb6551508dd736e83bbc317c52e88939f88175536c67ac1bc4212cb0ac60cbfd",
+    "capturePolicy": {
+      "includeTracked": true,
+      "includeUntracked": true,
+      "includeIgnored": false,
+      "redactionProfile": "managed-code-workspace-v1"
+    },
+    "workspaceLocator": {
+      "kind": "managed_runtime",
+      "runtimeId": "codex_cli",
+      "agentRunId": "mm:c7b23b45-a7ac-42cb-9ed9-51b1d4a912a7",
+      "relativePath": "repo"
+    }
+  },
+  "files": {
+    "auth.py": "token: str | None = None\n",
+    ".github/workflows/check.yml": "steps:\n  - with:\n      token: ${{ secrets.GITHUB_TOKEN }}\n",
+    "tests/test_auth.py": "def test_example():\n    password = \"synthetic-test-password\"\n    assert password\n",
+    ".gitignore": ".env\n.codex/\ncredentials/\n"
+  },
+  "expected": {
+    "defaultCapture": "captured",
+    "defaultScan": "not_scanned",
+    "strictFailure": "CHECKPOINT_CAPTURE_SECRET_DETECTED"
+  }
+}

--- a/tests/integration/reliability/test_checkpoint_outbound_policy_replay.py
+++ b/tests/integration/reliability/test_checkpoint_outbound_policy_replay.py
@@ -1,0 +1,266 @@
+"""Replay c7b23b45 through the worker binding, Git capture, and cold restore."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from temporalio.exceptions import ApplicationError
+from temporalio.testing import ActivityEnvironment
+
+from moonmind.config.settings import SecuritySettings, settings
+from moonmind.schemas.agent_runtime_models import ManagedRunRecord
+from moonmind.schemas.temporal_models import STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE
+from moonmind.workflows.executions.runtime_capabilities import (
+    resolve_runtime_execution_capabilities,
+)
+from moonmind.workflows.skills.artifact_store import FileArtifactStore
+from moonmind.workflows.temporal.activity_catalog import (
+    TemporalActivityCatalog,
+    build_default_activity_catalog,
+)
+from moonmind.workflows.temporal.activity_runtime import (
+    TemporalAgentRuntimeActivities,
+    build_activity_bindings,
+)
+from moonmind.workflows.temporal.runtime.checkpoint_restore import (
+    ManagedCheckpointRestoreService,
+)
+from moonmind.workflows.temporal.runtime.store import ManagedRunStore
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+    pytest.mark.reliability_journey,
+]
+
+
+class _Artifacts(FileArtifactStore):
+    """Local durable transport for the production capture/restore boundaries."""
+
+    @property
+    def _meta(self):
+        return {
+            item["artifact_ref"]: SimpleNamespace(**item)
+            for path in self.root.glob("*.meta.json")
+            for item in [json.loads(path.read_text())]
+        }
+
+    async def put_content_addressed_payload_complete(
+        self, *, payload, content_type, **kwargs
+    ):
+        ref = self.put_bytes(payload, content_type=content_type)
+        persisted = self.get_bytes(ref.artifact_ref)
+        return (
+            SimpleNamespace(
+                artifact_id=ref.artifact_ref,
+                sha256=hashlib.sha256(persisted).hexdigest(),
+                size_bytes=len(persisted),
+                content_type=ref.content_type,
+                encryption=SimpleNamespace(value="none"),
+                status="COMPLETE",
+            ),
+            False,
+        )
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+@pytest.mark.parametrize("configured_mode", [None, "false", "true"])
+@pytest.mark.parametrize(
+    "historical_request", [False, True], ids=["defaults", "historical"]
+)
+async def test_checkpoint_outbound_policy_capture_and_cold_restore(
+    tmp_path: Path, monkeypatch, configured_mode, historical_request: bool
+) -> None:
+    fixture = json.loads(
+        (
+            Path(__file__).parent
+            / "replays/checkpoint-outbound-policy-c7b23b45/manifest.json"
+        ).read_text()
+    )
+    if configured_mode is None:
+        monkeypatch.delenv("MOONMIND_HIGH_SECURITY_MODE", raising=False)
+    else:
+        monkeypatch.setenv("MOONMIND_HIGH_SECURITY_MODE", configured_mode)
+    monkeypatch.setattr(settings, "security", SecuritySettings(_env_file=None))
+
+    request = fixture["request"]
+    if not historical_request:
+        request.pop("capturePolicy")
+    capabilities = resolve_runtime_execution_capabilities("codex_cli")
+    # Keep the incident's serialized invocation, with today's admitted digest.
+    request["capabilityDigest"] = capabilities.capability_digest
+    identity = request["identity"]
+    agent_run_id = request["workspaceLocator"]["agentRunId"]
+    repo = tmp_path / "source" / agent_run_id / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    for name, content in fixture["files"].items():
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(repo, "add", ".")
+    _git(
+        repo,
+        "-c",
+        "user.name=test",
+        "-c",
+        "user.email=test@example.invalid",
+        "commit",
+        "-qm",
+        "source",
+    )
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "clone", "--bare", "-q", str(repo), str(origin)], check=True)
+    (repo / "assessment.json").write_text('{"verdict": "PARTIALLY_IMPLEMENTED"}\n')
+    (repo / "binary.bin").write_bytes(b"\x00\xff\x10")
+    for name in (".env", ".codex/auth.json", "credentials/runtime.json"):
+        path = repo / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("must stay outside the export\n")
+    before = _git(repo, "status", "--porcelain=v1", "--untracked-files=all")
+
+    runs = ManagedRunStore(tmp_path / "run-store")
+    now = datetime.now(UTC)
+    runs.save(
+        ManagedRunRecord(
+            runId=agent_run_id,
+            workflowId=f"{identity['workflowId']}:agent:{identity['logicalStepId']}",
+            ownerRunId=identity["runId"],
+            logicalStepId=identity["logicalStepId"],
+            executionOrdinal=identity["executionOrdinal"],
+            agentId="codex_cli",
+            runtimeId="codex_cli",
+            sessionId="replay-session",
+            status="completed",
+            startedAt=now,
+            finishedAt=now,
+            workspacePath=str(repo),
+        )
+    )
+    artifacts = _Artifacts(tmp_path / "artifacts")
+    activities = TemporalAgentRuntimeActivities(
+        run_store=runs, artifact_service=artifacts, client_adapter=object()
+    )
+    catalog = build_default_activity_catalog()
+    capture_catalog = TemporalActivityCatalog(
+        activities=tuple(
+            item
+            for item in catalog.activities
+            if item.activity_type == fixture["failedActivityType"]
+        ),
+        fleets=catalog.fleets,
+    )
+    binding = next(
+        item
+        for item in build_activity_bindings(
+            capture_catalog,
+            agent_runtime_activities=activities,
+            fleets=["agent_runtime"],
+        )
+        if item.activity_type == fixture["failedActivityType"]
+    )
+    environment = ActivityEnvironment()
+    if configured_mode == "true":
+        with pytest.raises(ApplicationError) as error:
+            await environment.run(binding.handler, request)
+        assert error.value.type == fixture["expected"]["strictFailure"]
+        assert error.value.non_retryable
+        assert not list(artifacts.root.iterdir())
+        assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before
+        return
+
+    captured = await environment.run(binding.handler, request)
+    assert captured["status"] == fixture["expected"]["defaultCapture"]
+    saved = artifacts.get_json(captured["savedWorkRef"])
+    assert saved["scan"]["disposition"] == fixture["expected"]["defaultScan"]
+    assert saved["scan"]["manifestScan"] == "not_scanned"
+    assert (
+        saved["scan"]["exportScan"]["exportDigest"]
+        == captured["workspace"]["archiveDigest"]
+    )
+    assert saved["scan"]["exportScan"]["coverage"] == "none"
+    assert _git(repo, "status", "--porcelain=v1", "--untracked-files=all") == before
+    assert await environment.run(binding.handler, request) == captured
+
+    # Cold restore must depend on persisted bytes, never the source process/tree.
+    checkpoint_ref = artifacts.put_bytes(
+        json.dumps(
+            {
+                "contentType": STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
+                "source": identity,
+                "boundary": request["boundary"],
+                "workspace": captured["workspace"],
+            }
+        ).encode(),
+        content_type=STEP_EXECUTION_CHECKPOINT_CONTENT_TYPE,
+    ).artifact_ref
+    shutil.rmtree(tmp_path / "source")
+    runs.delete(agent_run_id)
+    del activities, binding, artifacts
+    restored_artifacts = _Artifacts(tmp_path / "artifacts")
+    restore = ManagedCheckpointRestoreService(
+        authority_root=tmp_path / "restored",
+        artifact_store=restored_artifacts,
+        repository_source_root=origin,
+    )
+    workspace = captured["workspace"]
+    result = await restore.restore(
+        {
+            "schemaVersion": "v1",
+            "recoveryIdentity": {
+                **identity,
+                "workflowId": "recovery",
+                "runId": "recovery-run",
+                "executionOrdinal": 2,
+            },
+            "source": {
+                **identity,
+                "checkpointRef": checkpoint_ref,
+                "checkpointBoundary": request["boundary"],
+                "sourceWorkspaceLocator": captured["sourceWorkspaceLocator"],
+            },
+            "checkpoint": {
+                key: workspace[key]
+                for key in (
+                    "kind",
+                    "baseCommit",
+                    "archiveRef",
+                    "archiveDigest",
+                    "manifestRef",
+                    "manifestDigest",
+                )
+            },
+            "destination": {
+                "runtimeId": "codex_cli",
+                "agentRunId": "restored-run",
+                "repository": "MoonLadderStudios/MoonMind",
+                "relativePath": "repo",
+            },
+            "workspacePolicy": "restore_pre_execution",
+            "resumePhase": "rerun_failed_step",
+            "capabilitySetVersion": capabilities.capability_set_version,
+            "capabilityDigest": capabilities.capability_digest,
+            "idempotencyKey": "replay-restore",
+        }
+    )
+    assert result["status"] == "succeeded"
+    destination = tmp_path / "restored/restored-run/repo"
+    for name, contents in fixture["files"].items():
+        assert (destination / name).read_text() == contents
+    assert (
+        json.loads((destination / "assessment.json").read_text())["verdict"]
+        == "PARTIALLY_IMPLEMENTED"
+    )
+    assert (destination / "binary.bin").read_bytes() == b"\x00\xff\x10"
+    for name in (".env", ".codex", "credentials"):
+        assert not (destination / name).exists()

--- a/tests/unit/workflows/temporal/test_saved_work_capture.py
+++ b/tests/unit/workflows/temporal/test_saved_work_capture.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from moonmind.config.settings import SecuritySettings, settings
 from moonmind.schemas.agent_runtime_models import ManagedRunRecord
 from moonmind.schemas.managed_checkpoint_models import (
     ManagedWorkspaceCheckpointCaptureInput,
@@ -444,7 +445,11 @@ def test_retry_identity_rejects_conflicting_reused_complete() -> None:
 
 
 @pytest.mark.asyncio
-async def test_capture_commits_saved_work_with_truthful_outputs(tmp_path) -> None:
+@pytest.mark.parametrize("high_security_mode", [False, True])
+async def test_capture_commits_saved_work_with_truthful_outputs(
+    tmp_path, monkeypatch, high_security_mode
+) -> None:
+    monkeypatch.setattr(settings.security, "high_security_mode", high_security_mode)
     repo, activities, stored, digest = _capture_harness(
         tmp_path, {"tracked.txt": "checkpoint evidence\n"}
     )
@@ -456,6 +461,9 @@ async def test_capture_commits_saved_work_with_truthful_outputs(tmp_path) -> Non
     assert result["savedWorkDigest"].startswith("sha256:")
     saved_payload, _, _ = stored["saved_work_manifest"]
     saved_work = json.loads(saved_payload.decode("utf-8"))
+    assert saved_work["scan"]["disposition"] == (
+        "clean" if high_security_mode else "not_scanned"
+    )
     assert saved_work["captureId"] == "saved-work-1:capture"
     assert saved_work["contentDigest"] == result["workspace"]["archiveDigest"]
     outputs = {output["format"]: output for output in saved_work["outputs"]}
@@ -567,7 +575,8 @@ async def test_capture_fails_explicitly_on_unreadable_files(
 
 
 @pytest.mark.asyncio
-async def test_capture_blocks_secret_bearing_exports(tmp_path) -> None:
+async def test_capture_blocks_secret_bearing_exports(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(settings.security, "high_security_mode", True)
     _repo, activities, _stored, digest = _capture_harness(
         tmp_path, {"notes.txt": "api_key = supersecretvalue123\n"}
     )
@@ -575,6 +584,50 @@ async def test_capture_blocks_secret_bearing_exports(tmp_path) -> None:
         await activities.agent_runtime_capture_workspace_checkpoint(
             _request(digest=digest)
         )
+    assert not _stored
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("configured_mode", [None, "false", "true"])
+async def test_capture_uses_configured_outbound_policy(
+    tmp_path, monkeypatch, configured_mode
+) -> None:
+    if configured_mode is None:
+        monkeypatch.delenv("MOONMIND_HIGH_SECURITY_MODE", raising=False)
+    else:
+        monkeypatch.setenv("MOONMIND_HIGH_SECURITY_MODE", configured_mode)
+    monkeypatch.setattr(settings, "security", SecuritySettings(_env_file=None))
+    repo, activities, stored, digest = _capture_harness(
+        tmp_path,
+        {"auth.py": "token: str | None = None\n"},
+    )
+    # Runtime-issued credential paths stay excluded independently of strict mode.
+    (repo / ".codex").mkdir()
+    (repo / ".codex/auth.json").write_text('{"access_token": "test-only-value"}')
+    _git(repo, "add", ".codex/auth.json")
+    if configured_mode == "true":
+        with pytest.raises(Exception, match="secret scanning"):
+            await activities.agent_runtime_capture_workspace_checkpoint(
+                _request(digest=digest)
+            )
+        assert not stored
+        return
+
+    result = await activities.agent_runtime_capture_workspace_checkpoint(
+        _request(digest=digest)
+    )
+    assert result["status"] == "captured"
+    saved_work = json.loads(stored["saved_work_manifest"][0])
+    assert saved_work["scan"]["disposition"] == "not_scanned"
+    assert saved_work["scan"]["manifestScan"] == "not_scanned"
+    assert saved_work["scan"]["exportScan"]["coverage"] == "none"
+    assert saved_work["scan"]["exportScan"]["limitations"]
+    assert saved_work["scan"]["exportScan"]["exportDigest"] == (
+        result["workspace"]["archiveDigest"]
+    )
+    assert {"path": ".codex/auth.json", "reason": "sensitive-path-policy"} in (
+        saved_work["exclusions"]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Workflow `mm:c7b23b45-a7ac-42cb-9ed9-51b1d4a912a7` completed its assessment step, then failed twice while checkpointing an unchanged repository. Capture forced strict secret scanning even though the deployed outbound policy was disabled, so ordinary source syntax and synthetic security fixtures triggered `CHECKPOINT_CAPTURE_SECRET_DETECTED`.

Resolve the existing `MOONMIND_HIGH_SECURITY_MODE` setting once at the capture Activity and apply it to archive and metadata scanning. Disabled scans record `not_scanned` with no coverage claim; enabled scans remain fail-closed. Credential-path exclusions, workspace containment, immutable capture reuse, and activity request shapes are preserved.

Validation:

- 64 targeted unit tests and 7 reliability tests passed, including the historical activity request through the worker binding, durable artifacts, and cold restore after source deletion.
- 28 checks passed in the Linux/Python 3.12 test container.
- The exact source revision from the incident captured 2,755 entries successfully without modifying the checkout.
- Full-history replay fails identically on the untouched base and this candidate at event 194, before checkpoint capture, due to an existing workflow-properties/search-attributes mismatch. This change does not modify workflow code.

The minimized incident fixture runs in the required reliability CI suite.
