### PR TITLE
Fix Omnigent session ownership across capacity readmission

### DIFF
--- a/docs/Omnigent/CanonicalTurnCommandBoundary.md
+++ b/docs/Omnigent/CanonicalTurnCommandBoundary.md
@@ -194,6 +194,23 @@ evidence remain readable after provider, host, credential, and workspace cleanup
 
 ## Continuation versus cleanup
 
+An admission epoch owns its runtime binding, canonical session, turn command,
+and cleanup authority together. Activity redelivery within that epoch preserves
+those identities. When the workflow re-admits after lost capacity, its existing
+`admittedProviderCapacity.admissionEpoch` selects a new session and command; the
+completed cleanup of the previous attempt stays terminal. The request, Step
+Execution, execution plan, selected profile, and workspace retain their original
+authority. No runtime- or error-specific recovery bypass may reopen cleanup.
+
+Absent/zero epochs and the first admission preserve the historical session and
+command identities. Later epochs derive distinct deterministic identities from
+the same workflow-owned ticket already used for runtime bindings. Delivery
+uses an existing binding's provider attachment when present, preserving the
+session and command of an in-flight execution created before epoch scoping.
+Turn rejection diagnostics retain the bounded reason codes, including
+`cleanup_complete`, so
+operators can distinguish lost runtime authority from changed execution policy.
+
 An accepted turn advances the cleanup generation before any provider mutation.
 The race is therefore resolved in one direction:
 

--- a/docs/Omnigent/CanonicalTurnCommandBoundary.md
+++ b/docs/Omnigent/CanonicalTurnCommandBoundary.md
@@ -205,8 +205,12 @@ authority. No runtime- or error-specific recovery bypass may reopen cleanup.
 Absent/zero epochs and the first admission preserve the historical session and
 command identities. Later epochs derive distinct deterministic identities from
 the same workflow-owned ticket already used for runtime bindings. Delivery
-uses an existing binding's provider attachment when present, preserving the
-session and command of an in-flight execution created before epoch scoping.
+uses an existing binding's provider attachment when present. Before bootstrapping
+or cleaning up an unattached session, it resolves persisted canonical authority:
+an existing scoped session retains its identity; otherwise a legacy session with
+incomplete cleanup retains its original command, including delivery-unknown
+fencing. This preserves in-flight executions created before epoch scoping even
+when a worker stopped before recording its runtime binding or provider attachment.
 Turn rejection diagnostics retain the bounded reason codes, including
 `cleanup_complete`, so
 operators can distinguish lost runtime authority from changed execution policy.

--- a/moonmind/omnigent/control_plane/identities.py
+++ b/moonmind/omnigent/control_plane/identities.py
@@ -13,10 +13,24 @@ EGRESS_CLEANUP_AUTHORITY_VERSION = 1
 
 
 def canonical_omnigent_session_id(
-    *, workflow_id: str, step_execution_id: str, agent_run_id: str
+    *,
+    workflow_id: str,
+    step_execution_id: str,
+    agent_run_id: str,
+    admission_epoch: int = 0,
 ) -> str:
+    # Preserve historical and first-admission identities. Re-admission owns new
+    # resources; it must never reopen the prior attempt's completed cleanup.
+    parts: list[str | int] = [
+        "omnigent-session/v1",
+        workflow_id,
+        step_execution_id,
+        agent_run_id,
+    ]
+    if admission_epoch > 1:
+        parts.extend(["admission", admission_epoch])
     authority = json.dumps(
-        ["omnigent-session/v1", workflow_id, step_execution_id, agent_run_id],
+        parts,
         separators=(",", ":"),
     ).encode("utf-8")
     return "oms_" + hashlib.sha256(authority).hexdigest()[:40]

--- a/moonmind/omnigent/control_plane/turn_commands.py
+++ b/moonmind/omnigent/control_plane/turn_commands.py
@@ -78,6 +78,7 @@ class CanonicalSessionBootstrap:
     source_idempotency_key: str
     execution_plan_ref: str | None = None
     owner_principal: str | None = None
+    admission_epoch: int = 0
 
 
 def _bootstrap_metadata(
@@ -237,6 +238,7 @@ class CanonicalTurnCommandService:
                 workflow_id=workflow_id,
                 step_execution_id=bootstrap.step_execution_id,
                 agent_run_id=bootstrap.agent_run_id,
+                admission_epoch=bootstrap.admission_epoch,
             )
             existing_session = await repos.sessions.get(bootstrap_session_id)
             if existing_session is not None:

--- a/moonmind/omnigent/control_plane/turn_commands.py
+++ b/moonmind/omnigent/control_plane/turn_commands.py
@@ -144,6 +144,43 @@ class CanonicalTurnCommandService:
         # not import or construct a SQL-backed repository implementation.
         self._store = store
 
