### PR TITLE
Fix provider-profile preset race breaking frontend builds

### DIFF
--- a/frontend/src/components/settings/ProviderProfilesManager.test.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import type { ProviderProfile } from './ProviderProfilesManager';
 import {
@@ -2126,7 +2126,16 @@ describe('MoonLadderStudios/MoonMind#3820 guided provider-profile creation', () 
     expect(screen.getAllByText('Not used')).toHaveLength(2);
   });
 
-  it('creates a backend-preset profile and opens the one-way OpenAI API-key drawer', async () => {
+  it.each([
+    'in order',
+    'late OAuth preset',
+    'late OAuth error',
+  ])('creates a backend-preset profile and opens the one-way OpenAI API-key drawer (%s)', async (responseOrder) => {
+    let finishOAuthPreset!: () => void;
+    const oauthPresetPending = new Promise<void>((resolve) => {
+      finishOAuthPreset = resolve;
+    });
+    let oauthPresetSignal: AbortSignal | null | undefined;
     const savedProfile = {
       profile_id: 'codex-guided-key',
       runtime_id: 'codex_cli',
@@ -2146,6 +2155,22 @@ describe('MoonLadderStudios/MoonMind#3820 guided provider-profile creation', () 
     const fetchSpy = vi.spyOn(window, 'fetch').mockImplementation(async (input, init) => {
       const url = String(input);
       const creationResponse = openAiCreationResponse(url);
+      if (
+        responseOrder !== 'in order' &&
+        url.includes('/creation-preset?') &&
+        url.includes('authentication_method=oauth')
+      ) {
+        oauthPresetSignal = init?.signal;
+        return {
+          ok: responseOrder !== 'late OAuth error',
+          json: async () => {
+            await oauthPresetPending;
+            return responseOrder === 'late OAuth error'
+              ? { detail: 'Superseded OAuth preset failed.' }
+              : creationResponse!.json();
+          },
+        } as Response;
+      }
       if (creationResponse) return creationResponse;
       if (url === '/api/v1/provider-profiles') {
         const payload = JSON.parse(String(init?.body));
@@ -2170,6 +2195,12 @@ describe('MoonLadderStudios/MoonMind#3820 guided provider-profile creation', () 
     });
     await selectOpenAiApiKeyCreation();
     await screen.findByText(/Backend preset provider-profile-creation-v1 loaded/);
+    if (responseOrder !== 'in order') {
+      // Decode the superseded request after the selected API-key preset loads.
+      expect(oauthPresetSignal?.aborted).toBe(true);
+      await act(async () => finishOAuthPreset());
+      expect(screen.queryByText('Superseded OAuth preset failed.')).toBeNull();
+    }
     fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
     expect(

--- a/frontend/src/components/settings/ProviderProfilesManager.tsx
+++ b/frontend/src/components/settings/ProviderProfilesManager.tsx
@@ -1479,6 +1479,9 @@ export function ProviderProfilesManager({
         return payload as ProviderProfileCreationPreset;
       })
       .then((preset) => {
+        // A superseded request may finish decoding after cancellation. Only
+        // the active request owns the preset and its form updates.
+        if (controller.signal.aborted) return;
         if (
           !preset ||
           typeof preset.version !== 'string' ||
@@ -1506,7 +1509,7 @@ export function ProviderProfilesManager({
         }
       })
       .catch((error: unknown) => {
-        if (error instanceof DOMException && error.name === 'AbortError') return;
+        if (controller.signal.aborted) return;
         setCreationPresetError(
           error instanceof Error
             ? error.message


### PR DESCRIPTION
## Related issue

Fixes the failure in [Release / Build App Image run 34680695494](https://github.com/MoonLadderStudios/MoonMind/actions/runs/34680695494).

## Summary

Switching from OAuth to API-key profile creation could let a canceled OAuth preset response overwrite the active API-key preset. The resulting save payload caused the enrollment test to fail before the AMD64 image build. Ignore both success and error results from canceled preset requests.

The existing creation test now covers normal response order, a late OAuth preset, and a late OAuth error. Both late-response cases fail before the fix; the late-success case reproduces the missing enrollment dialog reported by CI.

## Test Plan

```bash
npm run ui:test -- frontend/src/components/settings/ProviderProfilesManager.test.tsx
npm run ui:typecheck
npm run ui:lint
npm run ui:test
npm run contracts:check
npm run ui:build:check
MOONMIND_BROWSER_ENGINES=chromium npm run ui:test:browser
```

## Demo

N/A — asynchronous request handling; no visual changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [ ] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Frontend tests added / updated
- [ ] Workflow boundary tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Limited to provider-profile preset request ownership. Canceled requests cannot replace the selected preset or surface obsolete errors. Active-request validation and credential enrollment continue through the existing paths.

## Coverage notes

Controlled response ordering exercises preset loading, profile-save payload validation, enrollment opening, and plaintext clearing on cancellation. The repository impact selector requires frontend static checks and Chromium; it does not select backend or integration suites.

## Changelog

Preserve the selected provider-profile creation preset when an earlier request finishes late.