+    async def resolve_admission_session_id(
+        self,
+        *,
+        workflow_id: str,
+        step_execution_id: str,
+        agent_run_id: str,
+        admission_epoch: int,
+    ) -> str:
+        """Retain persisted in-flight authority across admission identity cutover.
+
+        A legacy command can exist before either a runtime binding or provider
+        attachment. Until its cleanup completes, a later-epoch redelivery must
+        use that session and its original command, including delivery-unknown
+        fencing. An existing scoped session always retains its own identity.
+        Claim still validates and fences the selected session transactionally.
+        """
+
+        identity = dict(
+            workflow_id=workflow_id,
+            step_execution_id=step_execution_id,
+            agent_run_id=agent_run_id,
+        )
+        scoped_id = canonical_omnigent_session_id(
+            **identity, admission_epoch=admission_epoch
+        )
+        if admission_epoch <= 1:
+            return scoped_id
+        async with self._store.transaction() as repos:
+            if await repos.sessions.get(scoped_id) is not None:
+                return scoped_id
+            legacy_id = canonical_omnigent_session_id(**identity)
+            if await repos.sessions.get(legacy_id) is not None:
+                cleanup = await repos.cleanup.get(legacy_id)
+                if cleanup is None or cleanup.state != CLEANUP_STATE_COMPLETE:
+                    return legacy_id
+        return scoped_id
+
     async def claim(
         self,
         *,

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -29,6 +29,7 @@ from moonmind.omnigent.harness_platform.failures import (
     HarnessPlatformFailure,
 )
 from moonmind.omnigent.realizers.turn_delivery import (
+    admission_epoch,
     deliver_canonical_turn,
     execution_identity as _execution_identity,
 )
@@ -64,21 +65,6 @@ def _cleanup_outcome_label(*, cancelled: bool, released: bool) -> str:
     if cancelled:
         return "cancelled_clean" if released else "cancelled_incomplete"
     return "completed_clean" if released else "leaked"
-
-
-def _admission_epoch(request: AgentExecutionRequest) -> int:
-    """Return the admission attempt this request was dispatched for.
-
-    A re-admission after lost capacity releases the previous attempt's host,
-    credentials and provider lease, so it must not resume that attempt's
-    terminally cleaned aggregate. The workflow already stamps its monotonic
-    epoch on the capacity ticket; the attempt identity is derived from it here
-    so the pre-admission read and the allocation name the same one.
-    """
-
-    return int(
-        getattr(request.admitted_provider_capacity, "admission_epoch", 0) or 0
-    )
 
 
 def _carry_host_logs(host_evidence: Any, prior_host_evidence: Any) -> Any:
@@ -208,7 +194,7 @@ class GenericOmnigentHostRealizer:
             stable_binding_id(
                 execution_plan_ref=plan.planRef,
                 idempotency_key=request.idempotency_key,
-                admission_epoch=_admission_epoch(request),
+                admission_epoch=admission_epoch(request),
             )
         )
         if completed is not None and completed.state is RuntimeBindingState.cleaned:
@@ -220,6 +206,9 @@ class GenericOmnigentHostRealizer:
             plan=plan,
             command_type="execute_admitted_plan",
             operation=lambda: self._execute_lifecycle(request, plan),
+            session_id=(
+                await self._recovered_session_id(completed) if completed else None
+            ),
         )
 
     async def _execute_lifecycle(
@@ -231,7 +220,7 @@ class GenericOmnigentHostRealizer:
             stable_binding_id(
                 execution_plan_ref=plan.planRef,
                 idempotency_key=request.idempotency_key,
-                admission_epoch=_admission_epoch(request),
+                admission_epoch=admission_epoch(request),
             )
         )
         if prior is not None and prior.state is RuntimeBindingState.cleaned:
@@ -309,7 +298,7 @@ class GenericOmnigentHostRealizer:
                 execution_plan_ref=plan.planRef,
                 idempotency_key=request.idempotency_key,
                 provider_leases=provider_authority,
-                admission_epoch=_admission_epoch(request),
+                admission_epoch=admission_epoch(request),
                 initial_phase_results=initial_phases,
             )
             if binding.state is RuntimeBindingState.cleaned:
@@ -1004,7 +993,8 @@ class GenericOmnigentHostRealizer:
             return binding, host_lease
 
         cleanup_claim = await self._claim_canonical_cleanup(
-            self._canonical_session_id(request)
+            await self._recovered_session_id(binding)
+            or self._canonical_session_id(request)
         )
         if cleanup_claim is _CLEANUP_NOT_OWNED:
             # Another owner holds this session's cleanup, or an admitted turn
@@ -1139,14 +1129,15 @@ class GenericOmnigentHostRealizer:
             workflow_id=workflow_id,
             step_execution_id=step_execution_id,
             agent_run_id=request.correlation_id,
+            admission_epoch=admission_epoch(request),
         )
 
     async def _recovered_session_id(self, binding: StableRuntimeBinding) -> str:
         """Resolve the canonical session a recovery scan is about to clean up.
 
         Recovery has no admitted request, so it resolves the session through the
-        provider session the turn boundary attached to it. A binding with no
-        attached provider session never reached a canonical turn.
+        provider session the turn boundary attached to it. Before attachment,
+        in-band cleanup uses the request's deterministic admission identity.
         """
 
         if self._cleanup_authority is None or not binding.omnigentSessionId:
@@ -1259,6 +1250,7 @@ class GenericOmnigentHostRealizer:
                 self._turn_commands, request=turn_request, plan=plan,
                 command_type="terminal_contract_continuation", operation=deliver,
                 recorded_result=recorded_result,
+                session_id=await self._recovered_session_id(sink.binding),
             )
 
         async def complete_attempt():

--- a/moonmind/omnigent/realizers/generic_host.py
+++ b/moonmind/omnigent/realizers/generic_host.py
@@ -32,6 +32,7 @@ from moonmind.omnigent.realizers.turn_delivery import (
     admission_epoch,
     deliver_canonical_turn,
     execution_identity as _execution_identity,
+    resolve_admission_session_id,
 )
 from moonmind.omnigent.runtime_bindings import (
     RuntimeBindingSessionAuthoritySink,
@@ -994,7 +995,7 @@ class GenericOmnigentHostRealizer:
 
         cleanup_claim = await self._claim_canonical_cleanup(
             await self._recovered_session_id(binding)
-            or self._canonical_session_id(request)
+            or await resolve_admission_session_id(self._turn_commands, request)
         )
         if cleanup_claim is _CLEANUP_NOT_OWNED:
             # Another owner holds this session's cleanup, or an admitted turn
@@ -1117,27 +1118,12 @@ class GenericOmnigentHostRealizer:
             )
         return evidence
 
-    def _canonical_session_id(self, request: AgentExecutionRequest) -> str:
-        """Return the canonical session this realizer's turn bootstrapped."""
-
-        from moonmind.omnigent.control_plane.identities import (
-            canonical_omnigent_session_id,
-        )
-
-        workflow_id, step_execution_id = _execution_identity(request)
-        return canonical_omnigent_session_id(
-            workflow_id=workflow_id,
-            step_execution_id=step_execution_id,
-            agent_run_id=request.correlation_id,
-            admission_epoch=admission_epoch(request),
-        )
-
     async def _recovered_session_id(self, binding: StableRuntimeBinding) -> str:
         """Resolve the canonical session a recovery scan is about to clean up.
 
         Recovery has no admitted request, so it resolves the session through the
         provider session the turn boundary attached to it. Before attachment,
-        in-band cleanup uses the request's deterministic admission identity.
+        in-band cleanup resolves persisted canonical admission authority.
         """
 
         if self._cleanup_authority is None or not binding.omnigentSessionId:

--- a/moonmind/omnigent/realizers/turn_delivery.py
+++ b/moonmind/omnigent/realizers/turn_delivery.py
@@ -65,6 +65,23 @@ def execution_identity(request: AgentExecutionRequest) -> tuple[str, str]:
     return request.correlation_id, request.correlation_id
 
 
+async def resolve_admission_session_id(
+    turn_commands: Any, request: AgentExecutionRequest
+) -> str:
+    """Use the same persisted admission authority for delivery and cleanup."""
+
+    workflow_id, step_execution_id = execution_identity(request)
+    identity = dict(
+        workflow_id=workflow_id,
+        step_execution_id=step_execution_id,
+        agent_run_id=request.correlation_id,
+        admission_epoch=admission_epoch(request),
+    )
+    if turn_commands is None or admission_epoch(request) <= 1:
+        return canonical_omnigent_session_id(**identity)
+    return await turn_commands.resolve_admission_session_id(**identity)
+
+
 def _canonical_turn_lineage(request: AgentExecutionRequest) -> Any | None:
     """Return the controller-attested lineage this launch carries, if any."""
 
@@ -157,9 +174,9 @@ async def deliver_canonical_turn(
     claims, owns, fences cleanup, and settles through this same boundary rather
     than submitting outside it.
 
-    ``session_id`` is resolved from an existing runtime binding's provider
-    attachment. It preserves persisted session authority across Activity
-    redelivery, including sessions created before admission epochs were scoped.
+    ``session_id`` can name an existing runtime binding's provider attachment.
+    Otherwise persisted canonical authority is resolved before bootstrap, so
+    redelivery preserves legacy commands even before provider attachment.
 
     ``turn_commands`` may be ``None`` in unit harnesses that do not wire the
     control plane; the operation then runs unwrapped. A rejected admission
@@ -174,15 +191,18 @@ async def deliver_canonical_turn(
 
     turn_source = canonical_turn_source(request)
     workflow_id, step_execution_id = execution_identity(request)
+    admission_session_id = session_id or await resolve_admission_session_id(
+        turn_commands, request
+    )
     idempotency_key = canonical_turn_idempotency_key(request)
-    if session_id == canonical_omnigent_session_id(
+    legacy_session = admission_session_id == canonical_omnigent_session_id(
         workflow_id=workflow_id,
         step_execution_id=step_execution_id,
         agent_run_id=request.correlation_id,
-    ):
-        # An in-flight binding may already own a provider attachment created
-        # before admission-scoped identities. Keep its original command too;
-        # only a new admission without that binding bootstraps new authority.
+    )
+    if legacy_session:
+        # A retained legacy session keeps its original command even when the
+        # worker stopped before recording its binding or provider attachment.
         idempotency_key = request.idempotency_key
     execution_plan_ref = getattr(plan, "planRef", None) if plan is not None else None
     try:
@@ -203,7 +223,9 @@ async def deliver_canonical_turn(
                 agent_run_id=request.correlation_id,
                 source_idempotency_key=idempotency_key,
                 execution_plan_ref=execution_plan_ref,
-                admission_epoch=admission_epoch(request),
+                # Request-derived recovery stays on the bootstrap path so its
+                # immutable plan, workflow, step and run checks still apply.
+                admission_epoch=0 if legacy_session else admission_epoch(request),
             ),
             requested_authority=(
                 canonical_turn_authority(request, plan) if plan is not None else None
@@ -298,4 +320,5 @@ __all__ = [
     "deliver_canonical_turn",
     "execution_identity",
     "instruction_digest",
+    "resolve_admission_session_id",
 ]

--- a/moonmind/omnigent/realizers/turn_delivery.py
+++ b/moonmind/omnigent/realizers/turn_delivery.py
@@ -16,6 +16,7 @@ import logging
 from typing import Any, Awaitable, Callable
 
 from moonmind.omnigent.control_plane import metrics as control_plane_metrics
+from moonmind.omnigent.control_plane.identities import canonical_omnigent_session_id
 from moonmind.omnigent.control_plane.records import compute_digest
 from moonmind.omnigent.control_plane.turn_admission import (
     CanonicalTurnAdmissionRejected,
@@ -35,6 +36,22 @@ from moonmind.schemas.agent_runtime_models import AgentExecutionRequest, AgentRu
 
 
 logger = logging.getLogger(__name__)
+
+
+def admission_epoch(request: AgentExecutionRequest) -> int:
+    """Use the workflow's admitted attempt for binding, turn and cleanup identity."""
+
+    capacity = request.admitted_provider_capacity
+    return capacity.admission_epoch if capacity is not None else 0
+
+
+def canonical_turn_idempotency_key(request: AgentExecutionRequest) -> str:
+    """Keep redelivery idempotent without sharing commands across re-admissions."""
+
+    epoch = admission_epoch(request)
+    if epoch <= 1:
+        return request.idempotency_key
+    return "omnigent-admission:" + compute_digest([request.idempotency_key, epoch])
 
 
 def execution_identity(request: AgentExecutionRequest) -> tuple[str, str]:
@@ -126,6 +143,7 @@ async def deliver_canonical_turn(
     command_type: str,
     operation: Callable[[], Awaitable[AgentRunResult]],
     recorded_result: AgentRunResult | None = None,
+    session_id: str | None = None,
 ) -> AgentRunResult:
     """Run ``operation`` inside one claimed, fenced canonical turn command.
 
@@ -138,6 +156,10 @@ async def deliver_canonical_turn(
     immutable authority to assert, but it still mutates the provider, so it
     claims, owns, fences cleanup, and settles through this same boundary rather
     than submitting outside it.
+
+    ``session_id`` is resolved from an existing runtime binding's provider
+    attachment. It preserves persisted session authority across Activity
+    redelivery, including sessions created before admission epochs were scoped.
 
     ``turn_commands`` may be ``None`` in unit harnesses that do not wire the
     control plane; the operation then runs unwrapped. A rejected admission
@@ -152,15 +174,26 @@ async def deliver_canonical_turn(
 
     turn_source = canonical_turn_source(request)
     workflow_id, step_execution_id = execution_identity(request)
+    idempotency_key = canonical_turn_idempotency_key(request)
+    if session_id == canonical_omnigent_session_id(
+        workflow_id=workflow_id,
+        step_execution_id=step_execution_id,
+        agent_run_id=request.correlation_id,
+    ):
+        # An in-flight binding may already own a provider attachment created
+        # before admission-scoped identities. Keep its original command too;
+        # only a new admission without that binding bootstraps new authority.
+        idempotency_key = request.idempotency_key
     execution_plan_ref = getattr(plan, "planRef", None) if plan is not None else None
     try:
         command_claim = await turn_commands.claim(
             workflow_id=workflow_id,
             provider_session_ref="",
             chat_binding_id=None,
+            session_id=session_id,
             command_type=command_type,
             turn_source=turn_source,
-            idempotency_key=request.idempotency_key,
+            idempotency_key=idempotency_key,
             payload_digest=execution_plan_ref or instruction_digest(request),
             step_execution_id=step_execution_id,
             base_step_execution_id=canonical_turn_base_step_execution_id(request),
@@ -168,8 +201,9 @@ async def deliver_canonical_turn(
                 provider="omnigent",
                 step_execution_id=step_execution_id,
                 agent_run_id=request.correlation_id,
-                source_idempotency_key=request.idempotency_key,
+                source_idempotency_key=idempotency_key,
                 execution_plan_ref=execution_plan_ref,
+                admission_epoch=admission_epoch(request),
             ),
             requested_authority=(
                 canonical_turn_authority(request, plan) if plan is not None else None
@@ -181,7 +215,8 @@ async def deliver_canonical_turn(
         )
         raise HarnessPlatformError(
             "canonical turn admission returned "
-            f"{exc.decision.value}; the prior Omnigent session was not mutated",
+            f"{exc.decision.value} ({', '.join(exc.outcome.reason_codes)}); "
+            "the prior Omnigent session was not mutated",
             code=HarnessPlatformFailure.OMNIGENT_RUNTIME_BINDING_CONFLICT,
         ) from exc
     except RemediationAuthorityBroadenedError:
@@ -213,7 +248,7 @@ async def deliver_canonical_turn(
         try:
             await turn_commands.settle(
                 workflow_id=workflow_id,
-                idempotency_key=request.idempotency_key,
+                idempotency_key=idempotency_key,
                 outcome=ControlPlaneOutcome.DELIVERY_UNKNOWN,
             )
         except Exception:
@@ -236,7 +271,7 @@ async def deliver_canonical_turn(
         )
         await turn_commands.settle(
             workflow_id=workflow_id,
-            idempotency_key=request.idempotency_key,
+            idempotency_key=idempotency_key,
             outcome=ControlPlaneOutcome.APPLIED,
             provider_receipt_id=provider_session_ref or None,
             result_ref=str((result.metadata or {}).get("externalStateRef") or "")
@@ -256,6 +291,8 @@ async def deliver_canonical_turn(
 
 
 __all__ = [
+    "admission_epoch",
+    "canonical_turn_idempotency_key",
     "canonical_turn_base_step_execution_id",
     "canonical_turn_source",
     "deliver_canonical_turn",

--- a/tests/integration/omnigent/test_capacity_readmission_turn.py
+++ b/tests/integration/omnigent/test_capacity_readmission_turn.py
@@ -1,0 +1,30 @@
+"""Run the escaped admission/cleanup journey with real PostgreSQL authority."""
+
+import pytest
+
+from api_service.db.models import OmnigentExecutionPlanRecord
+from tests.unit.omnigent.test_capacity_readmission_turn import (
+    replay_capacity_readmission,
+)
+from tests.unit.omnigent.test_generic_platform_production_services import _plan
+
+pytestmark = [pytest.mark.integration, pytest.mark.integration_ci, pytest.mark.asyncio]
+
+
+async def test_capacity_readmission_turn_postgres(pg_store, monkeypatch):
+    plan = _plan("opencode-go/model")
+    async with pg_store._session_factory() as session:
+        session.add(
+            OmnigentExecutionPlanRecord(
+                plan_ref=plan.planRef,
+                schema_version=plan.schemaVersion,
+                payload_json=plan.payload.model_dump(mode="json"),
+                harness_id=plan.payload.harnessId,
+                harness_implementation_ref=plan.payload.harnessImplementationRef,
+                host_class_ref=plan.payload.hostClassRef,
+                launch_policy_ref=plan.payload.launchPolicyRef,
+                execution_realizer_ref=plan.payload.executionRealizerRef,
+            )
+        )
+        await session.commit()
+    await replay_capacity_readmission(pg_store, monkeypatch)

--- a/tests/integration/omnigent/test_capacity_readmission_turn_postgres.py
+++ b/tests/integration/omnigent/test_capacity_readmission_turn_postgres.py
@@ -5,14 +5,32 @@ import pytest
 from api_service.db.models import OmnigentExecutionPlanRecord
 from tests.unit.omnigent.test_capacity_readmission_turn import (
     replay_capacity_readmission,
+    replay_unattached_legacy_claim,
 )
-from tests.unit.omnigent.test_generic_platform_production_services import _plan
+from tests.unit.omnigent.test_generic_platform_production_services import (
+    _exact_plan,
+    _plan,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.integration_ci, pytest.mark.asyncio]
 
 
 async def test_capacity_readmission_turn_postgres(pg_store, monkeypatch):
     plan = _plan("opencode-go/model")
+    await seed_plan(pg_store, plan)
+    await replay_capacity_readmission(pg_store, monkeypatch)
+
+
+@pytest.mark.parametrize("delivery_unknown", [False, True])
+@pytest.mark.parametrize("binding_exists", [False, True])
+async def test_legacy_claim_before_attachment_postgres(
+    pg_store, delivery_unknown, binding_exists
+):
+    await seed_plan(pg_store, _exact_plan("opencode-go/model"))
+    await replay_unattached_legacy_claim(pg_store, delivery_unknown, binding_exists)
+
+
+async def seed_plan(pg_store, plan):
     async with pg_store._session_factory() as session:
         session.add(
             OmnigentExecutionPlanRecord(
@@ -27,4 +45,3 @@ async def test_capacity_readmission_turn_postgres(pg_store, monkeypatch):
             )
         )
         await session.commit()
-    await replay_capacity_readmission(pg_store, monkeypatch)

--- a/tests/integration/reliability/replays/omnigent-capacity-readmission-turn/manifest.json
+++ b/tests/integration/reliability/replays/omnigent-capacity-readmission-turn/manifest.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "escaped-failure-replay/v1",
+  "incidentWorkflowId": "mm:07161650-68db-4325-8583-c6711e2cb8bc-2026-09-12T18:25:00Z",
+  "activityType": "integration.omnigent.profile_bound_execute",
+  "epochs": [1, 2],
+  "capacityFailure": {
+    "code": "OMNIGENT_HOST_CAPACITY_UNAVAILABLE",
+    "message": "Waiting for machine resource capacity; missing_condition=machine_cpu; utilization_percent={'cpu': 89, 'memory': 73, 'processes': 11, 'temporaryStorage': 6}."
+  },
+  "observedRetryFailure": "canonical turn admission returned cold_restore",
+  "recordedSession": {"providerSessionRef": null, "runtimeBindingRef": null, "cleanupState": "complete"},
+  "expected": "Re-admission owns a distinct session, command, runtime binding and cleanup aggregate; same-epoch redelivery reuses terminal evidence."
+}

--- a/tests/unit/omnigent/test_capacity_readmission_turn.py
+++ b/tests/unit/omnigent/test_capacity_readmission_turn.py
@@ -1,0 +1,269 @@
+"""Replay capacity rejection through the real turn, lifecycle and cleanup owners."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from temporalio.testing import ActivityEnvironment
+
+from moonmind.omnigent.control_plane import OmnigentControlPlaneStore
+from moonmind.omnigent.control_plane.cleanup_authority import CanonicalCleanupAuthority
+from moonmind.omnigent.control_plane.identities import canonical_omnigent_session_id
+from moonmind.omnigent.control_plane.turn_commands import (
+    CanonicalSessionBootstrap,
+    CanonicalTurnCommandService,
+)
+from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
+from moonmind.omnigent.realizers.registry import OmnigentExecutionRealizerRegistry
+from moonmind.omnigent.runtime_bindings import RuntimeBindingState, stable_binding_id
+from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
+from moonmind.workflows.temporal.activities.omnigent_activities import (
+    omnigent_profile_bound_execute_activity,
+)
+from tests.unit.omnigent.test_canonical_turn_routing import (  # noqa: F401
+    _engine,
+    session_factory,
+)
+from tests.unit.omnigent.test_generic_platform_production_services import (
+    _exact_plan,
+    _generic_publication_harness,
+    _plan,
+    _prime_attested_host_binding,
+)
+
+
+REPLAY = json.loads(
+    (
+        Path(__file__).parents[2] / "integration/reliability/replays/"
+        "omnigent-capacity-readmission-turn/manifest.json"
+    ).read_text()
+)
+
+
+def admitted_request(request, plan, epoch):
+    payload = request.model_dump(by_alias=True, mode="json")
+    payload["omnigentExecutionPlan"] = {
+        "planRef": plan.planRef,
+        "planDigest": "sha256:" + plan.planRef.rsplit(":", 1)[-1],
+        "planArtifactRef": "artifact:plan",
+        "taskInputSnapshotRef": "artifact:input",
+        "taskInputSnapshotDigest": "sha256:" + "a" * 64,
+    }
+    payload["admittedProviderCapacity"] = {
+        "schemaVersion": "admitted-provider-capacity/v2",
+        "leaseOwnerId": "agent-run-1",
+        "profiles": [
+            {
+                "providerProfileRef": "opencode-go-primary",
+                "providerRuntimeId": "opencode",
+                "capacityScopeRef": "provider-profile:opencode-go-primary",
+                "credentialGeneration": 4,
+            }
+        ],
+        "executionPlanRef": plan.planRef,
+        "agentRunWorkflowId": "agent-run-1",
+        "agentRunRunId": "run-1",
+        "stepExecutionId": request.correlation_id,
+        "idempotencyKey": request.idempotency_key,
+        "admissionEpoch": epoch,
+    }
+    return AgentExecutionRequest.model_validate(payload)
+
+
+async def replay_capacity_readmission(store, monkeypatch):
+    """Only external host/provider services are simulated; owners persist real state."""
+
+    harness = await _generic_publication_harness({})
+    harness.publish_request = harness.publish_request.model_copy(
+        update={
+            "parameters": {**harness.publish_request.parameters, "publishMode": "none"},
+        }
+    )
+    realizer = harness.realizer
+    realizer._turn_commands = CanonicalTurnCommandService(store)
+    realizer._cleanup_authority = CanonicalCleanupAuthority(store)
+    plan = _plan("opencode-go/model")
+    registry = OmnigentExecutionRealizerRegistry()
+    registry.register(realizer)
+
+    class PlanStore:
+        async def load(self, ref):
+            assert ref == plan.planRef
+            return plan
+
+    monkeypatch.setattr(
+        "moonmind.omnigent.harness_platform.stores.DbExecutionPlanStore",
+        lambda _session_factory: PlanStore(),
+    )
+    monkeypatch.setattr(
+        "moonmind.omnigent.realizers.registry.get_default_registry",
+        lambda: registry,
+    )
+
+    async def execute(request):
+        return await ActivityEnvironment().run(
+            omnigent_profile_bound_execute_activity, request
+        )
+
+    acquire = harness.host_leases.acquire
+
+    async def reject_capacity(**kwargs):
+        raise HarnessPlatformError(
+            REPLAY["capacityFailure"]["message"], code=REPLAY["capacityFailure"]["code"]
+        )
+
+    monkeypatch.setattr(harness.host_leases, "acquire", reject_capacity)
+    first = admitted_request(harness.publish_request, plan, REPLAY["epochs"][0])
+    rejected = await execute(first)
+    assert rejected.provider_error_code == REPLAY["capacityFailure"]["code"]
+    assert rejected.retry_recommendation == "wait_for_host_capacity"
+    first_session_id = realizer._canonical_session_id(first)
+    async with store.transaction() as repos:
+        first_session = await repos.sessions.get(first_session_id)
+        first_cleanup = await repos.cleanup.get(first_session_id)
+    assert first_session.provider_session_ref is None
+    assert first_cleanup.state == "complete"
+    assert "host-ready" not in harness.events
+    assert "credentials-cleaned" in harness.events
+    assert "provider-released" in harness.events
+
+    # The same immutable input is re-admitted; only the workflow-owned epoch changes.
+    monkeypatch.setattr(harness.host_leases, "acquire", acquire)
+    second = admitted_request(harness.publish_request, plan, REPLAY["epochs"][1])
+    result = await execute(second)
+    assert result.failure_class is None
+    assert result.metadata["omnigentSessionId"] == "session-1"
+    second_session_id = realizer._canonical_session_id(second)
+    assert second_session_id != first_session_id
+    async with store.transaction() as repos:
+        assert await repos.sessions.get(first_session_id) == first_session
+        assert await repos.cleanup.get(first_session_id) == first_cleanup
+        second_session = await repos.sessions.get(second_session_id)
+        second_cleanup = await repos.cleanup.get(second_session_id)
+        commands = await repos.commands.list_for_session(second_session_id)
+    assert second_session.provider_session_ref == "session-1"
+    assert second_cleanup.state == "complete"
+    assert len(commands) == 1
+    assert commands[0].provider_receipt_id == "session-1"
+
+    for epoch in REPLAY["epochs"]:
+        binding = await harness.runtime_store.get(
+            stable_binding_id(
+                execution_plan_ref=plan.planRef,
+                idempotency_key=first.idempotency_key,
+                admission_epoch=epoch,
+            )
+        )
+        assert binding.state is RuntimeBindingState.cleaned
+
+    # Activity redelivery reads the terminal receipt without another billed turn.
+    before = list(harness.events)
+    duplicate = await execute(second)
+    assert duplicate.failure_class is None
+    assert harness.events == before
+    assert harness.events.count("host-ready") == 1
+    assert harness.events.count("message-completed") == 1
+
+
+@pytest.mark.asyncio
+async def test_capacity_readmission_survives_completed_cleanup(
+    session_factory, monkeypatch
+):
+    await replay_capacity_readmission(
+        OmnigentControlPlaneStore(session_factory), monkeypatch
+    )
+
+
+@pytest.mark.parametrize("epoch", [None, 0, 1])
+def test_historical_and_first_admission_keep_durable_identity(epoch):
+    from moonmind.omnigent.realizers.turn_delivery import canonical_turn_idempotency_key
+
+    request = AgentExecutionRequest(
+        agentKind="external",
+        agentId="omnigent",
+        correlationId="workflow-1",
+        idempotencyKey="idem-1",
+    )
+    if epoch is not None:
+        request = admitted_request(request, _plan("opencode-go/model"), epoch)
+    assert canonical_turn_idempotency_key(request) == "idem-1"
+    assert (
+        canonical_omnigent_session_id(
+            workflow_id="workflow-1",
+            step_execution_id="workflow-1",
+            agent_run_id="workflow-1",
+            admission_epoch=epoch or 0,
+        )
+        == "oms_d75bad6fe38fe89bfaf524e9fe4f1965dad05d43"
+    )
+
+
+@pytest.mark.asyncio
+async def test_existing_later_epoch_keeps_legacy_session_and_command(session_factory):
+    """An old Activity can resume its durable result after the identity cutover."""
+
+    harness = await _generic_publication_harness({})
+    plan = _exact_plan("opencode-go/model")
+    request = admitted_request(harness.publish_request, plan, 2)
+    store = OmnigentControlPlaneStore(session_factory)
+    commands = CanonicalTurnCommandService(store)
+    harness.realizer._turn_commands = commands
+    harness.realizer._cleanup_authority = CanonicalCleanupAuthority(store)
+    claim = await commands.claim(
+        workflow_id=request.correlation_id,
+        provider_session_ref="",
+        chat_binding_id=None,
+        command_type="execute_admitted_plan",
+        turn_source="initial",
+        idempotency_key=request.idempotency_key,
+        payload_digest=plan.planRef,
+        bootstrap=CanonicalSessionBootstrap(
+            provider="omnigent",
+            step_execution_id=request.correlation_id,
+            agent_run_id=request.correlation_id,
+            source_idempotency_key=request.idempotency_key,
+            execution_plan_ref=plan.planRef,
+        ),
+    )
+    await commands.attach_provider_session(
+        session_id=claim.session_id,
+        provider_session_ref="session-1",
+        fencing_generation=claim.fencing_generation,
+    )
+    # The worker died after persisting terminal evidence but before settlement.
+    await _prime_attested_host_binding(harness, plan, admission_epoch=2)
+    binding = await harness.runtime_store.get(
+        stable_binding_id(
+            execution_plan_ref=plan.planRef,
+            idempotency_key=request.idempotency_key,
+            admission_epoch=2,
+        )
+    )
+    await harness.runtime_store.update(
+        binding.bindingId,
+        expected_revision=binding.revision,
+        expected_fencing_generation=binding.fencingGeneration,
+        updates={
+            "omnigentSessionId": "session-1",
+            "terminalResult": {
+                "summary": "previously completed",
+                "metadata": {"omnigentSessionId": "session-1"},
+            },
+        },
+    )
+    result = await harness.realizer.execute(request, plan)
+    assert result.summary == "previously completed"
+    assert "host-ready" not in harness.events
+    assert "message-completed" not in harness.events
+    async with store.transaction() as repos:
+        assert (
+            await repos.sessions.get(harness.realizer._canonical_session_id(request))
+            is None
+        )
+        cleanup = await repos.cleanup.get(claim.session_id)
+        journal = await repos.commands.list_for_session(claim.session_id)
+    assert cleanup.state == "complete"
+    assert len(journal) == 1
+    assert journal[0].provider_receipt_id == "session-1"

--- a/tests/unit/omnigent/test_capacity_readmission_turn.py
+++ b/tests/unit/omnigent/test_capacity_readmission_turn.py
@@ -9,10 +9,12 @@ import pytest
 from temporalio.testing import ActivityEnvironment
 
 from moonmind.omnigent.control_plane import OmnigentControlPlaneStore
+from moonmind.omnigent.control_plane.records import ControlPlaneOutcome
 from moonmind.omnigent.control_plane.cleanup_authority import CanonicalCleanupAuthority
 from moonmind.omnigent.control_plane.identities import canonical_omnigent_session_id
 from moonmind.omnigent.control_plane.turn_commands import (
     CanonicalSessionBootstrap,
+    CanonicalTurnAuthorityUnavailable,
     CanonicalTurnCommandService,
 )
 from moonmind.omnigent.harness_platform.failures import HarnessPlatformError
@@ -22,6 +24,8 @@ from moonmind.schemas.agent_runtime_models import AgentExecutionRequest
 from moonmind.workflows.temporal.activities.omnigent_activities import (
     omnigent_profile_bound_execute_activity,
 )
+
+# Importing fixtures registers them with pytest; session_factory needs _engine.
 from tests.unit.omnigent.test_canonical_turn_routing import (  # noqa: F401
     _engine,
     session_factory,
@@ -72,6 +76,15 @@ def admitted_request(request, plan, epoch):
     return AgentExecutionRequest.model_validate(payload)
 
 
+def admitted_session_id(request):
+    return canonical_omnigent_session_id(
+        workflow_id=request.correlation_id,
+        step_execution_id=request.correlation_id,
+        agent_run_id=request.correlation_id,
+        admission_epoch=request.admitted_provider_capacity.admission_epoch,
+    )
+
+
 async def replay_capacity_readmission(store, monkeypatch):
     """Only external host/provider services are simulated; owners persist real state."""
 
@@ -119,7 +132,7 @@ async def replay_capacity_readmission(store, monkeypatch):
     rejected = await execute(first)
     assert rejected.provider_error_code == REPLAY["capacityFailure"]["code"]
     assert rejected.retry_recommendation == "wait_for_host_capacity"
-    first_session_id = realizer._canonical_session_id(first)
+    first_session_id = admitted_session_id(first)
     async with store.transaction() as repos:
         first_session = await repos.sessions.get(first_session_id)
         first_cleanup = await repos.cleanup.get(first_session_id)
@@ -135,7 +148,7 @@ async def replay_capacity_readmission(store, monkeypatch):
     result = await execute(second)
     assert result.failure_class is None
     assert result.metadata["omnigentSessionId"] == "session-1"
-    second_session_id = realizer._canonical_session_id(second)
+    second_session_id = admitted_session_id(second)
     assert second_session_id != first_session_id
     async with store.transaction() as repos:
         assert await repos.sessions.get(first_session_id) == first_session
@@ -258,12 +271,128 @@ async def test_existing_later_epoch_keeps_legacy_session_and_command(session_fac
     assert "host-ready" not in harness.events
     assert "message-completed" not in harness.events
     async with store.transaction() as repos:
-        assert (
-            await repos.sessions.get(harness.realizer._canonical_session_id(request))
-            is None
-        )
+        assert await repos.sessions.get(admitted_session_id(request)) is None
         cleanup = await repos.cleanup.get(claim.session_id)
         journal = await repos.commands.list_for_session(claim.session_id)
     assert cleanup.state == "complete"
     assert len(journal) == 1
     assert journal[0].provider_receipt_id == "session-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("delivery_unknown", [False, True])
+@pytest.mark.parametrize("binding_exists", [False, True])
+async def test_legacy_claim_survives_redelivery_before_provider_attachment(
+    session_factory, delivery_unknown, binding_exists
+):
+    await replay_unattached_legacy_claim(
+        OmnigentControlPlaneStore(session_factory), delivery_unknown, binding_exists
+    )
+
+
+async def replay_unattached_legacy_claim(store, delivery_unknown, binding_exists):
+    """Crashes before provider attachment must not create fresh turn authority."""
+
+    harness = await _generic_publication_harness({})
+    plan = _exact_plan("opencode-go/model")
+    request = admitted_request(
+        harness.publish_request.model_copy(
+            update={
+                "parameters": {
+                    **harness.publish_request.parameters,
+                    "publishMode": "none",
+                }
+            }
+        ),
+        plan,
+        2,
+    )
+    commands = CanonicalTurnCommandService(store)
+    harness.realizer._turn_commands = commands
+    harness.realizer._cleanup_authority = CanonicalCleanupAuthority(store)
+    claim = await commands.claim(
+        workflow_id=request.correlation_id,
+        provider_session_ref="",
+        chat_binding_id=None,
+        command_type="execute_admitted_plan",
+        turn_source="initial",
+        idempotency_key=request.idempotency_key,
+        payload_digest=plan.planRef,
+        bootstrap=CanonicalSessionBootstrap(
+            provider="omnigent",
+            step_execution_id=request.correlation_id,
+            agent_run_id=request.correlation_id,
+            source_idempotency_key=request.idempotency_key,
+            execution_plan_ref=plan.planRef,
+        ),
+    )
+    if binding_exists:
+        await _prime_attested_host_binding(harness, plan, admission_epoch=2)
+    if delivery_unknown:
+        await commands.settle(
+            workflow_id=request.correlation_id,
+            idempotency_key=request.idempotency_key,
+            outcome=ControlPlaneOutcome.DELIVERY_UNKNOWN,
+        )
+        before = list(harness.events)
+        with pytest.raises(HarnessPlatformError, match="already settled or owned"):
+            await harness.realizer.execute(request, plan)
+        assert harness.events == before
+    else:
+        result = await harness.realizer.execute(request, plan)
+        assert result.failure_class is None
+        assert result.metadata["omnigentSessionId"] == "session-1"
+        assert harness.events.count("message-completed") == 1
+    async with store.transaction() as repos:
+        assert await repos.sessions.get(admitted_session_id(request)) is None
+        session = await repos.sessions.get(claim.session_id)
+        cleanup = await repos.cleanup.get(claim.session_id)
+        journal = await repos.commands.list_for_session(claim.session_id)
+    assert len(journal) == 1
+    assert journal[0].command_id == claim.command_id
+    if delivery_unknown:
+        assert session.provider_session_ref is None
+        assert cleanup.state != "complete"
+        assert journal[0].status == "delivery_unknown"
+    else:
+        assert session.provider_session_ref == "session-1"
+        assert cleanup.state == "complete"
+        assert journal[0].provider_receipt_id == "session-1"
+
+
+@pytest.mark.asyncio
+async def test_unattached_legacy_resolution_preserves_bootstrap_authority(
+    session_factory,
+):
+    harness = await _generic_publication_harness({})
+    plan = _exact_plan("opencode-go/model")
+    request = admitted_request(harness.publish_request, plan, 2)
+    store = OmnigentControlPlaneStore(session_factory)
+    commands = CanonicalTurnCommandService(store)
+    harness.realizer._turn_commands = commands
+    claim = await commands.claim(
+        workflow_id=request.correlation_id,
+        provider_session_ref="",
+        chat_binding_id=None,
+        command_type="execute_admitted_plan",
+        turn_source="initial",
+        idempotency_key="older-command",
+        payload_digest="plan:older",
+        bootstrap=CanonicalSessionBootstrap(
+            provider="omnigent",
+            step_execution_id=request.correlation_id,
+            agent_run_id=request.correlation_id,
+            source_idempotency_key="older-command",
+            execution_plan_ref="plan:older",
+        ),
+    )
+    before = list(harness.events)
+    with pytest.raises(CanonicalTurnAuthorityUnavailable, match="bootstrap authority"):
+        await harness.realizer.execute(request, plan)
+    assert harness.events == before
+    async with store.transaction() as repos:
+        session = await repos.sessions.get(claim.session_id)
+        journal = await repos.commands.list_for_session(claim.session_id)
+    assert session.execution_plan_ref == "plan:older"
+    assert "immutableTurnAuthority" not in session.metadata
+    assert len(journal) == 1

--- a/tests/unit/omnigent/test_generic_platform_production_services.py
+++ b/tests/unit/omnigent/test_generic_platform_production_services.py
@@ -2059,6 +2059,9 @@ async def _generic_publication_harness(
         async def cleanup_prepared(self, _prepared):
             events.append("inputs-cleaned")
 
+        async def cleanup_authorities(self, _authorities):
+            events.append("inputs-cleaned")
+
     host_class = HostClass.model_validate(
         {
             "hostClassId": "omnigent-opencode",
@@ -2194,7 +2197,7 @@ async def _generic_publication_harness(
     )
 
 
-async def _prime_attested_host_binding(harness, plan) -> None:
+async def _prime_attested_host_binding(harness, plan, *, admission_epoch=0) -> None:
     """Leave one durable binding on an attested, ready host.
 
     This is the state a retry of an interrupted generic execution actually
@@ -2241,6 +2244,7 @@ async def _prime_attested_host_binding(harness, plan) -> None:
         execution_plan_ref=plan.planRef,
         idempotency_key=harness.publish_request.idempotency_key,
         provider_leases=provider_authority,
+        admission_epoch=admission_epoch,
     )
     binding = await harness.runtime_store.update(
         binding.bindingId,


### PR DESCRIPTION
## Related issue

N/A — incident workflow `mm:07161650-68db-4325-8583-c6711e2cb8bc-2026-09-12T18:25:00Z`.

## Summary

A temporary CPU-capacity rejection cleaned up an Omnigent attempt. The workflow correctly re-admitted, but its new runtime binding reused the old canonical session and failed with `cold_restore: cleanup_complete`.

Scope canonical sessions, command idempotency, and cleanup to the existing admission epoch. Preserve historical first-admission identities and persisted canonical authority for in-flight executions, including crashes before provider attachment. Include bounded admission reason codes in diagnostics.

ELI5: a fresh launch attempt gets its own session and cleanup record; retrying delivery within that attempt keeps the same identity and saved result.

## Test Plan

277 targeted unit tests and 16 PostgreSQL integration tests passed in isolated Compose test projects. The minimized replay fails with the original error against unchanged baseline modules and passes through the actual Temporal Activity with the fix.

```bash
./tools/test_unit.sh --python-only \
  tests/unit/omnigent/test_capacity_readmission_turn.py \
  tests/unit/omnigent/test_canonical_turn_routing.py \
  tests/unit/omnigent/test_canonical_turn_producers.py \
  tests/unit/omnigent/test_generic_platform_production_services.py \
  tests/unit/omnigent/test_attempt_completion.py \
  tests/unit/workflows/temporal/workflows/test_agent_run_omnigent_capacity_admission.py \
  tests/unit/workflows/temporal/workflows/test_agent_run_profile_bound_retry_4226.py \
  tests/unit/workflows/temporal/test_omnigent_activities.py
pytest tests/integration/omnigent/test_capacity_readmission_turn_postgres.py \
  tests/integration/omnigent/test_control_plane_postgres.py \
  -m integration_ci -q --tb=short --timeout=120
```

## Demo

N/A.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / dashboard change
- [x] Runtime / agent adapter change
- [ ] Workflow / Temporal change
- [ ] Security / policy / sandboxing change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Frontend tests added / updated
- [x] Workflow boundary tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Risk notes

Changes canonical session and command identity for re-admission epochs greater than one. Omitted, zero, and first epochs retain historical identities; existing canonical authority preserves older in-flight sessions and commands, including before provider attachment. Workflow history and Activity payload schemas are unchanged. Completed cleanup remains terminal, and model, profile, workspace, and publication authority are preserved.

## Coverage notes

The replay uses production Activity dispatch, realizer, turn, and cleanup logic with real SQLite/PostgreSQL persistence and simulated host/provider services. It verifies successful re-admission, unchanged prior cleanup, terminal-result redelivery without another provider turn, legacy-session continuation, unknown-delivery fencing before provider attachment, and unchanged bootstrap plan validation. No deployment or live provider rerun was performed.

## Changelog

Fix Omnigent workflows failing after a recoverable capacity rejection.
